### PR TITLE
fix: clippy doc_overindented_list_items in import-ollama docstring

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -740,7 +740,7 @@ struct OllamaManifest {
 /// * `store` — EULLM local model store (`~/.eullm/models/`)
 /// * `model` — Ollama model specifier, e.g. `"llama3.2"` or `"qwen3:14b"`
 /// * `ollama_dir` — Optional override for the Ollama data directory
-///                   (defaults to `~/.ollama`)
+///   (defaults to `~/.ollama`)
 fn cmd_import_ollama(store: &ModelStore, model: &str, ollama_dir: Option<&str>) {
     // Resolve Ollama data directory
     let ollama_root = if let Some(dir) = ollama_dir {


### PR DESCRIPTION
Fixes CI failure: the continuation line of the `ollama_dir` doc comment was indented with extra spaces, triggering clippy's doc_overindented_list_items lint (-D warnings in CI).
