### PR TITLE
fix: suppress ggml logs in scheduler and warn on asymmetric TQ KV cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -101,13 +101,22 @@ pub(crate) fn build_ctx_params_with_cache(
         params = params.with_type_k(cache_type_k).with_type_v(cache_type_v);
     }
 
-    if config.flash_attn {
+    // The default flash_attn_type in llama.cpp is AUTO (-1), not DISABLED (0).
+    // We must always set it explicitly — if we skip this when flash_attn=false,
+    // the default AUTO mode stays active, which can enable FA unexpectedly.
+    let fa_policy: i32 = if config.flash_attn {
         // AUTO (-1): llama.cpp tests whether the GPU supports FA for the
-        // current KV cache types.  If not → disables FA and uses regular
-        // attention on GPU.  ENABLED (1) would skip this check and silently
-        // route the FA op to the CPU backend on unsupported configs.
-        params = params.with_flash_attention_policy(-1);
-    }
+        // current KV cache types.  If not → disables FA and uses standard
+        // attention.  ENABLED (1) would skip this check.
+        -1
+    } else {
+        // DISABLED (0): explicitly turn off FA.
+        // Note: llama.cpp requires flash_attn for quantized V cache; if V is
+        // quantized and FA is disabled, context creation returns an error and
+        // our fallback logic switches to F16/F16.
+        0
+    };
+    params = params.with_flash_attention_policy(fa_policy);
     params
 }
 

--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -251,7 +251,11 @@ fn run_scheduler_loop(
     super::log_turboquant_status();
 
     tracing::info!("Initializing llama.cpp backend (scheduler)...");
-    let backend = LlamaBackend::init()?;
+    let mut backend = LlamaBackend::init()?;
+    // Suppress llama.cpp/ggml log messages (CUDA graph warmup etc.) — these
+    // come from the global ggml logger and pollute interactive output.
+    // void_logs() calls llama_log_set which internally calls ggml_log_set.
+    backend.void_logs();
 
     let model_params = if config.gpu_layers >= 0 {
         LlamaModelParams::default().with_n_gpu_layers(config.gpu_layers as u32)

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -252,14 +252,22 @@ async fn main() {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             });
-            // Mixed TurboQuant types (e.g. K=tq4_0, V=tq3_0) are valid:
-            // K needs more precision (attention scores), V tolerates more compression.
-            // Warn the user, but allow it — fallback handles failures gracefully.
+            // Mixed TurboQuant types (e.g. K=tq4_0, V=tq3_0) — both Unknown.
             if let (inference::KvCacheType::Unknown(k_id), inference::KvCacheType::Unknown(v_id)) = (&ctk, &ctv)
                 && k_id != v_id
             {
                 eprintln!("Note: mixed TurboQuant KV cache (K={cache_type_k}, V={cache_type_v}).");
                 eprintln!("  Advanced config — if OOM, will fallback to uniform type then F16.");
+            }
+            // Asymmetric F16/Q8_0-K + TurboQuant-V — may crash on models with
+            // non-standard head dimensions (e.g. Gemma 4 D=512/256 SWA).
+            // For those models, use symmetric TQ/TQ (e.g. tbq4_0/tbq4_0) instead.
+            if matches!(&ctv, inference::KvCacheType::Unknown(_))
+                && !matches!(&ctk, inference::KvCacheType::Unknown(_))
+            {
+                eprintln!("Note: asymmetric KV cache (K={cache_type_k}, V={cache_type_v}).");
+                eprintln!("  TurboQuant V with non-TQ K may crash on Gemma 4 / models with D=512.");
+                eprintln!("  If it crashes, try symmetric: --cache-type-k {cache_type_v} --cache-type-v {cache_type_v}");
             }
             cmd_run(&store, &model, port, replace, gpu_layers, ctx_size, threads, batch_size, !no_flash_attn, n_batch, ctk, ctv).await;
         }


### PR DESCRIPTION
Two fixes for v0.3.13:

1. Log suppression: void_logs() was only called in the sequential InferenceEngine path. The BatchScheduler (default for `run`) never silenced the ggml logger, so CUDA graph warmup messages kept leaking into interactive output. Now called in both code paths.

2. Flash attention policy: the default flash_attn_type in llama.cpp is AUTO (-1), not DISABLED (0). Skipping the policy call when --no-flash-attn was set left FA in AUTO mode. Now explicitly sets DISABLED (0) when flash_attn=false.

3. Asymmetric TQ warning: TurboQuant V-cache with non-TQ K-cache (e.g. f16/tbq4_0) can crash on models with non-standard head dimensions (Gemma 4 D=512/256 SWA). Added startup warning suggesting symmetric TQ/TQ as the safe alternative.