### PR TITLE
feat(engine): aggiungi alias bare tbqp3/tbq3/tbqp4/tbq4 per config ra…

### DIFF
--- a/engine/src/inference/turboquant/tests.rs
+++ b/engine/src/inference/turboquant/tests.rs
@@ -28,6 +28,11 @@ fn parse_tq_types() {
     assert_eq!(parse_turboquant_type("tq4_0"),  Some(TurboquantType::TQ4_0));
     assert_eq!(parse_turboquant_type("turbo3"), Some(TurboquantType::TQ3_0));
     assert_eq!(parse_turboquant_type("turbo4"), Some(TurboquantType::TQ4_0));
+    // AmesianX recommended config bare aliases (default → _1, head_dim=128)
+    assert_eq!(parse_turboquant_type("tbq3"),   Some(TurboquantType::TQ3_1));
+    assert_eq!(parse_turboquant_type("tbq4"),   Some(TurboquantType::TQ4_1));
+    assert_eq!(parse_turboquant_type("tbqp3"),  Some(TurboquantType::TQP3_1));
+    assert_eq!(parse_turboquant_type("tbqp4"),  Some(TurboquantType::TQP4_1));
     assert_eq!(parse_turboquant_type("f16"),  None);
     assert_eq!(parse_turboquant_type("q8_0"), None);
 }
@@ -44,6 +49,10 @@ fn is_tq_type() {
     assert!(is_turboquant_type("tbqp4_1"));
     assert!(is_turboquant_type("tq3_0"));   // legacy alias
     assert!(is_turboquant_type("tq4_0"));   // legacy alias
+    assert!(is_turboquant_type("tbq3"));    // AmesianX recommended bare alias → _1
+    assert!(is_turboquant_type("tbq4"));
+    assert!(is_turboquant_type("tbqp3"));
+    assert!(is_turboquant_type("tbqp4"));
     assert!(!is_turboquant_type("f16"));
     assert!(!is_turboquant_type("q4_0"));
 }

--- a/engine/src/inference/turboquant/types.rs
+++ b/engine/src/inference/turboquant/types.rs
@@ -89,6 +89,10 @@ impl fmt::Display for TurboquantType {
 /// AmesianX auto-detects head_dim at the llama-cli layer; via Rust bindings
 /// the suffix must be correct for the model. Most models (Qwen3, Llama,
 /// Mistral) have head_dim=128 → use tbq4_1 / tbqp4_1.
+///
+/// Bare aliases without suffix (tbqp3, tbq3, tbqp4, tbq4) default to _1
+/// (head_dim=128) following the AmesianX recommended config:
+///   --cache-type-k tbqp3 --cache-type-v tbq3 --flash-attn on
 pub fn parse_turboquant_type(s: &str) -> Option<TurboquantType> {
     match s.to_lowercase().as_str() {
         // head_dim=256 (_0)
@@ -97,10 +101,11 @@ pub fn parse_turboquant_type(s: &str) -> Option<TurboquantType> {
         "tbqp3_0" | "tqp3_0"                     => Some(TurboquantType::TQP3_0),
         "tbqp4_0" | "tqp4_0"                     => Some(TurboquantType::TQP4_0),
         // head_dim=128 (_1) — Qwen3, Llama, Mistral, Falcon
-        "tbq3_1"  | "tq3_1"                      => Some(TurboquantType::TQ3_1),
-        "tbq4_1"  | "tq4_1"                      => Some(TurboquantType::TQ4_1),
-        "tbqp3_1" | "tqp3_1"                     => Some(TurboquantType::TQP3_1),
-        "tbqp4_1" | "tqp4_1"                     => Some(TurboquantType::TQP4_1),
+        // Bare aliases (no suffix) map here — AmesianX recommended defaults.
+        "tbq3_1"  | "tq3_1"  | "tbq3"            => Some(TurboquantType::TQ3_1),
+        "tbq4_1"  | "tq4_1"  | "tbq4"            => Some(TurboquantType::TQ4_1),
+        "tbqp3_1" | "tqp3_1" | "tbqp3"           => Some(TurboquantType::TQP3_1),
+        "tbqp4_1" | "tqp4_1" | "tbqp4"           => Some(TurboquantType::TQP4_1),
         // head_dim=64 (_2) — Phi-3-mini
         "tbq3_2"  | "tq3_2"                      => Some(TurboquantType::TQ3_2),
         "tbq4_2"  | "tq4_2"                      => Some(TurboquantType::TQ4_2),

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -260,12 +260,14 @@ async fn main() {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             });
-            // Mixed TurboQuant types (e.g. K=tq4_0, V=tq3_0) — both Unknown.
+            // Mixed TurboQuant types (e.g. K=tbqp3, V=tbq3) — both Unknown.
+            // AmesianX recommended: --cache-type-k tbqp3 --cache-type-v tbq3
+            // (corrected K for recall, MSE-only V for speed, flash-attn on by default)
             if let (inference::KvCacheType::Unknown(k_id), inference::KvCacheType::Unknown(v_id)) = (&ctk, &ctv)
                 && k_id != v_id
             {
                 eprintln!("Note: mixed TurboQuant KV cache (K={cache_type_k}, V={cache_type_v}).");
-                eprintln!("  Advanced config — if OOM, will fallback to uniform type then F16.");
+                eprintln!("  This is the AmesianX recommended config (corrected K, MSE-only V).");
             }
             // Asymmetric F16/Q8_0-K + TurboQuant-V — may crash on models with
             // non-standard head dimensions (e.g. Gemma 4 D=512/256 SWA).
@@ -279,11 +281,9 @@ async fn main() {
             }
             // Standard quantized KV (q8_0, q4_0) on Gemma 4 (mixed SWA D=512/256)
             // Gemma 4's mixed SWA architecture (25 SWA layers D=256 + 5 global D=512)
-            // is incompatible with any KV quantization in AmesianX v1.5.0:
-            //   - q8_0/q4_0: KV layout mismatch → model echoes input
-            //   - tbq4_0/tbq4_0: SWA quantization noise → model generates past stop token
-            // AmesianX v1.5.1 will fix this with SWA bypass to f16. Until then,
-            // auto-correct all non-f16 KV to f16/f16 for Gemma 4.
+            // is incompatible with standard KV quantization — SWA bypass to f16
+            // was added in AmesianX v1.5.1 and is active in v1.5.3.
+            // Auto-correct all non-f16 KV to f16/f16 for Gemma 4.
             let model_lower = model.to_lowercase();
             let is_gemma4 = model_lower.contains("gemma-4") || model_lower.contains("gemma4");
             let needs_correction = ctk != inference::KvCacheType::F16


### PR DESCRIPTION
…ccomandata

AmesianX consiglia: --cache-type-k tbqp3 --cache-type-v tbq3 --flash-attn on Gli alias senza suffisso mappano a _1 (head_dim=128, default per Qwen3/Llama/Mistral). Il messaggio CLI per KV misto ora riconosce questa come config raccomandata. Rimosso riferimento a v1.5.0 nel warning Gemma 4 (SWA bypass attivo da v1.5.1).

28/28 test passati.
