### PR TITLE
fix(turboquant): patch workspace root Cargo.toml, not engine member

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,8 @@ jobs:
         run: |
           cargo fetch
           bash scripts/setup-turboquant.sh
-          echo "--- Cargo.toml patch section ---"
-          grep -A2 'patch.crates-io' Cargo.toml || echo "NO PATCH FOUND"
+          echo "--- Workspace Cargo.toml patch section ---"
+          grep -A2 'patch.crates-io' ../Cargo.toml || echo "NO PATCH FOUND"
           echo "--- cargo tree llama-cpp-sys-2 ---"
           cargo tree -i llama-cpp-sys-2 2>&1 | head -5
       - name: Build (turboquant)

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -142,8 +142,8 @@ jobs:
           . "$HOME/.cargo/env"
           cargo fetch
           bash scripts/setup-turboquant.sh
-          echo "--- Verifying patch ---"
-          grep -A2 'patch.crates-io' Cargo.toml || echo "NO PATCH FOUND"
+          echo "--- Verifying patch (workspace root) ---"
+          grep -A2 'patch.crates-io' ../Cargo.toml || echo "NO PATCH FOUND"
           . "$HOME/.cargo/env" && cargo tree -i llama-cpp-sys-2 2>&1 | head -5
 
       - name: Build engine with CUDA + TurboQuant

--- a/engine/scripts/setup-turboquant.sh
+++ b/engine/scripts/setup-turboquant.sh
@@ -15,7 +15,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ENGINE_DIR="$(dirname "$SCRIPT_DIR")"
 VENDOR_DIR="${ENGINE_DIR}/vendor"
 SYS_CRATE_DIR="${VENDOR_DIR}/llama-cpp-sys-2"
-CARGO_TOML="${ENGINE_DIR}/Cargo.toml"
+# [patch.crates-io] must live in the workspace root Cargo.toml, not in the
+# engine/ member manifest.  Detect workspace root by looking for [workspace].
+WORKSPACE_ROOT="${ENGINE_DIR}/.."
+if [ -f "${WORKSPACE_ROOT}/Cargo.toml" ] && grep -q '^\[workspace\]' "${WORKSPACE_ROOT}/Cargo.toml"; then
+    CARGO_TOML="${WORKSPACE_ROOT}/Cargo.toml"
+    # Path must be relative to the workspace root
+    PATCH_PATH="engine/vendor/llama-cpp-sys-2"
+else
+    # Fallback: no workspace, patch the engine Cargo.toml directly
+    CARGO_TOML="${ENGINE_DIR}/Cargo.toml"
+    PATCH_PATH="vendor/llama-cpp-sys-2"
+fi
+CARGO_TOML="$(cd "$(dirname "$CARGO_TOML")" && pwd)/$(basename "$CARGO_TOML")"
 
 echo "=== EULLM TurboQuant Backend Setup ==="
 echo ""
@@ -82,12 +94,12 @@ else
     cat >> "$CARGO_TOML" <<PATCH
 
 [patch.crates-io]
-llama-cpp-sys-2 = { path = "vendor/llama-cpp-sys-2" }
+llama-cpp-sys-2 = { path = "${PATCH_PATH}" }
 PATCH
 fi
 
 # 7. Verify the patch is active
-if grep -q '^llama-cpp-sys-2 = { path = "vendor/llama-cpp-sys-2" }' "$CARGO_TOML" || \
+if grep -q "llama-cpp-sys-2" "$CARGO_TOML" && \
    grep -q "^\[patch.crates-io\]" "$CARGO_TOML"; then
     echo "Verified: [patch.crates-io] is active"
 else
@@ -98,11 +110,12 @@ echo ""
 echo "=== Setup complete ==="
 echo ""
 echo "Vendored llama-cpp-sys-2: ${SYS_CRATE_DIR}"
+echo "Patch in: ${CARGO_TOML}  (path = ${PATCH_PATH})"
 echo "Fork verified: GGML_TYPE_TURBO3_0 = 41"
 echo ""
 echo "Build with:"
 echo "  cd ${ENGINE_DIR}"
 echo "  cargo build --release --features 'cuda turboquant_native'"
 echo ""
-echo "Verify with:"
-echo "  cargo tree -i llama-cpp-sys-2  # should show (vendor/llama-cpp-sys-2)"
+echo "Verify with (from workspace root):"
+echo "  cargo tree -i llama-cpp-sys-2  # should show (${PATCH_PATH})"


### PR DESCRIPTION
[patch.crates-io] is only honoured in the workspace root manifest. The repo uses a workspace (root Cargo.toml with members=[engine,hub]), so setup-turboquant.sh was patching engine/Cargo.toml which Cargo silently ignores, causing the standard crates.io llama-cpp-sys-2 to be linked and GGML_ASSERT to fire at runtime.

Fix:
- setup-turboquant.sh now detects the workspace root (looks for [workspace] in ../Cargo.toml) and patches that file instead.
- PATCH_PATH is set to engine/vendor/llama-cpp-sys-2 (workspace-relative).
- CI verification grep updated to check ../Cargo.toml.
