### PR TITLE
ci: remove pull_request trigger, run CI only on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
-# Cancel redundant runs: when a PR is merged, the in-progress PR run
-# is cancelled since the push-to-main run covers the same commits.
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.sha }}
+  group: ci-${{ github.sha }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Saves CI minutes — no more duplicate runs on PR + merge. CI runs once when the code lands on main.
