### PR TITLE
feat: add transparent web browsing with --web flag (v0.4.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.3.14"
+version = "0.4.0"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -57,6 +57,10 @@ pub struct AppState {
     /// 0 = sequential, >0 = continuous batching with this many slots.
     pub batch_size: usize,
 
+    /// Enable transparent web fetching: URLs in user messages are fetched
+    /// and their content is injected into the prompt before inference.
+    pub web_enabled: bool,
+
     /// Model store for resolving names → GGUF paths.
     pub store: ModelStore,
 }
@@ -262,6 +266,7 @@ pub struct ServeConfig {
     pub cache_type_k: crate::inference::KvCacheType,
     pub cache_type_v: crate::inference::KvCacheType,
     pub batch_size: usize,
+    pub web_enabled: bool,
     pub store: ModelStore,
 }
 
@@ -286,6 +291,7 @@ pub async fn serve(cfg: ServeConfig) -> Result<(), Box<dyn std::error::Error>> {
         cache_type_k: cfg.cache_type_k,
         cache_type_v: cfg.cache_type_v,
         batch_size: cfg.batch_size,
+        web_enabled: cfg.web_enabled,
         store: cfg.store,
     });
     let port = cfg.port;

--- a/engine/src/api/routes.rs
+++ b/engine/src/api/routes.rs
@@ -27,6 +27,7 @@ use super::AppState;
 use crate::audit::{AuditEntry, AuditLogger};
 use crate::inference::{GenerateRequest, InferenceEngine, SchedulerHandle, StreamEvent, JSON_GBNF};
 use crate::models::EU_CATALOG;
+use crate::tools;
 
 type S = Arc<AppState>;
 
@@ -211,6 +212,81 @@ async fn collect_stream(
     }
 
     Ok((text, tokens_generated, tokens_prompt, duration_ms))
+}
+
+// ── Web content injection ────────────────────────────────────────────────────
+
+/// If web browsing is enabled and the last user message contains URLs,
+/// fetch each URL and inject the content as a system-style message
+/// prepended to the conversation (before the last user turn).
+///
+/// Returns a new messages Vec with injected content, or the original unchanged.
+async fn inject_web_content(
+    mut messages: Vec<Value>,
+    web_enabled: bool,
+    ctx_size: u32,
+) -> Vec<Value> {
+    if !web_enabled {
+        return messages;
+    }
+
+    // Find last user message
+    let last_user_idx = messages.iter().rposition(|m| {
+        m.get("role").and_then(|v| v.as_str()) == Some("user")
+    });
+    let idx = match last_user_idx {
+        Some(i) => i,
+        None => return messages,
+    };
+
+    let user_text = messages[idx]
+        .get("content")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let urls = tools::extract_urls(&user_text);
+    if urls.is_empty() {
+        return messages;
+    }
+
+    // Estimate prompt chars already used (rough: all messages joined)
+    let existing_chars: usize = messages.iter()
+        .map(|m| m.get("content").and_then(|v| v.as_str()).unwrap_or("").len())
+        .sum();
+
+    let mut injections: Vec<String> = Vec::new();
+    for url in &urls {
+        match tools::fetch_for_context(url, ctx_size, existing_chars, &user_text).await {
+            Ok((content, truncated)) => {
+                let note = if truncated {
+                    format!(" [content truncated to fit context]")
+                } else {
+                    String::new()
+                };
+                injections.push(format!(
+                    "[Web content from {url}{note}]\n\n{content}"
+                ));
+                tracing::info!("Web: fetched {} ({} chars{})", url, content.len(), if truncated { ", truncated" } else { "" });
+            }
+            Err(e) => {
+                injections.push(format!("[Failed to fetch {url}: {e}]"));
+                tracing::warn!("Web: fetch failed for {url}: {e}");
+            }
+        }
+    }
+
+    if injections.is_empty() {
+        return messages;
+    }
+
+    // Insert a synthetic "tool" message before the last user turn
+    let web_message = json!({
+        "role": "system",
+        "content": injections.join("\n\n---\n\n")
+    });
+    messages.insert(idx, web_message);
+    messages
 }
 
 // ── EULLM API handlers ──────────────────────────────────────────────────────
@@ -417,6 +493,8 @@ async fn chat(
         .cloned()
         .unwrap_or_default();
 
+    let messages = inject_web_content(messages, state.web_enabled, state.ctx_size).await;
+
     let think = body.get("think").and_then(|v| v.as_bool()).unwrap_or(true);
     let model_name_ref: &str = &model;
     let template = crate::chat_template::ChatTemplate::detect(model_name_ref);
@@ -590,6 +668,8 @@ async fn chat_completions(
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default();
+
+    let messages = inject_web_content(messages, state.web_enabled, state.ctx_size).await;
 
     let think = body.get("think").and_then(|v| v.as_bool()).unwrap_or(true);
     let model_name_ref: &str = &model;

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -5,6 +5,7 @@ mod gguf_patch;
 mod inference;
 mod models;
 mod registry;
+mod tools;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -74,6 +75,12 @@ enum Commands {
         /// KV cache type for values. Options: f16 (default, best GPU compat), q8_0, q4_0
         #[arg(long, default_value = "f16")]
         cache_type_v: String,
+
+        /// Enable transparent web browsing: URLs in user messages are fetched
+        /// and their content is injected into the prompt before inference.
+        /// Dynamic budget: available context = ctx_size - prompt - 512 reserve.
+        #[arg(long)]
+        web: bool,
 
         /// Run as a background daemon (writes PID to --pidfile)
         #[arg(long)]
@@ -239,6 +246,7 @@ async fn main() {
             n_batch,
             cache_type_k,
             cache_type_v,
+            web,
             daemon,
             pidfile,
         } => {
@@ -288,7 +296,7 @@ async fn main() {
                 ctk = inference::KvCacheType::F16;
                 ctv = inference::KvCacheType::F16;
             }
-            cmd_run(&store, &model, port, replace, gpu_layers, ctx_size, threads, batch_size, !no_flash_attn, n_batch, ctk, ctv).await;
+            cmd_run(&store, &model, port, replace, gpu_layers, ctx_size, threads, batch_size, !no_flash_attn, n_batch, ctk, ctv, web).await;
         }
         Commands::List => cmd_list(&store),
         Commands::Show { model } => cmd_show(&store, &model),
@@ -573,6 +581,7 @@ async fn cmd_run(
     n_batch: u32,
     cache_type_k: inference::KvCacheType,
     cache_type_v: inference::KvCacheType,
+    web: bool,
 ) {
     ensure_port_available(port, replace).await;
 
@@ -717,6 +726,9 @@ async fn cmd_run(
         if is_tq {
             println!("  TurboQuant:    active (experimental)");
         }
+        if web {
+            println!("  Web browsing:  enabled (URLs in messages are fetched and injected)");
+        }
         println!("  Threads:       {resolved_threads}");
         println!("  Batch (prefill): {n_batch}");
         println!("  Mode:          {mode}");
@@ -751,6 +763,7 @@ async fn cmd_run(
             cache_type_k,
             cache_type_v,
             batch_size,
+            web_enabled: web,
             store: api_store,
         })
         .await
@@ -802,6 +815,7 @@ async fn cmd_serve(port: u16, replace: bool) {
         cache_type_k: inference::KvCacheType::Q8_0,
         cache_type_v: inference::KvCacheType::Q4_0,
         batch_size: 8,
+        web_enabled: false,
         store,
     })
     .await

--- a/engine/src/tools/mod.rs
+++ b/engine/src/tools/mod.rs
@@ -1,0 +1,255 @@
+//! Web tool — transparent URL fetch and content injection.
+//!
+//! When `--web` is enabled, the server scans user messages for URLs.
+//! If found, it fetches the page, strips HTML to plain text, and injects
+//! the content into the prompt before inference — with no model-side changes.
+//!
+//! Content budget is dynamic:
+//!   available_tokens = ctx_size - prompt_tokens - RESPONSE_RESERVE
+//!   budget_chars     = available_tokens * CHARS_PER_TOKEN
+//!
+//! If the fetched text fits in the budget, the full text is injected.
+//! If it exceeds the budget, paragraphs are scored by keyword overlap
+//! with the user's query and the top-scoring ones are selected (BM25-lite).
+
+/// Tokens reserved for the model's response (never consumed by injected content).
+const RESPONSE_RESERVE: usize = 512;
+
+/// Rough estimate: 1 token ≈ 4 UTF-8 chars (conservative for European languages).
+const CHARS_PER_TOKEN: usize = 4;
+
+/// Minimum paragraph length to consider for relevance scoring.
+const MIN_CHUNK_CHARS: usize = 80;
+
+// ── URL extraction ────────────────────────────────────────────────────────────
+
+/// Extract all http/https URLs from a text string.
+pub fn extract_urls(text: &str) -> Vec<String> {
+    let mut urls = Vec::new();
+    let mut i = 0;
+    while i < text.len() {
+        if text[i..].starts_with("https://") || text[i..].starts_with("http://") {
+            let end = text[i..]
+                .find(|c: char| c.is_whitespace() || matches!(c, '"' | '\'' | '<' | '>' | ')' | ']'))
+                .map(|n| i + n)
+                .unwrap_or(text.len());
+            let url = text[i..end].trim_end_matches(['.', ',', '!', '?']).to_string();
+            if !url.is_empty() {
+                urls.push(url);
+            }
+            i = end;
+        } else {
+            i += 1;
+        }
+    }
+    urls
+}
+
+// ── HTTP fetch ────────────────────────────────────────────────────────────────
+
+/// Fetch a URL and return plain text content, stripped of HTML.
+pub async fn fetch_url(url: &str) -> Result<String, String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .user_agent("Mozilla/5.0 (compatible; EULLM/0.4; +https://eullm.eu)")
+        .build()
+        .map_err(|e| format!("HTTP client error: {e}"))?;
+
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("Fetch error for {url}: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("HTTP {} fetching {url}", resp.status()));
+    }
+
+    let body = resp.text().await.map_err(|e| format!("Read error: {e}"))?;
+    Ok(html_to_text(&body))
+}
+
+// ── HTML → plain text ─────────────────────────────────────────────────────────
+
+fn remove_block_tag(html: &str, tag: &str) -> String {
+    let open = format!("<{tag}");
+    let close = format!("</{tag}>");
+    let mut result = String::with_capacity(html.len());
+    let mut pos = 0;
+    let lower = html.to_lowercase();
+    loop {
+        let start = match lower[pos..].find(&open) {
+            Some(n) => pos + n,
+            None => {
+                result.push_str(&html[pos..]);
+                break;
+            }
+        };
+        result.push_str(&html[pos..start]);
+        let end = match lower[start..].find(&close) {
+            Some(n) => start + n + close.len(),
+            None => html.len(),
+        };
+        pos = end;
+    }
+    result
+}
+
+/// Strip HTML to readable plain text: remove noisy blocks, tags, decode entities.
+fn html_to_text(html: &str) -> String {
+    // Remove entire noisy blocks (including their content)
+    let mut text = remove_block_tag(html, "script");
+    text = remove_block_tag(&text, "style");
+    text = remove_block_tag(&text, "nav");
+    text = remove_block_tag(&text, "footer");
+    text = remove_block_tag(&text, "header");
+    text = remove_block_tag(&text, "aside");
+    text = remove_block_tag(&text, "noscript");
+
+    // Block-level tags → newline before stripping
+    for tag in &[
+        "</p>", "</div>", "</li>", "</h1>", "</h2>", "</h3>", "</h4>", "</h5>",
+        "<br>", "<br/>", "<br />", "</tr>", "</section>", "</article>",
+    ] {
+        text = text.replace(tag, "\n");
+    }
+
+    // Strip all remaining tags
+    let mut stripped = String::with_capacity(text.len());
+    let mut in_tag = false;
+    for ch in text.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => stripped.push(ch),
+            _ => {}
+        }
+    }
+
+    // Decode common HTML entities
+    let decoded = stripped
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&nbsp;", " ")
+        .replace("&mdash;", "—")
+        .replace("&ndash;", "–")
+        .replace("&hellip;", "...")
+        .replace("&euro;", "€")
+        .replace("&copy;", "©");
+
+    // Collapse whitespace: multiple spaces → one, 3+ newlines → 2
+    let mut result = String::with_capacity(decoded.len());
+    let mut consecutive_nl = 0usize;
+    let mut last_was_space = false;
+    for ch in decoded.chars() {
+        if ch == '\n' || ch == '\r' {
+            last_was_space = false;
+            consecutive_nl += 1;
+            if consecutive_nl <= 2 {
+                result.push('\n');
+            }
+        } else if ch.is_whitespace() {
+            consecutive_nl = 0;
+            if !last_was_space {
+                result.push(' ');
+                last_was_space = true;
+            }
+        } else {
+            consecutive_nl = 0;
+            last_was_space = false;
+            result.push(ch);
+        }
+    }
+
+    result.trim().to_string()
+}
+
+// ── Relevance-based content selection ────────────────────────────────────────
+
+/// Select the most relevant content from `text` to fit within `budget_chars`.
+///
+/// Paragraphs are scored by keyword overlap with the query and position bias
+/// (earlier paragraphs score slightly higher — typical web page structure).
+///
+/// Returns `(selected_text, was_truncated)`.
+pub fn select_relevant(text: &str, query: &str, budget_chars: usize) -> (String, bool) {
+    if text.len() <= budget_chars {
+        return (text.to_string(), false);
+    }
+
+    let chunks: Vec<&str> = text
+        .split('\n')
+        .map(str::trim)
+        .filter(|s| s.len() >= MIN_CHUNK_CHARS)
+        .collect();
+
+    if chunks.is_empty() {
+        return (text.chars().take(budget_chars).collect(), true);
+    }
+
+    let query_words: Vec<String> = query
+        .split_whitespace()
+        .map(|w| w.to_lowercase())
+        .filter(|w| w.len() > 3)
+        .collect();
+
+    let n = chunks.len();
+    let mut scored: Vec<(usize, f32)> = chunks
+        .iter()
+        .enumerate()
+        .map(|(i, chunk)| {
+            let lower = chunk.to_lowercase();
+            let kw_score: f32 = query_words.iter()
+                .map(|w| if lower.contains(w.as_str()) { 1.0 } else { 0.0 })
+                .sum();
+            // Slight position bias: first 20% of page gets +0.3
+            let pos_bias = if i < n / 5 { 0.3 } else { 0.0 };
+            (i, kw_score + pos_bias)
+        })
+        .collect();
+
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal).then(a.0.cmp(&b.0)));
+
+    let mut selected: Vec<usize> = Vec::new();
+    let mut used = 0usize;
+    for (idx, _score) in &scored {
+        let chunk_len = chunks[*idx].len();
+        if used + chunk_len + 2 > budget_chars {
+            continue;
+        }
+        selected.push(*idx);
+        used += chunk_len + 2;
+    }
+
+    selected.sort_unstable();
+    let result = selected.iter().map(|&i| chunks[i]).collect::<Vec<_>>().join("\n\n");
+    (result, true)
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+/// Fetch a URL and return context-ready text, truncated to fit the available budget.
+///
+/// - `ctx_size`:      total context window in tokens (from server config)
+/// - `prompt_chars`:  chars already consumed by the conversation prompt
+/// - `query`:         user's question — used for relevance scoring when truncating
+///
+/// Returns `(injected_text, was_truncated)`.
+pub async fn fetch_for_context(
+    url: &str,
+    ctx_size: u32,
+    prompt_chars: usize,
+    query: &str,
+) -> Result<(String, bool), String> {
+    let text = fetch_url(url).await?;
+
+    let available_tokens = (ctx_size as usize)
+        .saturating_sub(prompt_chars / CHARS_PER_TOKEN + RESPONSE_RESERVE);
+    let budget_chars = available_tokens * CHARS_PER_TOKEN;
+
+    Ok(select_relevant(&text, query, budget_chars))
+}


### PR DESCRIPTION
When --web is enabled, URLs in user messages are automatically fetched and their content injected into the prompt before inference. No model-side changes required — works with any model via /api/chat and /v1/chat/completions.

Implementation:
- engine/src/tools/mod.rs: new module
  - extract_urls(): scan message text for http/https URLs
  - fetch_url(): reqwest fetch with 15s timeout + Mozilla UA
  - html_to_text(): strip script/style/nav/footer blocks, tags, entities, collapse whitespace
  - select_relevant(): BM25-lite keyword scoring + position bias to fit content within context budget when page is too large
  - fetch_for_context(): dynamic budget = ctx_size - prompt - 512 reserve

- engine/src/api/routes.rs: inject_web_content() helper called in both /api/chat and /v1/chat/completions before format_chat_prompt(). Inserts fetched content as a synthetic system message before the user turn. Logs fetch results via tracing. Truncation annotated in injected text.

- engine/src/api/mod.rs: AppState.web_enabled + ServeConfig.web_enabled

- engine/src/main.rs: --web flag on `run` command, passed to cmd_run() and ServeConfig. Shown in startup banner when enabled.
