### PR TITLE
fix(ci): setup-turboquant.sh now activates [patch.crates-io] automati…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,10 @@ jobs:
         run: |
           cargo fetch
           bash scripts/setup-turboquant.sh
-          sed -i 's|^# \[patch.crates-io\]|\[patch.crates-io\]|' Cargo.toml
-          sed -i 's|^# llama-cpp-sys-2|llama-cpp-sys-2|' Cargo.toml
+          echo "--- Cargo.toml patch section ---"
+          grep -A2 'patch.crates-io' Cargo.toml || echo "NO PATCH FOUND"
+          echo "--- cargo tree llama-cpp-sys-2 ---"
+          cargo tree -i llama-cpp-sys-2 2>&1 | head -5
       - name: Build (turboquant)
         working-directory: engine
         run: cargo build --features turboquant

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -142,8 +142,9 @@ jobs:
           . "$HOME/.cargo/env"
           cargo fetch
           bash scripts/setup-turboquant.sh
-          sed -i 's|^# \[patch.crates-io\]|\[patch.crates-io\]|' Cargo.toml
-          sed -i 's|^# llama-cpp-sys-2|llama-cpp-sys-2|' Cargo.toml
+          echo "--- Verifying patch ---"
+          grep -A2 'patch.crates-io' Cargo.toml || echo "NO PATCH FOUND"
+          . "$HOME/.cargo/env" && cargo tree -i llama-cpp-sys-2 2>&1 | head -5
 
       - name: Build engine with CUDA + TurboQuant
         run: |

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -51,10 +51,7 @@ assert_cmd = "2"
 predicates = "3"
 
 # ── TurboQuant backend (experimental) ───────────────────────────
-# Uncomment after running: scripts/setup-turboquant.sh
-# Redirects llama-cpp-sys-2 to a vendored copy that uses spiritbuun's
-# TurboQuant CUDA fork of llama.cpp.  Production builds (without
-# --features turboquant) are unaffected — the fork is API-compatible.
-#
-# [patch.crates-io]
-# llama-cpp-sys-2 = { path = "vendor/llama-cpp-sys-2" }
+# To enable TurboQuant, run: scripts/setup-turboquant.sh
+# The script vendors llama-cpp-sys-2 with spiritbuun's fork and
+# appends [patch.crates-io] to this file automatically.
+# Then build with: cargo build --release --features "cuda turboquant_native"

--- a/engine/scripts/setup-turboquant.sh
+++ b/engine/scripts/setup-turboquant.sh
@@ -5,27 +5,28 @@
 # spiritbuun's TurboQuant CUDA fork of llama.cpp instead of upstream.
 #
 # After running this script, build eullm with:
-#   cargo build --release --features "cuda turboquant"
+#   cargo build --release --features "cuda turboquant_native"
 #
 # The fork is local to this workspace and does not affect other projects.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-WORKSPACE_ROOT="$(dirname "$SCRIPT_DIR")"
-VENDOR_DIR="${WORKSPACE_ROOT}/vendor"
+ENGINE_DIR="$(dirname "$SCRIPT_DIR")"
+VENDOR_DIR="${ENGINE_DIR}/vendor"
 SYS_CRATE_DIR="${VENDOR_DIR}/llama-cpp-sys-2"
+CARGO_TOML="${ENGINE_DIR}/Cargo.toml"
 
 echo "=== EULLM TurboQuant Backend Setup ==="
 echo ""
 
 # 1. Find the installed llama-cpp-sys-2 crate
 CARGO_REGISTRY="${CARGO_HOME:-$HOME/.cargo}/registry/src"
-INSTALLED_CRATE=$(find "$CARGO_REGISTRY" -maxdepth 2 -name "llama-cpp-sys-2-0.1.140" -type d | head -1)
+INSTALLED_CRATE=$(find "$CARGO_REGISTRY" -maxdepth 2 -name "llama-cpp-sys-2-0.1.140" -type d 2>/dev/null | head -1)
 
 if [ -z "$INSTALLED_CRATE" ]; then
     echo "ERROR: llama-cpp-sys-2 v0.1.140 not found in cargo registry."
-    echo "Run 'cargo build --release' first to download it."
+    echo "Run 'cargo fetch' in the engine/ directory first."
     exit 1
 fi
 
@@ -35,11 +36,13 @@ echo "Found llama-cpp-sys-2 at: $INSTALLED_CRATE"
 mkdir -p "$VENDOR_DIR"
 
 if [ -d "$SYS_CRATE_DIR" ]; then
-    echo "Vendor directory already exists: $SYS_CRATE_DIR"
-    read -p "Replace it? (y/N) " -r
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        echo "Aborted."
-        exit 0
+    # In CI (non-interactive), always replace.
+    if [ -t 0 ]; then
+        read -p "Vendor directory exists. Replace it? (y/N) " -r
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "Aborted."
+            exit 0
+        fi
     fi
     rm -rf "$SYS_CRATE_DIR"
 fi
@@ -57,16 +60,49 @@ git clone --depth 1 --branch feature/turboquant-kv-cache \
 # 4. Remove .git from the cloned repo (we vendor it, not submodule it)
 rm -rf "${SYS_CRATE_DIR}/llama.cpp/.git"
 
+# 5. Verify TurboQuant types exist in the fork
+if grep -q "GGML_TYPE_TURBO3_0" "${SYS_CRATE_DIR}/llama.cpp/ggml/include/ggml.h"; then
+    echo "Verified: GGML_TYPE_TURBO3_0 found in fork"
+else
+    echo "ERROR: GGML_TYPE_TURBO3_0 not found in fork — wrong branch?"
+    exit 1
+fi
+
+# 6. Activate [patch.crates-io] in Cargo.toml
+#    Uncomment the patch section so cargo uses the vendored fork
+#    instead of the standard crate from crates.io.
+if grep -q '^# \[patch.crates-io\]' "$CARGO_TOML"; then
+    echo "Activating [patch.crates-io] in Cargo.toml..."
+    sed -i 's|^# \[patch.crates-io\]|[patch.crates-io]|' "$CARGO_TOML"
+    sed -i 's|^# llama-cpp-sys-2 = |llama-cpp-sys-2 = |' "$CARGO_TOML"
+elif grep -q '^\[patch.crates-io\]' "$CARGO_TOML"; then
+    echo "[patch.crates-io] already active in Cargo.toml"
+else
+    echo "Adding [patch.crates-io] to Cargo.toml..."
+    cat >> "$CARGO_TOML" <<PATCH
+
+[patch.crates-io]
+llama-cpp-sys-2 = { path = "vendor/llama-cpp-sys-2" }
+PATCH
+fi
+
+# 7. Verify the patch is active
+if grep -q '^llama-cpp-sys-2 = { path = "vendor/llama-cpp-sys-2" }' "$CARGO_TOML" || \
+   grep -q "^\[patch.crates-io\]" "$CARGO_TOML"; then
+    echo "Verified: [patch.crates-io] is active"
+else
+    echo "WARNING: Could not verify [patch.crates-io] activation"
+fi
+
 echo ""
 echo "=== Setup complete ==="
 echo ""
-echo "The vendored llama-cpp-sys-2 at:"
-echo "  ${SYS_CRATE_DIR}"
-echo "now uses spiritbuun's TurboQuant CUDA fork of llama.cpp."
+echo "Vendored llama-cpp-sys-2: ${SYS_CRATE_DIR}"
+echo "Fork verified: GGML_TYPE_TURBO3_0 = 41"
 echo ""
 echo "Build with:"
-echo "  cd ${WORKSPACE_ROOT}/engine"
-echo "  cargo build --release --features 'cuda turboquant'"
+echo "  cd ${ENGINE_DIR}"
+echo "  cargo build --release --features 'cuda turboquant_native'"
 echo ""
-echo "The [patch.crates-io] section in engine/Cargo.toml"
-echo "redirects the dependency to this vendored copy."
+echo "Verify with:"
+echo "  cargo tree -i llama-cpp-sys-2  # should show (vendor/llama-cpp-sys-2)"


### PR DESCRIPTION
…cally

The CI sed commands to uncomment [patch.crates-io] were fragile and failed silently, causing the build to link against standard llama-cpp-sys-2 (without TurboQuant types).  GGML_ASSERT crashed at runtime because type IDs 41-43 were not in GGML_TYPE_COUNT.

Now setup-turboquant.sh:
- Activates [patch.crates-io] itself (appends if missing, uncomments if commented)
- Verifies GGML_TYPE_TURBO3_0 exists in the cloned fork
- Works in CI (non-interactive) and locally (interactive prompt)
- CI workflows log the patch status and cargo tree for debugging

Cargo.toml no longer has a fragile commented [patch] section — the script appends it when needed.
