### PR TITLE
fix: portable sccache install — no --wildcards, version 0.8.0, fail-f…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,9 +141,14 @@ jobs:
 
       - name: Setup sccache
         run: |
-          SCCACHE_VER=0.8.2
-          curl -sSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-x86_64-unknown-linux-musl.tar.gz" \
-            | tar -xz --strip-components=1 -C /usr/local/bin/ --wildcards '*/sccache'
+          SCCACHE_VER=0.8.0
+          TMPSC=$(mktemp -d)
+          curl -sSfL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-x86_64-unknown-linux-musl.tar.gz" \
+            -o "${TMPSC}/sccache.tar.gz"
+          tar -xzf "${TMPSC}/sccache.tar.gz" -C "${TMPSC}"
+          find "${TMPSC}" -maxdepth 2 -name sccache -type f -exec mv {} /usr/local/bin/ \;
+          chmod +x /usr/local/bin/sccache
+          rm -rf "${TMPSC}"
           mkdir -p ~/.cache/sccache
           echo "SCCACHE_DIR=$HOME/.cache/sccache" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -53,18 +54,24 @@ jobs:
       - name: Install sccache
         shell: bash
         run: |
-          SCCACHE_VER=0.8.2
+          SCCACHE_VER=0.8.0
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ARCH=$(uname -m)
           if [ "$OS" = "linux" ]; then
-            FNAME="sccache-v${SCCACHE_VER}-x86_64-unknown-linux-musl.tar.gz"
+            TRIPLE="x86_64-unknown-linux-musl"
           elif [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
-            FNAME="sccache-v${SCCACHE_VER}-aarch64-apple-darwin.tar.gz"
+            TRIPLE="aarch64-apple-darwin"
           else
-            FNAME="sccache-v${SCCACHE_VER}-x86_64-apple-darwin.tar.gz"
+            TRIPLE="x86_64-apple-darwin"
           fi
-          curl -sSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/${FNAME}" \
-            | tar -xz --strip-components=1 -C /usr/local/bin/ --wildcards '*/sccache'
+          # Use mktemp+find to avoid --wildcards which doesn't exist on BSD tar (macOS)
+          TMPSC=$(mktemp -d)
+          curl -sSfL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-${TRIPLE}.tar.gz" \
+            -o "${TMPSC}/sccache.tar.gz"
+          tar -xzf "${TMPSC}/sccache.tar.gz" -C "${TMPSC}"
+          find "${TMPSC}" -maxdepth 2 -name sccache -type f -exec mv {} /usr/local/bin/ \;
+          chmod +x /usr/local/bin/sccache
+          rm -rf "${TMPSC}"
           mkdir -p ~/.cache/sccache
           echo "SCCACHE_DIR=$HOME/.cache/sccache" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
@@ -141,9 +148,14 @@ jobs:
 
       - name: Install sccache
         run: |
-          SCCACHE_VER=0.8.2
-          curl -sSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-x86_64-unknown-linux-musl.tar.gz" \
-            | tar -xz --strip-components=1 -C /usr/local/bin/ --wildcards '*/sccache'
+          SCCACHE_VER=0.8.0
+          TMPSC=$(mktemp -d)
+          curl -sSfL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-x86_64-unknown-linux-musl.tar.gz" \
+            -o "${TMPSC}/sccache.tar.gz"
+          tar -xzf "${TMPSC}/sccache.tar.gz" -C "${TMPSC}"
+          find "${TMPSC}" -maxdepth 2 -name sccache -type f -exec mv {} /usr/local/bin/ \;
+          chmod +x /usr/local/bin/sccache
+          rm -rf "${TMPSC}"
           mkdir -p /tmp/sccache-store
           echo "SCCACHE_DIR=/tmp/sccache-store" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
@@ -225,9 +237,14 @@ jobs:
 
       - name: Install sccache
         run: |
-          SCCACHE_VER=0.8.2
-          curl -sSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-x86_64-unknown-linux-musl.tar.gz" \
-            | tar -xz --strip-components=1 -C /usr/local/bin/ --wildcards '*/sccache'
+          SCCACHE_VER=0.8.0
+          TMPSC=$(mktemp -d)
+          curl -sSfL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-x86_64-unknown-linux-musl.tar.gz" \
+            -o "${TMPSC}/sccache.tar.gz"
+          tar -xzf "${TMPSC}/sccache.tar.gz" -C "${TMPSC}"
+          find "${TMPSC}" -maxdepth 2 -name sccache -type f -exec mv {} /usr/local/bin/ \;
+          chmod +x /usr/local/bin/sccache
+          rm -rf "${TMPSC}"
           mkdir -p /tmp/sccache-store
           echo "SCCACHE_DIR=/tmp/sccache-store" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
@@ -314,9 +331,14 @@ jobs:
 
       - name: Install sccache
         run: |
-          SCCACHE_VER=0.8.2
-          curl -sSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-aarch64-apple-darwin.tar.gz" \
-            | tar -xz --strip-components=1 -C /usr/local/bin/ --wildcards '*/sccache'
+          SCCACHE_VER=0.8.0
+          TMPSC=$(mktemp -d)
+          curl -sSfL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-aarch64-apple-darwin.tar.gz" \
+            -o "${TMPSC}/sccache.tar.gz"
+          tar -xzf "${TMPSC}/sccache.tar.gz" -C "${TMPSC}"
+          find "${TMPSC}" -maxdepth 2 -name sccache -type f -exec mv {} /usr/local/bin/ \;
+          chmod +x /usr/local/bin/sccache
+          rm -rf "${TMPSC}"
           mkdir -p ~/.cache/sccache
           echo "SCCACHE_DIR=$HOME/.cache/sccache" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV


### PR DESCRIPTION
…ast off

BSD tar (macOS) does not support the --wildcards flag that GNU tar (Linux) provides. The build and build-metal-turboquant jobs were crashing immediately on macos-15 runners with exit code 1.

Fix: replace pipe-to-tar with mktemp+find approach that works on both GNU and BSD tar without any non-standard flags.

Also:
- Change sccache version from 0.8.2 (uncertain) to 0.8.0 (confirmed)
- Use curl -sSfL (-f fails on HTTP errors) to detect 404s early
- Add fail-fast: false to build matrix so a macOS failure no longer cascels all Linux jobs (previously one macOS failure cancelled 5 jobs)
