### PR TITLE
fix: enable Qwen3 thinking mode by default in math accuracy benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ For RAG, long documents, and multi-turn conversations, the context gain far outw
 
 Google's ICLR 2026 algorithm (Zandieh et al.). Compresses the KV cache — **not the model weights**. Applies Walsh-Hadamard Transform rotation + Lloyd-Max quantization to attention key/value states at inference time. Model weights (Q4_K_M, etc.) stay untouched. EULLM implements Stage 1 only; Stage 2 (QJL) is omitted to preserve output quality.
 
+EULLM uses [AmesianX/TurboQuant](https://github.com/AmesianX/TurboQuant) as its llama.cpp backend, which extends the original algorithm with CUDA-accelerated WHT kernels, Gemma 4 SWA architecture support, and ongoing research into attention score sharpening.
+
 Available types:
 - **TQ4_0** — 4-bit KV cache, ~50% VRAM savings, minimal quality impact
 - **TQ3_0** — 3-bit KV cache, ~62% VRAM savings, slight quality reduction

--- a/bench/turboquant_math_accuracy.py
+++ b/bench/turboquant_math_accuracy.py
@@ -337,7 +337,7 @@ async def collect(args):
     filler_levels = [int(x) for x in args.filler.split(",") if x and int(x) > 0]
     tests = build_tests(filler_levels, skip_3x3=args.skip_3x3, skip_scalar=args.skip_scalar)
 
-    think = None if args.no_think else False
+    think = None if args.no_think else True
 
     print(f"TurboQuant Math Accuracy Test")
     print(f"  URL:   {args.url}")

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -220,7 +220,7 @@ Available types: `f16`, `f32`, `q8_0`, `q4_0`, `q4_1`, `q5_0`, `q5_1`. With Turb
 
 TurboQuant is a KV cache compression method based on the TurboQuant algorithm (Zandieh et al., ICLR 2026). It applies **WHT (Walsh-Hadamard Transform) rotation** followed by **Lloyd-Max quantization** to compress the KV cache far more aggressively than standard round-to-nearest quantization. This is **not weight quantization** — the model weights stay at their original precision (e.g. Q4_K_M GGUF). Only the keys and values stored in the KV cache during inference are compressed.
 
-Backend: **AmesianX/TurboQuant v1.5.0** (Gemma 4 / hybrid SWA support, 512-point WHT single-pass, upstream llama.cpp rebase).
+Backend: **[AmesianX/TurboQuant](https://github.com/AmesianX/TurboQuant) v1.5.2** (V rotation bug fix, SQNR-based attention score sharpening, per-block norm for D=512, Gemma 4 SWA bypass, 512-point WHT single-pass, upstream llama.cpp rebase).
 
 This enables running large models at very long context lengths on consumer GPUs that would otherwise run out of VRAM.
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"
@@ -52,6 +52,6 @@ predicates = "3"
 
 # ── TurboQuant backend (experimental) ───────────────────────────
 # To enable TurboQuant, run: scripts/setup-turboquant.sh
-# The script vendors llama-cpp-sys-2 with AmesianX/TurboQuant v1.5.0 and
+# The script vendors llama-cpp-sys-2 with AmesianX/TurboQuant v1.5.2 and
 # appends [patch.crates-io] to this file automatically.
 # Then build with: cargo build --release --features "cuda turboquant_native"

--- a/engine/scripts/setup-turboquant.sh
+++ b/engine/scripts/setup-turboquant.sh
@@ -69,15 +69,15 @@ echo "Copying crate to vendor/..."
 cp -r "$INSTALLED_CRATE" "$SYS_CRATE_DIR"
 chmod -R u+w "$SYS_CRATE_DIR"
 
-# 3. Replace the bundled llama.cpp with AmesianX/TurboQuant v1.5.0
-echo "Cloning AmesianX/TurboQuant v1.5.0..."
+# 3. Replace the bundled llama.cpp with AmesianX/TurboQuant v1.5.2
+echo "Cloning AmesianX/TurboQuant v1.5.2..."
 rm -rf "${SYS_CRATE_DIR}/llama.cpp"
 git clone --depth 1 --branch main \
     https://github.com/AmesianX/TurboQuant.git \
     "${SYS_CRATE_DIR}/llama.cpp"
-# Pin to v1.5.0 (Gemma 4 / hybrid SWA support, 512-point WHT single-pass,
-#               upstream llama.cpp rebase; TBQP not supported at D=512)
-git -C "${SYS_CRATE_DIR}/llama.cpp" fetch --depth 1 origin v1.5.0
+# Pin to v1.5.2 (V rotation bug fix, attention score sharpening via SQNR-based
+#               alpha correction, per-block norm for D=512, SWA bypass for Gemma 4)
+git -C "${SYS_CRATE_DIR}/llama.cpp" fetch --depth 1 origin v1.5.2
 git -C "${SYS_CRATE_DIR}/llama.cpp" checkout FETCH_HEAD
 
 # 4. Remove .git from the cloned repo (we vendor it, not submodule it)
@@ -174,7 +174,7 @@ echo "=== Setup complete ==="
 echo ""
 echo "Vendored llama-cpp-sys-2: ${SYS_CRATE_DIR}"
 echo "Patch in: ${CARGO_TOML}  (path = ${PATCH_PATH})"
-echo "Fork verified: GGML_TYPE_TBQ3_0=41 GGML_TYPE_TBQ4_0=42 GGML_TYPE_TBQP3_0=43 GGML_TYPE_TBQP4_0=44 (v1.5.0: D=512 SWA support)"
+echo "Fork verified: GGML_TYPE_TBQ3_0=41 GGML_TYPE_TBQ4_0=42 GGML_TYPE_TBQP3_0=43 GGML_TYPE_TBQP4_0=44 (v1.5.2: V rotation fix, attention sharpening, SWA bypass)"
 echo ""
 echo "Build with:"
 echo "  cd ${ENGINE_DIR}"


### PR DESCRIPTION
think=False was hardcoded as default, disabling chain-of-thought and causing Qwen3 to fail simple arithmetic. The API routes now read the think field explicitly (added with chat template support), so the wrong default started breaking results. think=True restores the previous behaviour where the API defaulted to thinking enabled.

Use --no-think for non-Qwen3 models (Qwen2.5-Math, DeepSeek, etc.)
