### PR TITLE
feat: integrate llama.cpp for real GGUF inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http",
@@ -130,13 +130,46 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -170,10 +203,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -211,7 +283,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -238,6 +321,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -281,6 +375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +413,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,14 +468,18 @@ name = "eullm-engine"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
- "axum",
+ "axum 0.8.8",
  "chrono",
  "clap",
+ "encoding_rs",
+ "llama-cpp-2",
+ "parking_lot",
  "predicates",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -348,7 +490,7 @@ name = "eullm-hub"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
- "axum",
+ "axum 0.7.9",
  "chrono",
  "serde",
  "serde_json",
@@ -363,6 +505,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "find_cuda_helper"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f9e65c593dd01ac77daad909ea4ad17f0d6d1776193fc8ea766356177abdad"
+dependencies = [
+ "glob",
+]
 
 [[package]]
 name = "float-cmp"
@@ -460,6 +611,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -756,10 +913,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -790,10 +966,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "llama-cpp-2"
+version = "0.1.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b92f824729095247507a51f5ef7100adc70bbb4f86f1c4fdccbe4afd356bb9"
+dependencies = [
+ "encoding_rs",
+ "enumflags2",
+ "llama-cpp-sys-2",
+ "thiserror",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "llama-cpp-sys-2"
+version = "0.1.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e762baca42996077c9b3e5af393d585ca5299977faacf8ac4391f2dbd013a5d5"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "find_cuda_helper",
+ "glob",
+ "walkdir",
+]
 
 [[package]]
 name = "lock_api"
@@ -832,6 +1046,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +1064,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +1078,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1245,6 +1481,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1702,6 +1947,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,6 +2109,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -10,17 +10,28 @@ repository = "https://github.com/eullm/eullm"
 name = "eullm"
 path = "src/main.rs"
 
+[features]
+default = []
+cuda = ["llama-cpp-2/cuda"]
+rocm = ["llama-cpp-2/rocm"]
+vulkan = ["llama-cpp-2/vulkan"]
+metal = ["llama-cpp-2/metal"]
+
 [dependencies]
-clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["full"] }
-axum = "0.7"
-serde = { version = "1", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
+tokio = { version = "1.50", features = ["full"] }
+axum = "0.8"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+llama-cpp-2 = { version = "0.1.139", features = ["sampler"] }
+encoding_rs = "0.8"
+parking_lot = "0.12"
+tower-http = { version = "0.6", features = ["cors"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -8,17 +8,29 @@ mod routes;
 use axum::Router;
 use std::sync::Arc;
 use tokio::net::TcpListener;
+use tower_http::cors::{Any, CorsLayer};
+
+use crate::inference::InferenceEngine;
 
 /// Shared state for API handlers.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AppState {
     /// Currently loaded model name (if any).
-    pub model: Option<String>,
+    pub model_name: Option<String>,
+    /// Inference engine (None if no model loaded yet).
+    pub engine: Option<Arc<InferenceEngine>>,
 }
 
 /// Start the API server on the given port.
-pub async fn serve(port: u16, model: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
-    let state = Arc::new(AppState { model });
+pub async fn serve(
+    port: u16,
+    model_name: Option<String>,
+    engine: Option<Arc<InferenceEngine>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let state = Arc::new(AppState {
+        model_name,
+        engine,
+    });
     let app = router(state);
     let addr = format!("0.0.0.0:{port}");
     tracing::info!("eullm listening on {addr}");
@@ -29,10 +41,16 @@ pub async fn serve(port: u16, model: Option<String>) -> Result<(), Box<dyn std::
     Ok(())
 }
 
-/// Build the EULLM API router.
+/// Build the EULLM API router with CORS enabled for Open WebUI and other frontends.
 fn router(state: Arc<AppState>) -> Router {
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
     Router::new()
         .nest("/api", routes::api_routes())
         .nest("/v1", routes::openai_routes())
+        .layer(cors)
         .with_state(state)
 }

--- a/engine/src/api/routes.rs
+++ b/engine/src/api/routes.rs
@@ -3,10 +3,13 @@
 use std::sync::Arc;
 
 use axum::extract::State;
+use axum::http::StatusCode;
 use axum::{routing::get, routing::post, Json, Router};
 use serde_json::{json, Value};
 
 use super::AppState;
+use crate::audit::{AuditEntry, AuditLogger};
+use crate::inference::GenerateRequest;
 use crate::models::EU_CATALOG;
 
 type S = Arc<AppState>;
@@ -58,66 +61,165 @@ async fn list_models(State(_state): State<S>) -> Json<Value> {
     Json(json!({ "models": models }))
 }
 
-async fn generate(State(state): State<S>, Json(body): Json<Value>) -> Json<Value> {
+async fn generate(
+    State(state): State<S>,
+    Json(body): Json<Value>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let model = body
         .get("model")
         .and_then(|v| v.as_str())
-        .or(state.model.as_deref())
+        .or(state.model_name.as_deref())
         .unwrap_or("unknown");
     let prompt = body
         .get("prompt")
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
-    // Mock response
-    let response = format!(
-        "Hello! I'm {model}, running on eullm. \
-         This is a mock response. You asked: \"{prompt}\""
-    );
+    let engine = state.engine.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "No model loaded. Use `eullm run <model>` to load a model." })),
+        )
+    })?;
 
-    Json(json!({
+    let max_tokens = body
+        .get("max_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(512) as u32;
+
+    let temperature = body
+        .get("temperature")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.7) as f32;
+
+    let request = GenerateRequest {
+        prompt: prompt.to_string(),
+        max_tokens,
+        temperature,
+        ..Default::default()
+    };
+
+    let result = tokio::task::spawn_blocking({
+        let engine = Arc::clone(engine);
+        move || engine.generate(&request)
+    })
+    .await
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("Task error: {e}") })),
+        )
+    })?
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("Inference error: {e}") })),
+        )
+    })?;
+
+    // Audit log
+    let mut audit = AuditEntry::new(model.to_string(), "generate".to_string());
+    audit.input_tokens = result.tokens_prompt;
+    audit.output_tokens = result.tokens_generated;
+    audit.duration_ms = result.duration_ms;
+    AuditLogger::new().log(&audit);
+
+    Ok(Json(json!({
         "model": model,
         "created_at": chrono::Utc::now().to_rfc3339(),
-        "response": response,
+        "response": result.text,
         "done": true,
-        "total_duration": 150_000_000,
-        "eval_count": 25,
-        "eval_duration": 100_000_000
-    }))
+        "total_duration": result.duration_ms * 1_000_000,
+        "eval_count": result.tokens_generated,
+        "eval_duration": result.duration_ms * 1_000_000,
+        "prompt_eval_count": result.tokens_prompt
+    })))
 }
 
-async fn chat(State(state): State<S>, Json(body): Json<Value>) -> Json<Value> {
+async fn chat(
+    State(state): State<S>,
+    Json(body): Json<Value>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let model = body
         .get("model")
         .and_then(|v| v.as_str())
-        .or(state.model.as_deref())
+        .or(state.model_name.as_deref())
         .unwrap_or("unknown");
 
-    let last_message = body
+    let messages = body
         .get("messages")
         .and_then(|v| v.as_array())
-        .and_then(|arr| arr.last())
-        .and_then(|m| m.get("content"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+        .cloned()
+        .unwrap_or_default();
 
-    let response = format!(
-        "Hello! I'm {model}, running on eullm. \
-         This is a mock response to: \"{last_message}\""
-    );
+    let engine = state.engine.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "No model loaded. Use `eullm run <model>` to load a model." })),
+        )
+    })?;
 
-    Json(json!({
+    // Build prompt from messages (simple ChatML-style)
+    let prompt = format_chat_prompt(&messages);
+
+    let max_tokens = body
+        .get("max_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(512) as u32;
+
+    let temperature = body
+        .get("temperature")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.7) as f32;
+
+    let request = GenerateRequest {
+        prompt,
+        max_tokens,
+        temperature,
+        stop_sequences: vec![
+            "<|im_end|>".to_string(),
+            "<|end|>".to_string(),
+        ],
+    };
+
+    let result = tokio::task::spawn_blocking({
+        let engine = Arc::clone(engine);
+        move || engine.generate(&request)
+    })
+    .await
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("Task error: {e}") })),
+        )
+    })?
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("Inference error: {e}") })),
+        )
+    })?;
+
+    // Audit log
+    let mut audit = AuditEntry::new(model.to_string(), "chat".to_string());
+    audit.input_tokens = result.tokens_prompt;
+    audit.output_tokens = result.tokens_generated;
+    audit.duration_ms = result.duration_ms;
+    AuditLogger::new().log(&audit);
+
+    Ok(Json(json!({
         "model": model,
         "created_at": chrono::Utc::now().to_rfc3339(),
         "message": {
             "role": "assistant",
-            "content": response
+            "content": result.text
         },
         "done": true,
-        "total_duration": 150_000_000,
-        "eval_count": 25,
-        "eval_duration": 100_000_000
-    }))
+        "total_duration": result.duration_ms * 1_000_000,
+        "eval_count": result.tokens_generated,
+        "eval_duration": result.duration_ms * 1_000_000,
+        "prompt_eval_count": result.tokens_prompt
+    })))
 }
 
 async fn show_model(Json(body): Json<Value>) -> Json<Value> {
@@ -155,7 +257,7 @@ async fn pull_model(Json(body): Json<Value>) -> Json<Value> {
         .unwrap_or("unknown");
 
     Json(json!({
-        "status": format!("pulling {name} from EU registry (mock)")
+        "status": format!("pulling {name} from EU registry (not yet implemented)")
     }))
 }
 
@@ -177,27 +279,77 @@ async fn list_models_openai() -> Json<Value> {
     Json(json!({ "object": "list", "data": data }))
 }
 
-async fn chat_completions(State(state): State<S>, Json(body): Json<Value>) -> Json<Value> {
+async fn chat_completions(
+    State(state): State<S>,
+    Json(body): Json<Value>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let model = body
         .get("model")
         .and_then(|v| v.as_str())
-        .or(state.model.as_deref())
+        .or(state.model_name.as_deref())
         .unwrap_or("eullm/general-eu-7b");
 
-    let last_message = body
+    let messages = body
         .get("messages")
         .and_then(|v| v.as_array())
-        .and_then(|arr| arr.last())
-        .and_then(|m| m.get("content"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+        .cloned()
+        .unwrap_or_default();
 
-    let response = format!(
-        "Hello! I'm {model}, running on eullm. \
-         This is a mock response to: \"{last_message}\""
-    );
+    let engine = state.engine.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "No model loaded. Use `eullm run <model>` to load a model." })),
+        )
+    })?;
 
-    Json(json!({
+    let prompt = format_chat_prompt(&messages);
+
+    let max_tokens = body
+        .get("max_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(512) as u32;
+
+    let temperature = body
+        .get("temperature")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.7) as f32;
+
+    let request = GenerateRequest {
+        prompt,
+        max_tokens,
+        temperature,
+        stop_sequences: vec![
+            "<|im_end|>".to_string(),
+            "<|end|>".to_string(),
+        ],
+    };
+
+    let result = tokio::task::spawn_blocking({
+        let engine = Arc::clone(engine);
+        move || engine.generate(&request)
+    })
+    .await
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("Task error: {e}") })),
+        )
+    })?
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("Inference error: {e}") })),
+        )
+    })?;
+
+    // Audit log
+    let mut audit = AuditEntry::new(model.to_string(), "chat.completions".to_string());
+    audit.input_tokens = result.tokens_prompt;
+    audit.output_tokens = result.tokens_generated;
+    audit.duration_ms = result.duration_ms;
+    AuditLogger::new().log(&audit);
+
+    Ok(Json(json!({
         "id": format!("chatcmpl-{}", uuid::Uuid::new_v4()),
         "object": "chat.completion",
         "created": chrono::Utc::now().timestamp(),
@@ -206,14 +358,29 @@ async fn chat_completions(State(state): State<S>, Json(body): Json<Value>) -> Js
             "index": 0,
             "message": {
                 "role": "assistant",
-                "content": response
+                "content": result.text
             },
             "finish_reason": "stop"
         }],
         "usage": {
-            "prompt_tokens": 10,
-            "completion_tokens": 25,
-            "total_tokens": 35
+            "prompt_tokens": result.tokens_prompt,
+            "completion_tokens": result.tokens_generated,
+            "total_tokens": result.tokens_prompt + result.tokens_generated
         }
-    }))
+    })))
+}
+
+/// Format chat messages into a ChatML-style prompt string.
+fn format_chat_prompt(messages: &[Value]) -> String {
+    let mut prompt = String::new();
+    for msg in messages {
+        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("user");
+        let content = msg
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        prompt.push_str(&format!("<|im_start|>{role}\n{content}<|im_end|>\n"));
+    }
+    prompt.push_str("<|im_start|>assistant\n");
+    prompt
 }

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -1,34 +1,247 @@
-//! Inference engine powered by llama.cpp.
+//! Inference engine powered by llama.cpp via llama-cpp-2 bindings.
 //!
-//! Provides bindings to llama.cpp for local model inference.
-//! Supports GGUF model format.
+//! Loads GGUF models and runs text generation with token sampling.
+
+use std::num::NonZeroU32;
+use std::path::PathBuf;
+use std::pin::pin;
+
+use llama_cpp_2::context::params::LlamaContextParams;
+use llama_cpp_2::llama_backend::LlamaBackend;
+use llama_cpp_2::llama_batch::LlamaBatch;
+use llama_cpp_2::model::params::LlamaModelParams;
+use llama_cpp_2::model::{AddBos, LlamaModel};
+use llama_cpp_2::sampling::LlamaSampler;
+use parking_lot::Mutex;
 
 /// Configuration for the inference engine.
 #[derive(Debug, Clone)]
 pub struct InferenceConfig {
-    /// Path to the GGUF model file
-    pub model_path: String,
-    /// Number of GPU layers to offload (-1 = all)
+    /// Path to the GGUF model file.
+    pub model_path: PathBuf,
+    /// Number of GPU layers to offload (-1 = all).
     pub gpu_layers: i32,
-    /// Context window size
+    /// Context window size.
     pub context_size: u32,
-    /// Number of threads for CPU inference
+    /// Number of threads for CPU inference.
     pub threads: u32,
 }
 
 impl Default for InferenceConfig {
     fn default() -> Self {
         Self {
-            model_path: String::new(),
+            model_path: PathBuf::new(),
             gpu_layers: -1,
             context_size: 4096,
-            threads: 4,
+            threads: num_cpus(),
         }
     }
 }
 
-/// Load and run inference on a GGUF model.
-pub async fn run(_config: &InferenceConfig) -> Result<(), Box<dyn std::error::Error>> {
-    // TODO: implement llama.cpp bindings
-    Ok(())
+/// Request for text generation.
+#[derive(Debug, Clone)]
+pub struct GenerateRequest {
+    pub prompt: String,
+    pub max_tokens: u32,
+    pub temperature: f32,
+    pub stop_sequences: Vec<String>,
+}
+
+impl Default for GenerateRequest {
+    fn default() -> Self {
+        Self {
+            prompt: String::new(),
+            max_tokens: 512,
+            temperature: 0.7,
+            stop_sequences: Vec::new(),
+        }
+    }
+}
+
+/// Result of text generation.
+#[derive(Debug, Clone)]
+pub struct GenerateResult {
+    pub text: String,
+    pub tokens_generated: u32,
+    pub tokens_prompt: u32,
+    pub duration_ms: u64,
+}
+
+/// The loaded inference engine, holding the model and backend.
+///
+/// Thread-safe: generation acquires a mutex on the context.
+pub struct InferenceEngine {
+    backend: LlamaBackend,
+    model: LlamaModel,
+    config: InferenceConfig,
+    /// Mutex around context because llama.cpp context is not thread-safe.
+    ctx_mutex: Mutex<()>,
+}
+
+// SAFETY: LlamaBackend and LlamaModel are safe to share across threads.
+// We guard mutable context access with a Mutex.
+unsafe impl Send for InferenceEngine {}
+unsafe impl Sync for InferenceEngine {}
+
+impl InferenceEngine {
+    /// Load a GGUF model and prepare the inference engine.
+    pub fn load(config: InferenceConfig) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        if !config.model_path.exists() {
+            return Err(format!(
+                "Model file not found: {}",
+                config.model_path.display()
+            )
+            .into());
+        }
+
+        tracing::info!("Initializing llama.cpp backend...");
+        let backend = LlamaBackend::init()?;
+
+        let model_params = if config.gpu_layers >= 0 {
+            LlamaModelParams::default().with_n_gpu_layers(config.gpu_layers as u32)
+        } else {
+            // -1 = offload all layers
+            LlamaModelParams::default().with_n_gpu_layers(1000)
+        };
+        let model_params = pin!(model_params);
+
+        tracing::info!("Loading model: {}", config.model_path.display());
+        let model = LlamaModel::load_from_file(&backend, &config.model_path, &model_params)
+            .map_err(|e| format!("Failed to load model: {e}"))?;
+
+        tracing::info!("Model loaded successfully.");
+
+        Ok(Self {
+            backend,
+            model,
+            config,
+            ctx_mutex: Mutex::new(()),
+        })
+    }
+
+    /// Generate text from a prompt.
+    pub fn generate(
+        &self,
+        request: &GenerateRequest,
+    ) -> Result<GenerateResult, Box<dyn std::error::Error + Send + Sync>> {
+        let _lock = self.ctx_mutex.lock();
+        let start = std::time::Instant::now();
+
+        let ctx_size = NonZeroU32::new(self.config.context_size)
+            .unwrap_or(NonZeroU32::new(4096).unwrap());
+
+        let ctx_params = LlamaContextParams::default()
+            .with_n_ctx(Some(ctx_size))
+            .with_n_threads(self.config.threads as i32)
+            .with_n_threads_batch(self.config.threads as i32);
+
+        let mut ctx = self
+            .model
+            .new_context(&self.backend, ctx_params)
+            .map_err(|e| format!("Failed to create context: {e}"))?;
+
+        // Tokenize the prompt
+        let tokens = self
+            .model
+            .str_to_token(&request.prompt, AddBos::Always)
+            .map_err(|e| format!("Tokenization failed: {e}"))?;
+
+        let tokens_prompt = tokens.len() as u32;
+        let n_len = (tokens.len() as u32 + request.max_tokens) as i32;
+
+        // Check context fits
+        let n_ctx = ctx.n_ctx() as i32;
+        if n_len > n_ctx {
+            return Err(format!(
+                "Prompt ({tokens_prompt} tokens) + max_tokens ({}) exceeds context window ({n_ctx})",
+                request.max_tokens
+            )
+            .into());
+        }
+
+        // Build initial batch with prompt tokens
+        let mut batch = LlamaBatch::new(self.config.context_size as usize, 1);
+        let last_idx = (tokens.len() - 1) as i32;
+        for (i, token) in (0_i32..).zip(tokens.into_iter()) {
+            let is_last = i == last_idx;
+            batch.add(token, i, &[0], is_last)?;
+        }
+
+        // Decode prompt
+        ctx.decode(&mut batch)
+            .map_err(|e| format!("Prompt decode failed: {e}"))?;
+
+        // Sample tokens
+        let mut sampler = LlamaSampler::chain_simple([
+            LlamaSampler::temp(request.temperature),
+            LlamaSampler::dist(1234),
+            LlamaSampler::greedy(),
+        ]);
+
+        let mut decoder = encoding_rs::UTF_8.new_decoder();
+        let mut output = String::new();
+        let mut n_cur = batch.n_tokens();
+        let mut tokens_generated: u32 = 0;
+
+        while n_cur <= n_len && tokens_generated < request.max_tokens {
+            let token = sampler.sample(&ctx, batch.n_tokens() - 1);
+            sampler.accept(token);
+
+            // End of generation?
+            if self.model.is_eog_token(token) {
+                break;
+            }
+
+            // Decode token to text
+            match self.model.token_to_piece(token, &mut decoder, true, None) {
+                Ok(piece) => {
+                    output.push_str(&piece);
+
+                    // Check stop sequences
+                    let should_stop = request
+                        .stop_sequences
+                        .iter()
+                        .any(|s| output.ends_with(s));
+                    if should_stop {
+                        // Remove the stop sequence from output
+                        for s in &request.stop_sequences {
+                            if output.ends_with(s) {
+                                let new_len = output.len() - s.len();
+                                output.truncate(new_len);
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+
+            // Prepare next batch
+            batch.clear();
+            batch.add(token, n_cur, &[0], true)?;
+
+            ctx.decode(&mut batch)
+                .map_err(|e| format!("Decode failed at token {tokens_generated}: {e}"))?;
+
+            n_cur += 1;
+            tokens_generated += 1;
+        }
+
+        let duration_ms = start.elapsed().as_millis() as u64;
+
+        Ok(GenerateResult {
+            text: output,
+            tokens_generated,
+            tokens_prompt,
+            duration_ms,
+        })
+    }
+
+}
+
+fn num_cpus() -> u32 {
+    std::thread::available_parallelism()
+        .map(|n| n.get() as u32)
+        .unwrap_or(4)
 }

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -4,8 +4,13 @@ mod inference;
 mod models;
 mod registry;
 
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use clap::{Parser, Subcommand};
 use models::{catalog, ModelStore};
+
+use crate::inference::{InferenceConfig, InferenceEngine};
 
 #[derive(Parser)]
 #[command(name = "eullm")]
@@ -25,7 +30,7 @@ enum Commands {
     },
     /// Run a model locally (starts API server)
     Run {
-        /// Model name (e.g., general-eu-14b)
+        /// Model name or path to a local GGUF file
         model: String,
 
         /// Port for the API server
@@ -35,6 +40,18 @@ enum Commands {
         /// Replace existing service on the port
         #[arg(long)]
         replace: bool,
+
+        /// Number of GPU layers to offload (-1 = all, 0 = CPU only)
+        #[arg(long, default_value_t = -1)]
+        gpu_layers: i32,
+
+        /// Context window size
+        #[arg(short, long, default_value_t = 4096)]
+        ctx_size: u32,
+
+        /// Number of CPU threads (default: all available)
+        #[arg(short, long)]
+        threads: Option<u32>,
     },
     /// List locally available models
     List,
@@ -129,7 +146,10 @@ async fn main() {
             model,
             port,
             replace,
-        } => cmd_run(&store, &model, port, replace).await,
+            gpu_layers,
+            ctx_size,
+            threads,
+        } => cmd_run(&store, &model, port, replace, gpu_layers, ctx_size, threads).await,
         Commands::List => cmd_list(&store),
         Commands::Show { model } => cmd_show(&store, &model),
         Commands::Serve { port, replace } => cmd_serve(port, replace).await,
@@ -166,7 +186,7 @@ fn cmd_pull(store: &ModelStore, model: &str) {
         Some(e) => e,
         None => {
             eprintln!("Error: model '{model}' not found in EU catalog.");
-            eprintln!("Run `eullm list --remote` to see available models.");
+            eprintln!("Run `eullm list` to see available models.");
             std::process::exit(1);
         }
     };
@@ -179,13 +199,9 @@ fn cmd_pull(store: &ModelStore, model: &str) {
     println!("Pulling {} from EU registry...", entry.name);
     println!(
         "  {} | {} | ~{}GB VRAM | {}",
-        entry.description,
-        entry.base,
-        entry.vram_gb,
-        entry.license
+        entry.description, entry.base, entry.vram_gb, entry.license
     );
 
-    // Simulate download progress
     println!("  Downloading manifest...");
 
     match store.pull(entry) {
@@ -213,6 +229,7 @@ fn cmd_list(store: &ModelStore) {
                 );
             }
             println!("\nPull with: eullm pull <model-name>");
+            println!("Or run a local GGUF: eullm run ./path/to/model.gguf");
         }
         Ok(models) => {
             println!("{:<30} {:>8} {:>6} {}", "NAME", "SIZE", "VRAM", "STATUS");
@@ -270,19 +287,33 @@ fn cmd_show(store: &ModelStore, model: &str) {
     }
 }
 
-/// Check what service is running on a given port.
+/// Resolve a model argument to a GGUF file path.
 ///
-/// Returns a description of the detected service, or `None` if the port is free.
+/// Supports:
+/// - Local GGUF file path: `./model.gguf` or `/path/to/model.gguf`
+/// - Catalog model name: `legal-it-7b` or `eullm/legal-it-7b`
+fn resolve_model_path(model: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(model);
+
+    // Direct GGUF file path
+    if path.exists() && path.extension().map_or(false, |e| e == "gguf") {
+        return Some(path);
+    }
+
+    // Could also check in the model store for downloaded GGUF files
+    // For now, only direct paths are supported for real inference
+    None
+}
+
+/// Check what service is running on a given port.
 async fn detect_port_service(port: u16) -> Option<String> {
     use tokio::net::TcpStream;
 
-    // Try to connect to the port
     let addr = format!("127.0.0.1:{port}");
     if TcpStream::connect(&addr).await.is_err() {
-        return None; // Port is free
+        return None;
     }
 
-    // Port is in use — try to identify the service
     let url = format!("http://127.0.0.1:{port}/api/version");
     if let Ok(resp) = reqwest::get(&url).await {
         if let Ok(body) = resp.text().await {
@@ -317,40 +348,102 @@ async fn ensure_port_available(port: u16, replace: bool) {
     }
 }
 
-async fn cmd_run(store: &ModelStore, model: &str, port: u16, replace: bool) {
-    // Check port availability before doing anything
+async fn cmd_run(
+    store: &ModelStore,
+    model: &str,
+    port: u16,
+    replace: bool,
+    gpu_layers: i32,
+    ctx_size: u32,
+    threads: Option<u32>,
+) {
     ensure_port_available(port, replace).await;
 
-    // Auto-pull if not available
-    if !store.exists(model) {
-        if let Some(entry) = catalog::find_model(model) {
-            println!("Model not found locally. Pulling...");
-            if let Err(e) = store.pull(entry) {
-                eprintln!("Error pulling model: {e}");
+    let model_name: String;
+    let engine: Option<Arc<InferenceEngine>>;
+
+    // Try to resolve as a local GGUF file first
+    if let Some(gguf_path) = resolve_model_path(model) {
+        model_name = gguf_path
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| model.to_string());
+
+        println!("Loading GGUF: {}", gguf_path.display());
+
+        let config = InferenceConfig {
+            model_path: gguf_path,
+            gpu_layers,
+            context_size: ctx_size,
+            threads: threads.unwrap_or_else(|| {
+                std::thread::available_parallelism()
+                    .map(|n| n.get() as u32)
+                    .unwrap_or(4)
+            }),
+        };
+
+        match InferenceEngine::load(config) {
+            Ok(eng) => {
+                engine = Some(Arc::new(eng));
+                println!("Model loaded.");
+            }
+            Err(e) => {
+                eprintln!("Error loading model: {e}");
                 std::process::exit(1);
             }
-        } else {
-            eprintln!("Error: model '{model}' not found in EU catalog.");
-            std::process::exit(1);
         }
+    } else {
+        // Catalog model (no real inference yet — would need GGUF download)
+        model_name = model.to_string();
+
+        if !store.exists(model) {
+            if let Some(entry) = catalog::find_model(model) {
+                println!("Model not found locally. Pulling...");
+                if let Err(e) = store.pull(entry) {
+                    eprintln!("Error pulling model: {e}");
+                    std::process::exit(1);
+                }
+            } else {
+                eprintln!("Error: model '{model}' not found.");
+                eprintln!();
+                eprintln!("Usage:");
+                eprintln!("  eullm run ./path/to/model.gguf    # Run a local GGUF file");
+                eprintln!("  eullm run legal-it-7b              # Run a catalog model (requires download)");
+                std::process::exit(1);
+            }
+        }
+
+        eprintln!("Warning: catalog models don't have GGUF files yet.");
+        eprintln!("  Inference will not work until the EU registry is operational.");
+        eprintln!("  To test inference now, use a local GGUF file:");
+        eprintln!("    eullm run ./path/to/model.gguf");
+        eprintln!();
+        engine = None;
     }
 
-    let short = model.strip_prefix("eullm/").unwrap_or(model);
-    println!("Loading model {short}...");
+    let short = model_name
+        .strip_prefix("eullm/")
+        .unwrap_or(&model_name);
+    println!();
     println!("eullm ready.");
     println!("  API (EULLM):   http://localhost:{port}/api");
     println!("  API (OpenAI):  http://localhost:{port}/v1");
     println!("  Model:         {short}");
-    println!("\nPress Ctrl+C to stop.\n");
+    if engine.is_some() {
+        println!("  GPU layers:    {}", if gpu_layers < 0 { "all".to_string() } else { gpu_layers.to_string() });
+        println!("  Context:       {ctx_size}");
+    }
+    println!();
+    println!("Press Ctrl+C to stop.");
+    println!();
 
-    if let Err(e) = api::serve(port, Some(model.to_string())).await {
+    if let Err(e) = api::serve(port, Some(model_name), engine).await {
         eprintln!("Server error: {e}");
         std::process::exit(1);
     }
 }
 
 async fn cmd_serve(port: u16, replace: bool) {
-    // Check port availability
     ensure_port_available(port, replace).await;
 
     println!("eullm ready (no model loaded).");
@@ -358,7 +451,7 @@ async fn cmd_serve(port: u16, replace: bool) {
     println!("  API (OpenAI):  http://localhost:{port}/v1");
     println!("\nPress Ctrl+C to stop.\n");
 
-    if let Err(e) = api::serve(port, None).await {
+    if let Err(e) = api::serve(port, None, None).await {
         eprintln!("Server error: {e}");
         std::process::exit(1);
     }
@@ -377,7 +470,6 @@ fn cmd_forge(
     skip_quantization: bool,
     skip_identity: bool,
 ) {
-    // Build the eullm-forge command
     let mut args = vec!["forge".to_string(), source.to_string()];
 
     if let Some(p) = profile {
@@ -418,7 +510,6 @@ fn cmd_forge(
 
     println!("eullm forge — delegating to eullm-forge pipeline...\n");
 
-    // Try to find eullm-forge in PATH
     let status = std::process::Command::new("eullm-forge")
         .args(&args)
         .status();
@@ -429,7 +520,6 @@ fn cmd_forge(
             std::process::exit(s.code().unwrap_or(1));
         }
         Err(_) => {
-            // eullm-forge not in PATH, try python -m eullm_forge.cli
             let py_status = std::process::Command::new("python3")
                 .arg("-m")
                 .arg("eullm_forge.cli")


### PR DESCRIPTION
- Add llama-cpp-2 v0.1.139 bindings (supports CUDA, ROCm, Vulkan, Metal)
- Implement InferenceEngine: load GGUF, tokenize, generate with sampling
- Wire API routes (/api/generate, /api/chat, /v1/chat/completions) to real inference
- Support local GGUF files: `eullm run ./model.gguf`
- Add CORS headers (tower-http) for Open WebUI compatibility
- Add --gpu-layers, --ctx-size, --threads CLI options to `eullm run`
- Feature flags: --features cuda/rocm/vulkan/metal for GPU acceleration
- Proper error responses (503) when no model is loaded
- Audit trail logging on every inference request

Build with GPU support:
  cargo build --features cuda    # NVIDIA
  cargo build --features rocm    # AMD
  cargo build --features vulkan  # Cross-platform GPU
