### PR TITLE
fix: collapse nested if blocks for Clippy edition 2024 compliance

### DIFF
--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -189,10 +189,8 @@ impl AppState {
         }
 
         // 2. Directory containing .gguf files? Pick the first one.
-        if path.is_dir() {
-            if let Some(gguf) = find_gguf_in_dir(&path) {
-                return Ok(gguf);
-            }
+        if path.is_dir() && let Some(gguf) = find_gguf_in_dir(&path) {
+            return Ok(gguf);
         }
 
         // 3. Try appending .gguf extension.
@@ -216,10 +214,8 @@ impl AppState {
 
         // 5. Try normalized name (Ollama tag format).
         let normalized = normalize_model_name(name);
-        if normalized != name {
-            if let Some(p) = self.store.gguf_path(&normalized) {
-                return Ok(p);
-            }
+        if normalized != name && let Some(p) = self.store.gguf_path(&normalized) {
+            return Ok(p);
         }
 
         Err(format!(

--- a/engine/src/gguf_patch.rs
+++ b/engine/src/gguf_patch.rs
@@ -108,18 +108,19 @@ pub fn patch_gguf_if_needed(src: &Path, dst: &Path) -> io::Result<bool> {
             };
 
             // Check if this key needs fixing
-            if let Some(&(_, target)) = KNOWN_FIXES.iter().find(|&&(k, _)| k == key.as_str()) {
-                if count < target && elem_sz > 0 {
-                    patches.push(ArrayPatch {
-                        count_offset,
-                        current_count: count,
-                        target_count: target,
-                        elem_size: elem_sz,
-                    });
-                    tracing::info!(
-                        "GGUF patch: {key} has {count} elements, extending to {target}"
-                    );
-                }
+            if let Some(&(_, target)) = KNOWN_FIXES.iter().find(|&&(k, _)| k == key.as_str())
+                && count < target
+                && elem_sz > 0
+            {
+                patches.push(ArrayPatch {
+                    count_offset,
+                    current_count: count,
+                    target_count: target,
+                    elem_size: elem_sz,
+                });
+                tracing::info!(
+                    "GGUF patch: {key} has {count} elements, extending to {target}"
+                );
             }
         } else {
             skip_gguf_value(&mut f, vtype)?;


### PR DESCRIPTION
collapsible_if is now a hard error with -D warnings on Rust 2024. Collapsed three nested if/if-let patterns using let-chains (stable since 1.88):
- engine/src/api/mod.rs:192 (is_dir + find_gguf_in_dir)
- engine/src/api/mod.rs:219 (normalized != name + gguf_path)
- engine/src/gguf_patch.rs:111 (KNOWN_FIXES + count/elem_sz guards