### PR TITLE
feat: add SSE streaming on all generation endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +424,7 @@ name = "eullm-engine"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "async-stream",
  "axum",
  "chrono",
  "clap",

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ eullm serve                               # Start API server without loading a m
 
 Key features:
 - **Real inference** powered by llama.cpp (not a mock, not a proxy)
+- **SSE streaming** — token-by-token output on all endpoints (`"stream": true`)
 - **GPU acceleration** — NVIDIA CUDA, AMD ROCm, Vulkan, Apple Metal
 - **Ollama-compatible API** — drop-in replacement, same endpoints, same port
 - **OpenAI-compatible API** — works with Open WebUI, LangChain, n8n, any standard client

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -180,10 +180,19 @@ curl -X POST http://localhost:11434/api/generate \
 | `prompt` | (required) | Input prompt |
 | `max_tokens` | 512 | Maximum tokens to generate |
 | `temperature` | 0.7 | Sampling temperature |
+| `stream` | false | Stream response token-by-token (SSE) |
+
+**Streaming:** Set `"stream": true` to receive Server-Sent Events. Each SSE event contains a JSON object with `"response"` (the token piece) and `"done": false`. The final event has `"done": true` with timing stats.
+
+```bash
+# Streaming example
+curl -N http://localhost:11434/api/generate \
+  -d '{"model": "local", "prompt": "Hello", "stream": true}'
+```
 
 #### `POST /api/chat`
 
-Chat completion with message history. Messages are formatted as ChatML internally.
+Chat completion with message history. Messages are formatted as ChatML internally. Supports `"stream": true` for token-by-token SSE responses.
 
 ```bash
 curl -X POST http://localhost:11434/api/chat \
@@ -193,6 +202,15 @@ curl -X POST http://localhost:11434/api/chat \
     "messages": [
       {"role": "user", "content": "Spiegami il GDPR in breve."}
     ]
+  }'
+
+# Streaming
+curl -N http://localhost:11434/api/chat \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "eullm/legal-it-7b",
+    "messages": [{"role": "user", "content": "Ciao!"}],
+    "stream": true
   }'
 ```
 
@@ -230,9 +248,10 @@ curl http://localhost:11434/v1/models
 
 #### `POST /v1/chat/completions`
 
-Chat completion in OpenAI format. Real inference with token counts.
+Chat completion in OpenAI format. Real inference with token counts. Supports `"stream": true` for SSE streaming (OpenAI `chat.completion.chunk` format with `[DONE]` terminator).
 
 ```bash
+# Non-streaming
 curl -X POST http://localhost:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
@@ -240,6 +259,15 @@ curl -X POST http://localhost:11434/v1/chat/completions \
     "messages": [
       {"role": "user", "content": "Hello"}
     ]
+  }'
+
+# Streaming (same format as OpenAI API)
+curl -N http://localhost:11434/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "eullm/legal-it-7b",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "stream": true
   }'
 ```
 
@@ -372,5 +400,6 @@ curl http://localhost:11434/v1/chat/completions \
 | Local model store (~/.eullm/models/) | Implemented |
 | Model download (HuggingFace, streaming with progress) | Implemented |
 | Audit trail (persistent JSONL) | Implemented |
+| SSE streaming (all endpoints) | Implemented (Ollama + OpenAI format) |
 | ChatML prompt formatting | Implemented |
 | EU registry download | Implemented (client ready, registry server coming soon) |

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -33,6 +33,7 @@ llama-cpp-2 = { version = "0.1.139", features = ["sampler"] }
 encoding_rs = "0.8"
 parking_lot = "0.12"
 tower-http = { version = "0.6", features = ["cors"] }
+async-stream = "0.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/engine/src/api/routes.rs
+++ b/engine/src/api/routes.rs
@@ -1,15 +1,23 @@
 //! Route definitions for the EULLM and OpenAI-compatible APIs.
+//!
+//! Supports both non-streaming (JSON) and streaming (SSE) responses
+//! on all generation endpoints. Set `"stream": true` in the request body
+//! to get token-by-token Server-Sent Events.
 
 use std::sync::Arc;
 
 use axum::extract::State;
 use axum::http::StatusCode;
+use axum::response::sse::{Event, Sse};
+use axum::response::IntoResponse;
 use axum::{routing::get, routing::post, Json, Router};
+use futures_util::stream::Stream;
 use serde_json::{json, Value};
+use tokio::sync::mpsc;
 
 use super::AppState;
 use crate::audit::{AuditEntry, AuditLogger};
-use crate::inference::GenerateRequest;
+use crate::inference::{GenerateRequest, StreamEvent};
 use crate::models::EU_CATALOG;
 
 type S = Arc<AppState>;
@@ -32,7 +40,52 @@ pub fn openai_routes() -> Router<S> {
         .route("/chat/completions", post(chat_completions))
 }
 
-// -- EULLM API handlers --
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn get_engine(state: &AppState) -> Result<&Arc<crate::inference::InferenceEngine>, (StatusCode, Json<Value>)> {
+    state.engine.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "No model loaded. Use `eullm run <model>` to load a model." })),
+        )
+    })
+}
+
+fn parse_generate_params(body: &Value) -> (u32, f32) {
+    let max_tokens = body
+        .get("max_tokens")
+        .or_else(|| body.get("num_predict"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(512) as u32;
+    let temperature = body
+        .get("temperature")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.7) as f32;
+    (max_tokens, temperature)
+}
+
+fn is_streaming(body: &Value) -> bool {
+    body.get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+/// Format chat messages into a ChatML-style prompt string.
+fn format_chat_prompt(messages: &[Value]) -> String {
+    let mut prompt = String::new();
+    for msg in messages {
+        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("user");
+        let content = msg
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        prompt.push_str(&format!("<|im_start|>{role}\n{content}<|im_end|>\n"));
+    }
+    prompt.push_str("<|im_start|>assistant\n");
+    prompt
+}
+
+// ── EULLM API handlers ──────────────────────────────────────────────────────
 
 async fn version() -> Json<Value> {
     Json(json!({ "version": env!("CARGO_PKG_VERSION") }))
@@ -64,87 +117,70 @@ async fn list_models(State(_state): State<S>) -> Json<Value> {
 async fn generate(
     State(state): State<S>,
     Json(body): Json<Value>,
-) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+) -> Result<axum::response::Response, (StatusCode, Json<Value>)> {
     let model = body
         .get("model")
         .and_then(|v| v.as_str())
         .or(state.model_name.as_deref())
-        .unwrap_or("unknown");
+        .unwrap_or("unknown")
+        .to_string();
     let prompt = body
         .get("prompt")
         .and_then(|v| v.as_str())
-        .unwrap_or("");
+        .unwrap_or("")
+        .to_string();
 
-    let engine = state.engine.as_ref().ok_or_else(|| {
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "No model loaded. Use `eullm run <model>` to load a model." })),
-        )
-    })?;
-
-    let max_tokens = body
-        .get("max_tokens")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(512) as u32;
-
-    let temperature = body
-        .get("temperature")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(0.7) as f32;
+    let engine = get_engine(&state)?;
+    let (max_tokens, temperature) = parse_generate_params(&body);
 
     let request = GenerateRequest {
-        prompt: prompt.to_string(),
+        prompt,
         max_tokens,
         temperature,
         ..Default::default()
     };
 
-    let result = tokio::task::spawn_blocking({
-        let engine = Arc::clone(engine);
-        move || engine.generate(&request)
-    })
-    .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": format!("Task error: {e}") })),
-        )
-    })?
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": format!("Inference error: {e}") })),
-        )
-    })?;
+    if is_streaming(&body) {
+        let stream = stream_generate(Arc::clone(engine), request, model);
+        Ok(Sse::new(stream).into_response())
+    } else {
+        let result = tokio::task::spawn_blocking({
+            let engine = Arc::clone(engine);
+            move || engine.generate(&request)
+        })
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": format!("Task error: {e}") }))))?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": format!("Inference error: {e}") }))))?;
 
-    // Audit log
-    let mut audit = AuditEntry::new(model.to_string(), "generate".to_string());
-    audit.input_tokens = result.tokens_prompt;
-    audit.output_tokens = result.tokens_generated;
-    audit.duration_ms = result.duration_ms;
-    AuditLogger::new().log(&audit);
+        let mut audit = AuditEntry::new(model.clone(), "generate".to_string());
+        audit.input_tokens = result.tokens_prompt;
+        audit.output_tokens = result.tokens_generated;
+        audit.duration_ms = result.duration_ms;
+        AuditLogger::new().log(&audit);
 
-    Ok(Json(json!({
-        "model": model,
-        "created_at": chrono::Utc::now().to_rfc3339(),
-        "response": result.text,
-        "done": true,
-        "total_duration": result.duration_ms * 1_000_000,
-        "eval_count": result.tokens_generated,
-        "eval_duration": result.duration_ms * 1_000_000,
-        "prompt_eval_count": result.tokens_prompt
-    })))
+        Ok(Json(json!({
+            "model": model,
+            "created_at": chrono::Utc::now().to_rfc3339(),
+            "response": result.text,
+            "done": true,
+            "total_duration": result.duration_ms * 1_000_000,
+            "eval_count": result.tokens_generated,
+            "eval_duration": result.duration_ms * 1_000_000,
+            "prompt_eval_count": result.tokens_prompt
+        })).into_response())
+    }
 }
 
 async fn chat(
     State(state): State<S>,
     Json(body): Json<Value>,
-) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+) -> Result<axum::response::Response, (StatusCode, Json<Value>)> {
     let model = body
         .get("model")
         .and_then(|v| v.as_str())
         .or(state.model_name.as_deref())
-        .unwrap_or("unknown");
+        .unwrap_or("unknown")
+        .to_string();
 
     let messages = body
         .get("messages")
@@ -152,25 +188,9 @@ async fn chat(
         .cloned()
         .unwrap_or_default();
 
-    let engine = state.engine.as_ref().ok_or_else(|| {
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "No model loaded. Use `eullm run <model>` to load a model." })),
-        )
-    })?;
-
-    // Build prompt from messages (simple ChatML-style)
+    let engine = get_engine(&state)?;
     let prompt = format_chat_prompt(&messages);
-
-    let max_tokens = body
-        .get("max_tokens")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(512) as u32;
-
-    let temperature = body
-        .get("temperature")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(0.7) as f32;
+    let (max_tokens, temperature) = parse_generate_params(&body);
 
     let request = GenerateRequest {
         prompt,
@@ -182,44 +202,38 @@ async fn chat(
         ],
     };
 
-    let result = tokio::task::spawn_blocking({
-        let engine = Arc::clone(engine);
-        move || engine.generate(&request)
-    })
-    .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": format!("Task error: {e}") })),
-        )
-    })?
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": format!("Inference error: {e}") })),
-        )
-    })?;
+    if is_streaming(&body) {
+        let stream = stream_chat(Arc::clone(engine), request, model);
+        Ok(Sse::new(stream).into_response())
+    } else {
+        let result = tokio::task::spawn_blocking({
+            let engine = Arc::clone(engine);
+            move || engine.generate(&request)
+        })
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": format!("Task error: {e}") }))))?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": format!("Inference error: {e}") }))))?;
 
-    // Audit log
-    let mut audit = AuditEntry::new(model.to_string(), "chat".to_string());
-    audit.input_tokens = result.tokens_prompt;
-    audit.output_tokens = result.tokens_generated;
-    audit.duration_ms = result.duration_ms;
-    AuditLogger::new().log(&audit);
+        let mut audit = AuditEntry::new(model.clone(), "chat".to_string());
+        audit.input_tokens = result.tokens_prompt;
+        audit.output_tokens = result.tokens_generated;
+        audit.duration_ms = result.duration_ms;
+        AuditLogger::new().log(&audit);
 
-    Ok(Json(json!({
-        "model": model,
-        "created_at": chrono::Utc::now().to_rfc3339(),
-        "message": {
-            "role": "assistant",
-            "content": result.text
-        },
-        "done": true,
-        "total_duration": result.duration_ms * 1_000_000,
-        "eval_count": result.tokens_generated,
-        "eval_duration": result.duration_ms * 1_000_000,
-        "prompt_eval_count": result.tokens_prompt
-    })))
+        Ok(Json(json!({
+            "model": model,
+            "created_at": chrono::Utc::now().to_rfc3339(),
+            "message": {
+                "role": "assistant",
+                "content": result.text
+            },
+            "done": true,
+            "total_duration": result.duration_ms * 1_000_000,
+            "eval_count": result.tokens_generated,
+            "eval_duration": result.duration_ms * 1_000_000,
+            "prompt_eval_count": result.tokens_prompt
+        })).into_response())
+    }
 }
 
 async fn show_model(Json(body): Json<Value>) -> Json<Value> {
@@ -261,7 +275,7 @@ async fn pull_model(Json(body): Json<Value>) -> Json<Value> {
     }))
 }
 
-// -- OpenAI-compatible handlers --
+// ── OpenAI-compatible handlers ───────────────────────────────────────────────
 
 async fn list_models_openai() -> Json<Value> {
     let data: Vec<Value> = EU_CATALOG
@@ -282,12 +296,13 @@ async fn list_models_openai() -> Json<Value> {
 async fn chat_completions(
     State(state): State<S>,
     Json(body): Json<Value>,
-) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+) -> Result<axum::response::Response, (StatusCode, Json<Value>)> {
     let model = body
         .get("model")
         .and_then(|v| v.as_str())
         .or(state.model_name.as_deref())
-        .unwrap_or("eullm/general-eu-7b");
+        .unwrap_or("eullm/general-eu-7b")
+        .to_string();
 
     let messages = body
         .get("messages")
@@ -295,24 +310,9 @@ async fn chat_completions(
         .cloned()
         .unwrap_or_default();
 
-    let engine = state.engine.as_ref().ok_or_else(|| {
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "No model loaded. Use `eullm run <model>` to load a model." })),
-        )
-    })?;
-
+    let engine = get_engine(&state)?;
     let prompt = format_chat_prompt(&messages);
-
-    let max_tokens = body
-        .get("max_tokens")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(512) as u32;
-
-    let temperature = body
-        .get("temperature")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(0.7) as f32;
+    let (max_tokens, temperature) = parse_generate_params(&body);
 
     let request = GenerateRequest {
         prompt,
@@ -324,63 +324,214 @@ async fn chat_completions(
         ],
     };
 
-    let result = tokio::task::spawn_blocking({
-        let engine = Arc::clone(engine);
-        move || engine.generate(&request)
-    })
-    .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": format!("Task error: {e}") })),
-        )
-    })?
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": format!("Inference error: {e}") })),
-        )
-    })?;
+    if is_streaming(&body) {
+        let stream = stream_chat_completions(Arc::clone(engine), request, model);
+        Ok(Sse::new(stream).into_response())
+    } else {
+        let result = tokio::task::spawn_blocking({
+            let engine = Arc::clone(engine);
+            move || engine.generate(&request)
+        })
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": format!("Task error: {e}") }))))?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": format!("Inference error: {e}") }))))?;
 
-    // Audit log
-    let mut audit = AuditEntry::new(model.to_string(), "chat.completions".to_string());
-    audit.input_tokens = result.tokens_prompt;
-    audit.output_tokens = result.tokens_generated;
-    audit.duration_ms = result.duration_ms;
-    AuditLogger::new().log(&audit);
+        let mut audit = AuditEntry::new(model.clone(), "chat.completions".to_string());
+        audit.input_tokens = result.tokens_prompt;
+        audit.output_tokens = result.tokens_generated;
+        audit.duration_ms = result.duration_ms;
+        AuditLogger::new().log(&audit);
 
-    Ok(Json(json!({
-        "id": format!("chatcmpl-{}", uuid::Uuid::new_v4()),
-        "object": "chat.completion",
-        "created": chrono::Utc::now().timestamp(),
-        "model": model,
-        "choices": [{
-            "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": result.text
-            },
-            "finish_reason": "stop"
-        }],
-        "usage": {
-            "prompt_tokens": result.tokens_prompt,
-            "completion_tokens": result.tokens_generated,
-            "total_tokens": result.tokens_prompt + result.tokens_generated
-        }
-    })))
+        Ok(Json(json!({
+            "id": format!("chatcmpl-{}", uuid::Uuid::new_v4()),
+            "object": "chat.completion",
+            "created": chrono::Utc::now().timestamp(),
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": result.text
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": result.tokens_prompt,
+                "completion_tokens": result.tokens_generated,
+                "total_tokens": result.tokens_prompt + result.tokens_generated
+            }
+        })).into_response())
+    }
 }
 
-/// Format chat messages into a ChatML-style prompt string.
-fn format_chat_prompt(messages: &[Value]) -> String {
-    let mut prompt = String::new();
-    for msg in messages {
-        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("user");
-        let content = msg
-            .get("content")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        prompt.push_str(&format!("<|im_start|>{role}\n{content}<|im_end|>\n"));
+// ── Streaming helpers ────────────────────────────────────────────────────────
+
+/// SSE stream for `/api/generate` (Ollama format).
+///
+/// Each event is a JSON object with `"response"` containing the token piece.
+/// The final event has `"done": true`.
+fn stream_generate(
+    engine: Arc<crate::inference::InferenceEngine>,
+    request: GenerateRequest,
+    model: String,
+) -> impl Stream<Item = Result<Event, std::convert::Infallible>> {
+    let (tx, rx) = mpsc::channel::<StreamEvent>(32);
+
+    tokio::task::spawn_blocking(move || {
+        engine.generate_streaming(&request, tx);
+    });
+
+    stream_from_channel(rx, model, StreamFormat::OllamaGenerate)
+}
+
+/// SSE stream for `/api/chat` (Ollama format).
+fn stream_chat(
+    engine: Arc<crate::inference::InferenceEngine>,
+    request: GenerateRequest,
+    model: String,
+) -> impl Stream<Item = Result<Event, std::convert::Infallible>> {
+    let (tx, rx) = mpsc::channel::<StreamEvent>(32);
+
+    tokio::task::spawn_blocking(move || {
+        engine.generate_streaming(&request, tx);
+    });
+
+    stream_from_channel(rx, model, StreamFormat::OllamaChat)
+}
+
+/// SSE stream for `/v1/chat/completions` (OpenAI format).
+fn stream_chat_completions(
+    engine: Arc<crate::inference::InferenceEngine>,
+    request: GenerateRequest,
+    model: String,
+) -> impl Stream<Item = Result<Event, std::convert::Infallible>> {
+    let (tx, rx) = mpsc::channel::<StreamEvent>(32);
+
+    tokio::task::spawn_blocking(move || {
+        engine.generate_streaming(&request, tx);
+    });
+
+    stream_from_channel(rx, model, StreamFormat::OpenAI)
+}
+
+#[derive(Clone, Copy)]
+enum StreamFormat {
+    OllamaGenerate,
+    OllamaChat,
+    OpenAI,
+}
+
+/// Convert an mpsc channel of StreamEvents into an SSE event stream.
+fn stream_from_channel(
+    mut rx: mpsc::Receiver<StreamEvent>,
+    model: String,
+    format: StreamFormat,
+) -> impl Stream<Item = Result<Event, std::convert::Infallible>> {
+    async_stream::stream! {
+        let completion_id = format!("chatcmpl-{}", uuid::Uuid::new_v4());
+
+        while let Some(event) = rx.recv().await {
+            match event {
+                StreamEvent::Token(piece) => {
+                    let data = match format {
+                        StreamFormat::OllamaGenerate => json!({
+                            "model": &model,
+                            "created_at": chrono::Utc::now().to_rfc3339(),
+                            "response": piece,
+                            "done": false,
+                        }),
+                        StreamFormat::OllamaChat => json!({
+                            "model": &model,
+                            "created_at": chrono::Utc::now().to_rfc3339(),
+                            "message": {
+                                "role": "assistant",
+                                "content": piece,
+                            },
+                            "done": false,
+                        }),
+                        StreamFormat::OpenAI => json!({
+                            "id": &completion_id,
+                            "object": "chat.completion.chunk",
+                            "created": chrono::Utc::now().timestamp(),
+                            "model": &model,
+                            "choices": [{
+                                "index": 0,
+                                "delta": {
+                                    "content": piece,
+                                },
+                                "finish_reason": Value::Null,
+                            }],
+                        }),
+                    };
+                    yield Ok(Event::default().data(data.to_string()));
+                }
+                StreamEvent::Done { tokens_generated, tokens_prompt, duration_ms } => {
+                    // Audit log
+                    let mut audit = AuditEntry::new(model.clone(), match format {
+                        StreamFormat::OllamaGenerate => "generate",
+                        StreamFormat::OllamaChat => "chat",
+                        StreamFormat::OpenAI => "chat.completions",
+                    }.to_string());
+                    audit.input_tokens = tokens_prompt;
+                    audit.output_tokens = tokens_generated;
+                    audit.duration_ms = duration_ms;
+                    AuditLogger::new().log(&audit);
+
+                    let data = match format {
+                        StreamFormat::OllamaGenerate => json!({
+                            "model": &model,
+                            "created_at": chrono::Utc::now().to_rfc3339(),
+                            "response": "",
+                            "done": true,
+                            "total_duration": duration_ms * 1_000_000,
+                            "eval_count": tokens_generated,
+                            "eval_duration": duration_ms * 1_000_000,
+                            "prompt_eval_count": tokens_prompt,
+                        }),
+                        StreamFormat::OllamaChat => json!({
+                            "model": &model,
+                            "created_at": chrono::Utc::now().to_rfc3339(),
+                            "message": {
+                                "role": "assistant",
+                                "content": "",
+                            },
+                            "done": true,
+                            "total_duration": duration_ms * 1_000_000,
+                            "eval_count": tokens_generated,
+                            "eval_duration": duration_ms * 1_000_000,
+                            "prompt_eval_count": tokens_prompt,
+                        }),
+                        StreamFormat::OpenAI => json!({
+                            "id": &completion_id,
+                            "object": "chat.completion.chunk",
+                            "created": chrono::Utc::now().timestamp(),
+                            "model": &model,
+                            "choices": [{
+                                "index": 0,
+                                "delta": {},
+                                "finish_reason": "stop",
+                            }],
+                            "usage": {
+                                "prompt_tokens": tokens_prompt,
+                                "completion_tokens": tokens_generated,
+                                "total_tokens": tokens_prompt + tokens_generated,
+                            },
+                        }),
+                    };
+                    yield Ok(Event::default().data(data.to_string()));
+
+                    // OpenAI format sends a final [DONE] marker
+                    if matches!(format, StreamFormat::OpenAI) {
+                        yield Ok(Event::default().data("[DONE]"));
+                    }
+                    break;
+                }
+                StreamEvent::Error(msg) => {
+                    let data = json!({ "error": msg });
+                    yield Ok(Event::default().data(data.to_string()));
+                    break;
+                }
+            }
+        }
     }
-    prompt.push_str("<|im_start|>assistant\n");
-    prompt
 }

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -1,6 +1,7 @@
 //! Inference engine powered by llama.cpp via llama-cpp-2 bindings.
 //!
 //! Loads GGUF models and runs text generation with token sampling.
+//! Supports both blocking generation and streaming (token-by-token via channel).
 
 use std::num::NonZeroU32;
 use std::path::PathBuf;
@@ -13,6 +14,7 @@ use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::{AddBos, LlamaModel};
 use llama_cpp_2::sampling::LlamaSampler;
 use parking_lot::Mutex;
+use tokio::sync::mpsc;
 
 /// Configuration for the inference engine.
 #[derive(Debug, Clone)]
@@ -58,13 +60,28 @@ impl Default for GenerateRequest {
     }
 }
 
-/// Result of text generation.
+/// Result of text generation (non-streaming).
 #[derive(Debug, Clone)]
 pub struct GenerateResult {
     pub text: String,
     pub tokens_generated: u32,
     pub tokens_prompt: u32,
     pub duration_ms: u64,
+}
+
+/// A single token event emitted during streaming generation.
+#[derive(Debug, Clone)]
+pub enum StreamEvent {
+    /// A text fragment (one or more decoded token characters).
+    Token(String),
+    /// Generation is complete.
+    Done {
+        tokens_generated: u32,
+        tokens_prompt: u32,
+        duration_ms: u64,
+    },
+    /// An error occurred during generation.
+    Error(String),
 }
 
 /// The loaded inference engine, holding the model and backend.
@@ -119,7 +136,7 @@ impl InferenceEngine {
         })
     }
 
-    /// Generate text from a prompt.
+    /// Generate text from a prompt (blocking, returns all at once).
     pub fn generate(
         &self,
         request: &GenerateRequest,
@@ -238,6 +255,148 @@ impl InferenceEngine {
         })
     }
 
+    /// Generate text with streaming — sends each token through the channel as it's produced.
+    ///
+    /// The caller receives `StreamEvent::Token(piece)` for each generated piece,
+    /// then `StreamEvent::Done { ... }` when generation is complete.
+    pub fn generate_streaming(
+        &self,
+        request: &GenerateRequest,
+        tx: mpsc::Sender<StreamEvent>,
+    ) {
+        let _lock = self.ctx_mutex.lock();
+        let start = std::time::Instant::now();
+
+        let ctx_size = NonZeroU32::new(self.config.context_size)
+            .unwrap_or(NonZeroU32::new(4096).unwrap());
+
+        let ctx_params = LlamaContextParams::default()
+            .with_n_ctx(Some(ctx_size))
+            .with_n_threads(self.config.threads as i32)
+            .with_n_threads_batch(self.config.threads as i32);
+
+        let mut ctx = match self.model.new_context(&self.backend, ctx_params) {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = tx.blocking_send(StreamEvent::Error(format!("Failed to create context: {e}")));
+                return;
+            }
+        };
+
+        let tokens = match self.model.str_to_token(&request.prompt, AddBos::Always) {
+            Ok(t) => t,
+            Err(e) => {
+                let _ = tx.blocking_send(StreamEvent::Error(format!("Tokenization failed: {e}")));
+                return;
+            }
+        };
+
+        let tokens_prompt = tokens.len() as u32;
+        let n_len = (tokens.len() as u32 + request.max_tokens) as i32;
+
+        let n_ctx = ctx.n_ctx() as i32;
+        if n_len > n_ctx {
+            let _ = tx.blocking_send(StreamEvent::Error(format!(
+                "Prompt ({tokens_prompt} tokens) + max_tokens ({}) exceeds context window ({n_ctx})",
+                request.max_tokens
+            )));
+            return;
+        }
+
+        let mut batch = match LlamaBatch::new(self.config.context_size as usize, 1) {
+            batch => batch,
+        };
+        let last_idx = (tokens.len() - 1) as i32;
+        for (i, token) in (0_i32..).zip(tokens.into_iter()) {
+            if batch.add(token, i, &[0], i == last_idx).is_err() {
+                let _ = tx.blocking_send(StreamEvent::Error("Failed to build batch".into()));
+                return;
+            }
+        }
+
+        if ctx.decode(&mut batch).is_err() {
+            let _ = tx.blocking_send(StreamEvent::Error("Prompt decode failed".into()));
+            return;
+        }
+
+        let mut sampler = LlamaSampler::chain_simple([
+            LlamaSampler::temp(request.temperature),
+            LlamaSampler::dist(1234),
+            LlamaSampler::greedy(),
+        ]);
+
+        let mut decoder = encoding_rs::UTF_8.new_decoder();
+        let mut full_output = String::new();
+        let mut n_cur = batch.n_tokens();
+        let mut tokens_generated: u32 = 0;
+
+        while n_cur <= n_len && tokens_generated < request.max_tokens {
+            let token = sampler.sample(&ctx, batch.n_tokens() - 1);
+            sampler.accept(token);
+
+            if self.model.is_eog_token(token) {
+                break;
+            }
+
+            match self.model.token_to_piece(token, &mut decoder, true, None) {
+                Ok(piece) => {
+                    full_output.push_str(&piece);
+
+                    // Check stop sequences
+                    let mut stopped = false;
+                    for s in &request.stop_sequences {
+                        if full_output.ends_with(s) {
+                            // Don't send the stop sequence token
+                            let piece_without_stop = if piece.len() >= s.len() {
+                                &piece[..piece.len() - s.len()]
+                            } else {
+                                ""
+                            };
+                            if !piece_without_stop.is_empty() {
+                                if tx.blocking_send(StreamEvent::Token(piece_without_stop.to_string())).is_err() {
+                                    return;
+                                }
+                            }
+                            stopped = true;
+                            break;
+                        }
+                    }
+
+                    if stopped {
+                        break;
+                    }
+
+                    // Send the token piece
+                    if tx.blocking_send(StreamEvent::Token(piece)).is_err() {
+                        return; // receiver dropped
+                    }
+                }
+                Err(_) => break,
+            }
+
+            batch.clear();
+            if batch.add(token, n_cur, &[0], true).is_err() {
+                break;
+            }
+
+            if ctx.decode(&mut batch).is_err() {
+                let _ = tx.blocking_send(StreamEvent::Error(format!(
+                    "Decode failed at token {tokens_generated}"
+                )));
+                return;
+            }
+
+            n_cur += 1;
+            tokens_generated += 1;
+        }
+
+        let duration_ms = start.elapsed().as_millis() as u64;
+        let _ = tx.blocking_send(StreamEvent::Done {
+            tokens_generated,
+            tokens_prompt,
+            duration_ms,
+        });
+    }
 }
 
 fn num_cpus() -> u32 {


### PR DESCRIPTION
Engine:
- Add generate_streaming() to InferenceEngine: sends tokens via mpsc channel as they're produced by llama.cpp, instead of buffering the full response
- /api/generate: supports "stream": true (Ollama format)
- /api/chat: supports "stream": true (Ollama format)
- /v1/chat/completions: supports "stream": true (OpenAI format with chat.completion.chunk objects and [DONE] terminator)
- Audit trail logged on stream completion (not per-token)
- Add async-stream dependency for ergonomic SSE stream construction

Docs:
- engine.md: document streaming parameter and examples for all endpoints
- README.md: add SSE streaming to Engine key features
