### PR TITLE
fix: update start() return type to (SchedulerHandle, ModelReadyInfo)

### DIFF
--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -147,7 +147,7 @@ impl AppState {
                 };
                 let sched = BatchScheduler::new(config, sched_config);
                 match sched.start() {
-                    Ok(handle) => Ok((None, Some(handle))),
+                    Ok((handle, _model_info)) => Ok((None, Some(handle))),
                     Err(e) => Err(format!("Failed to start scheduler: {e}")),
                 }
             } else {

--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -166,7 +166,7 @@ impl BatchScheduler {
     ///
     /// Blocks until the model is fully loaded so that callers can rely on the
     /// handle being ready for inference when this method returns.
-    pub fn start(self) -> Result<SchedulerHandle, Box<dyn std::error::Error + Send + Sync>> {
+    pub fn start(self) -> Result<(SchedulerHandle, ModelReadyInfo), Box<dyn std::error::Error + Send + Sync>> {
         // Validate model exists before spawning the thread.
         if !self.config.model_path.exists() {
             return Err(format!(


### PR DESCRIPTION
The start() signature and all call sites must match the tuple return.
