### PR TITLE
chore(engine): bump version to 0.4.3

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"


### PR DESCRIPTION
Patch release for:
- fix: NCCL stub in CI build-cuda-turboquant (was broken in 0.4.2)
- fix: defer void_logs() so llama.cpp OOM errors are visible to users
- fix: TurboQuant VRAM display (was showing F16-equivalent instead of 3/4-bit size)
