### PR TITLE
fix: use sm_89 for TurboQuant CUDA build to avoid Blackwell kernel fa…

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -279,7 +279,12 @@ jobs:
           CUDA_PATH: /usr/local/cuda
           CUDACXX: /usr/local/cuda/bin/nvcc
           CMAKE_CUDA_COMPILER: /usr/local/cuda/bin/nvcc
-          CMAKE_CUDA_ARCHITECTURES: "120"
+          # TurboQuant v1.5.3 compiles 100+ fattn-vec kernel instantiations (all TBQ
+          # type/head_dim combos). Some D=576 or cross-head variants hit register/shmem
+          # limits on sm_120 (Blackwell) with CUDA 12.8. Use sm_89 (Ada Lovelace) to
+          # produce PTX that JIT-compiles natively on sm_120 at first run — cached after,
+          # zero runtime overhead. sm_120 native stays in build-cuda (base llama.cpp only).
+          CMAKE_CUDA_ARCHITECTURES: "89"
 
       - name: Test TurboQuant module
         run: |

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -52,6 +52,6 @@ predicates = "3"
 
 # ── TurboQuant backend (experimental) ───────────────────────────
 # To enable TurboQuant, run: scripts/setup-turboquant.sh
-# The script vendors llama-cpp-sys-2 with AmesianX/TurboQuant v1.5.2 and
+# The script vendors llama-cpp-sys-2 with AmesianX/TurboQuant v1.5.3 and
 # appends [patch.crates-io] to this file automatically.
 # Then build with: cargo build --release --features "cuda turboquant_native"


### PR DESCRIPTION
…ilures

TurboQuant v1.5.3 compiles 100+ fattn-vec instantiations for all TBQ type/head_dim combos (tbq3_0..tbqp4_4 × K/V, including asym576x512). Some of these variants hit register or shared-memory limits on sm_120 (Blackwell) with CUDA 12.8, causing the build-cuda-turboquant job to fail after ~40 min with exit 101.

Fix: compile TurboQuant kernels for sm_89 (Ada Lovelace — fully tested by AmesianX). The resulting sm_89 PTX JIT-compiles to native sm_120 code on first run and is cached; zero runtime overhead afterward. Base llama.cpp build-cuda keeps CMAKE_CUDA_ARCHITECTURES=120.

Also fixes stale v1.5.2 reference in engine/Cargo.toml comment.
