### PR TITLE
feat: support raw:true for pre-tokenized ChatML prompts

### DIFF
--- a/engine/src/api/routes.rs
+++ b/engine/src/api/routes.rs
@@ -294,6 +294,7 @@ async fn generate(
 
     let (max_tokens, temperature, num_ctx) = parse_generate_params(&body);
     let grammar = parse_format_grammar(&body);
+    let raw = body.get("raw").and_then(|v| v.as_bool()).unwrap_or(false);
 
     let request = GenerateRequest {
         prompt,
@@ -301,6 +302,7 @@ async fn generate(
         temperature,
         num_ctx,
         grammar,
+        raw,
         ..Default::default()
     };
 
@@ -407,6 +409,7 @@ async fn chat(
         ],
         num_ctx,
         grammar,
+        raw: false,
     };
 
     if let Some(ref sched) = snap.scheduler {
@@ -572,6 +575,7 @@ async fn chat_completions(
         ],
         num_ctx,
         grammar,
+        raw: false,
     };
 
     if let Some(ref sched) = snap.scheduler {

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -176,6 +176,9 @@ pub struct GenerateRequest {
     /// When set, the sampler enforces that output conforms to this grammar.
     /// Used by `format: "json"` to guarantee valid JSON output.
     pub grammar: Option<String>,
+    /// When true, the prompt is used as-is without adding BOS token.
+    /// Required for raw ChatML prompts that already contain special tokens.
+    pub raw: bool,
 }
 
 impl Default for GenerateRequest {
@@ -187,6 +190,7 @@ impl Default for GenerateRequest {
             stop_sequences: Vec::new(),
             num_ctx: None,
             grammar: None,
+            raw: false,
         }
     }
 }
@@ -331,7 +335,7 @@ impl InferenceEngine {
         // Tokenize the prompt
         let tokens = self
             .model
-            .str_to_token(&request.prompt, AddBos::Always)
+            .str_to_token(&request.prompt, if request.raw { AddBos::Never } else { AddBos::Always })
             .map_err(|e| format!("Tokenization failed: {e}"))?;
 
         let tokens_prompt = tokens.len() as u32;
@@ -526,7 +530,7 @@ impl InferenceEngine {
             }
         };
 
-        let tokens = match self.model.str_to_token(&request.prompt, AddBos::Always) {
+        let tokens = match self.model.str_to_token(&request.prompt, if request.raw { AddBos::Never } else { AddBos::Always }) {
             Ok(t) => t,
             Err(e) => {
                 let _ = tx.blocking_send(StreamEvent::Error(format!("Tokenization failed: {e}")));

--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -649,8 +649,9 @@ fn prefill_sequence(
     seq: &ActiveSequence,
     per_seq_ctx: u32,
 ) -> Result<(u32, i32, u32), String> {
+    let bos = if request.raw { AddBos::Never } else { AddBos::Always };
     let tokens = model
-        .str_to_token(&request.prompt, AddBos::Always)
+        .str_to_token(&request.prompt, bos)
         .map_err(|e| format!("Tokenization failed: {e}"))?;
 
     let n_tokens = tokens.len() as u32;

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1302,6 +1302,7 @@ async fn interactive_chat(
             stop_sequences: vec!["<|im_end|>".into()],
             num_ctx: None,
             grammar: None,
+            raw: false,
         };
 
         // Submit to scheduler and stream tokens.


### PR DESCRIPTION
When "raw": true is set in the request body, the prompt is tokenized without adding a BOS token (AddBos::Never).  This is required for raw ChatML prompts that already contain special tokens like <|im_start|> and <|im_end|> — adding BOS on top of these created invalid token sequences that caused GGML_ASSERT crashes in llama.cpp.

Matches Ollama's raw mode behaviour: the prompt is used exactly as provided, with no template wrapping or BOS injection.
