### PR TITLE
fix: use POSIX [[:space:]] instead of \s in sed pattern

### DIFF
--- a/engine/scripts/setup-turboquant.sh
+++ b/engine/scripts/setup-turboquant.sh
@@ -132,7 +132,7 @@ TURBO_CUH="${SYS_CRATE_DIR}/llama.cpp/ggml/src/ggml-cuda/turbo-quant-cuda.cuh"
 if [ -f "$TURBO_CUH" ]; then
     COUNT=$(grep -c "turbo_rotate_forward_cuda(x," "$TURBO_CUH" || true)
     if [ "$COUNT" -gt 0 ]; then
-        sed 's/^\(\s*\)turbo_rotate_forward_cuda(x,/\1\/\/ EULLM-FIX(bug7-rotation-mismatch): turbo_rotate_forward_cuda(x,/' \
+        sed 's/^\([[:space:]]*\)turbo_rotate_forward_cuda(x,/\1\/\/ EULLM-FIX(bug7-rotation-mismatch): turbo_rotate_forward_cuda(x,/' \
             "$TURBO_CUH" > "${TURBO_CUH}.tmp" && mv "${TURBO_CUH}.tmp" "$TURBO_CUH"
         PATCHED=$(grep -c "EULLM-FIX(bug7-rotation-mismatch)" "$TURBO_CUH" || true)
         echo "  Applied Bug#7 rotation-mismatch fix: commented out $PATCHED turbo_rotate_forward_cuda call(s)"


### PR DESCRIPTION
BSD sed (macOS) does not recognize \s as a whitespace class. Replace with [[:space:]] which is POSIX and works on both GNU and BSD sed.