### PR TITLE
chore: bump engine version to 0.3.5

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.3.3"
+version = "0.3.5"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"


### PR DESCRIPTION
Change Manifest to 0.3.5