### PR TITLE
fix: correct binary path in release workflow for workspace layout

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -52,12 +52,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y cmake build-essential pkg-config libssl-dev
 
       - name: Build engine
-        working-directory: engine
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} -p eullm-engine
 
       - name: Package binary
         run: |
-          cp engine/target/${{ matrix.target }}/release/eullm ${{ matrix.artifact }}
+          cp target/${{ matrix.target }}/release/eullm ${{ matrix.artifact }}
           chmod +x ${{ matrix.artifact }}
 
       - name: Upload artifact


### PR DESCRIPTION
Cargo workspace places build artifacts in the workspace root's target/ directory, not engine/target/. Build from workspace root with -p flag and copy from target/ instead of engine/target/.

https://claude.ai/code/session_01LskTMJkSGRBBdxWgyymuAJ