### PR TITLE
fix(ci): run cargo fetch before setup-turboquant.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
       - name: Setup TurboQuant backend
         working-directory: engine
         run: |
+          cargo fetch
           bash scripts/setup-turboquant.sh
           sed -i 's|^# \[patch.crates-io\]|\[patch.crates-io\]|' Cargo.toml
           sed -i 's|^# llama-cpp-sys-2|llama-cpp-sys-2|' Cargo.toml

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -140,6 +140,7 @@ jobs:
         working-directory: engine
         run: |
           . "$HOME/.cargo/env"
+          cargo fetch
           bash scripts/setup-turboquant.sh
           sed -i 's|^# \[patch.crates-io\]|\[patch.crates-io\]|' Cargo.toml
           sed -i 's|^# llama-cpp-sys-2|llama-cpp-sys-2|' Cargo.toml


### PR DESCRIPTION
The setup script needs llama-cpp-sys-2 in the cargo registry to vendor it.  In CI, the registry is empty until cargo downloads dependencies.  Adding cargo fetch before the script ensures the crate is available.
