### PR TITLE
ci: accept EuLLM-v* tags for release workflow

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "engine-v*"
+      - "EuLLM-v*"
 
 permissions:
   contents: write


### PR DESCRIPTION
The release workflow only triggered on engine-v* tags, so releases created with the EuLLM-v* naming convention had no compiled binaries.
