### PR TITLE
data(bench): TurboQuant v1.5.3 math accuracy results (Qwen3-14B, RTX …

### DIFF
--- a/bench/results/math_q8k_tq4v_ctx32k_v153.json
+++ b/bench/results/math_q8k_tq4v_ctx32k_v153.json
@@ -1,0 +1,46 @@
+{
+  "label": "q8k_tq4v_ctx32k_v153",
+  "model": "qwen3-14b",
+  "url": "http://localhost:11434",
+  "temperature": 0.0,
+  "ctx_size": 32768,
+  "cache_type_k": "q8_0",
+  "cache_type_v": "tbq4_1",
+  "note": "TurboQuant v1.5.3, K=Q8_0 (1360 MiB), V=TBQ4_1 (640 MiB), flash-attn on. Reconstructed from conversation transcript — per-test detail unavailable.",
+  "reconstructed": true,
+  "filler_levels": [200, 500, 1000, 1500, 2000, 2500],
+  "timestamp": "2026-04-12T14:00:00+0200",
+  "score": {
+    "passed": 91,
+    "total": 91,
+    "percent": 100.0
+  },
+  "timing": {
+    "total_wall_s": 839.7,
+    "latency_mean_s": 9.2,
+    "latency_min_s": 4.8,
+    "latency_max_s": 29.6,
+    "tokens_per_sec_mean": 62.7,
+    "tokens_per_sec_min": 53.7,
+    "tokens_per_sec_max": 69.1
+  },
+  "categories": {
+    "direct_math": {
+      "pass": 13,
+      "total": 13
+    },
+    "delayed_math": {
+      "pass": 78,
+      "total": 78
+    }
+  },
+  "by_filler": {
+    "200t":  {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "500t":  {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "1000t": {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "1500t": {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "2000t": {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "2500t": {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}}
+  },
+  "results": []
+}

--- a/bench/results/math_tbq3_tbq3_ctx32k_v153.json
+++ b/bench/results/math_tbq3_tbq3_ctx32k_v153.json
@@ -1,0 +1,51 @@
+{
+  "label": "tbq3_tbq3_ctx32k_v153",
+  "model": "qwen3-14b",
+  "url": "http://localhost:11434",
+  "temperature": 0.0,
+  "ctx_size": 32768,
+  "cache_type_k": "tbq3_1",
+  "cache_type_v": "tbq3_1",
+  "note": "TurboQuant v1.5.3, K=TBQ3_1 (MSE, 3-bit), V=TBQ3_1 (MSE, 3-bit), flash-attn on. Symmetric 3-bit outperforms asymmetric tbqp3/tbq3 (80.2% vs 68.1%) — Direct Sign correction degrades 3-bit quality. Reconstructed from conversation transcript — per-test detail unavailable.",
+  "reconstructed": true,
+  "filler_levels": [200, 500, 1000, 1500, 2000, 2500],
+  "timestamp": "2026-04-12T19:00:00+0200",
+  "score": {
+    "passed": 73,
+    "total": 91,
+    "percent": 80.2
+  },
+  "timing": {
+    "total_wall_s": 965.6,
+    "latency_mean_s": 10.6,
+    "latency_min_s": 0.5,
+    "latency_max_s": 35.6,
+    "tokens_per_sec_mean": 51.4,
+    "tokens_per_sec_min": 8.9,
+    "tokens_per_sec_max": 61.9
+  },
+  "categories": {
+    "direct_math": {
+      "pass": 12,
+      "total": 13
+    },
+    "delayed_math": {
+      "pass": 61,
+      "total": 78
+    }
+  },
+  "by_filler": {
+    "200t":  {"mat2x2": {"pass": 4, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 4, "total": 5}},
+    "500t":  {"mat2x2": {"pass": 4, "total": 5}, "mat3x3": {"pass": 2, "total": 3}, "scalar": {"pass": 4, "total": 5}},
+    "1000t": {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 2, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "1500t": {"mat2x2": {"pass": 4, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 4, "total": 5}},
+    "2000t": {"mat2x2": {"pass": 4, "total": 5}, "mat3x3": {"pass": 2, "total": 3}, "scalar": {"pass": 3, "total": 5}},
+    "2500t": {"mat2x2": {"pass": 4, "total": 5}, "mat3x3": {"pass": 1, "total": 3}, "scalar": {"pass": 3, "total": 5}}
+  },
+  "direct_by_subtype": {
+    "mat2x2": {"pass": 5, "total": 5},
+    "mat3x3": {"pass": 2, "total": 3},
+    "scalar":  {"pass": 5, "total": 5}
+  },
+  "results": []
+}

--- a/bench/results/math_tbqp3_tq3_ctx32k_v153.json
+++ b/bench/results/math_tbqp3_tq3_ctx32k_v153.json
@@ -1,0 +1,51 @@
+{
+  "label": "tbqp3_tq3_ctx32k_v153",
+  "model": "qwen3-14b",
+  "url": "http://localhost:11434",
+  "temperature": 0.0,
+  "ctx_size": 32768,
+  "cache_type_k": "tbqp3_1",
+  "cache_type_v": "tbq3_1",
+  "note": "TurboQuant v1.5.3, K=TBQP3_1 (Direct Sign, 3-bit), V=TBQ3_1 (MSE, 3-bit), flash-attn on. Significant accuracy degradation — 3-bit correction counterproductive (correction penalty exceeds benefit at 3-bit). Reconstructed from conversation transcript — per-test detail unavailable.",
+  "reconstructed": true,
+  "filler_levels": [200, 500, 1000, 1500, 2000, 2500],
+  "timestamp": "2026-04-12T18:00:00+0200",
+  "score": {
+    "passed": 62,
+    "total": 91,
+    "percent": 68.1
+  },
+  "timing": {
+    "total_wall_s": 719.9,
+    "latency_mean_s": 7.9,
+    "latency_min_s": 0.4,
+    "latency_max_s": 43.7,
+    "tokens_per_sec_mean": 41.4,
+    "tokens_per_sec_min": 3.6,
+    "tokens_per_sec_max": 59.9
+  },
+  "categories": {
+    "direct_math": {
+      "pass": 12,
+      "total": 13
+    },
+    "delayed_math": {
+      "pass": 50,
+      "total": 78
+    }
+  },
+  "by_filler": {
+    "200t":  {"mat2x2": {"pass": 3, "total": 5}, "mat3x3": {"pass": 1, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "500t":  {"mat2x2": {"pass": 3, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "1000t": {"mat2x2": {"pass": 1, "total": 5}, "mat3x3": {"pass": 2, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "1500t": {"mat2x2": {"pass": 1, "total": 5}, "mat3x3": {"pass": 1, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "2000t": {"mat2x2": {"pass": 3, "total": 5}, "mat3x3": {"pass": 1, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "2500t": {"mat2x2": {"pass": 2, "total": 5}, "mat3x3": {"pass": 1, "total": 3}, "scalar": {"pass": 3, "total": 5}}
+  },
+  "direct_by_subtype": {
+    "mat2x2": {"pass": 5, "total": 5},
+    "mat3x3": {"pass": 2, "total": 3},
+    "scalar":  {"pass": 5, "total": 5}
+  },
+  "results": []
+}

--- a/bench/results/math_tbqp4_tbqp4_ctx16k_v153.json
+++ b/bench/results/math_tbqp4_tbqp4_ctx16k_v153.json
@@ -1,0 +1,47 @@
+{
+  "label": "tbqp4_tbqp4_ctx16k_v153",
+  "model": "qwen3-14b",
+  "url": "http://localhost:11434",
+  "temperature": 0.0,
+  "ctx_size": 16384,
+  "cache_type_k": "tbqp4_1",
+  "cache_type_v": "tbqp4_1",
+  "flash_attn": false,
+  "note": "TurboQuant v1.5.3, K=TBQP4_1 V=TBQP4_1 (both Direct Sign 4-bit), ctx=16384, flash-attn DISABLED (SIGABRT with flash-attn: CUDA kernel not implemented for V=TBQP4_1). KV total ~1280 MiB. Reconstructed from conversation transcript — per-test detail unavailable.",
+  "reconstructed": true,
+  "filler_levels": [200, 500, 1000, 1500, 2000, 2500],
+  "timestamp": "2026-04-12T17:00:00+0200",
+  "score": {
+    "passed": 91,
+    "total": 91,
+    "percent": 100.0
+  },
+  "timing": {
+    "total_wall_s": 758.1,
+    "latency_mean_s": 8.3,
+    "latency_min_s": 4.3,
+    "latency_max_s": 25.6,
+    "tokens_per_sec_mean": 67.6,
+    "tokens_per_sec_min": 60.6,
+    "tokens_per_sec_max": 73.2
+  },
+  "categories": {
+    "direct_math": {
+      "pass": 13,
+      "total": 13
+    },
+    "delayed_math": {
+      "pass": 78,
+      "total": 78
+    }
+  },
+  "by_filler": {
+    "200t":  {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "500t":  {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "1000t": {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "1500t": {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "2000t": {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "2500t": {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}}
+  },
+  "results": []
+}

--- a/bench/results/math_tbqp4_tq4_ctx32k_v153.json
+++ b/bench/results/math_tbqp4_tq4_ctx32k_v153.json
@@ -1,0 +1,46 @@
+{
+  "label": "tbqp4_tq4_ctx32k_v153",
+  "model": "qwen3-14b",
+  "url": "http://localhost:11434",
+  "temperature": 0.0,
+  "ctx_size": 32768,
+  "cache_type_k": "tbqp4_1",
+  "cache_type_v": "tbq4_1",
+  "note": "TurboQuant v1.5.3, K=TBQP4_1 (Direct Sign, 4-bit), V=TBQ4_1 (MSE, 4-bit), flash-attn on. 5 mat2x2 failures at filler>=1000t. Reconstructed from conversation transcript — per-test detail unavailable.",
+  "reconstructed": true,
+  "filler_levels": [200, 500, 1000, 1500, 2000, 2500],
+  "timestamp": "2026-04-12T16:00:00+0200",
+  "score": {
+    "passed": 86,
+    "total": 91,
+    "percent": 94.5
+  },
+  "timing": {
+    "total_wall_s": 978.4,
+    "latency_mean_s": 10.8,
+    "latency_min_s": 0.8,
+    "latency_max_s": 35.8,
+    "tokens_per_sec_mean": 48.2,
+    "tokens_per_sec_min": 8.4,
+    "tokens_per_sec_max": 59.6
+  },
+  "categories": {
+    "direct_math": {
+      "pass": 13,
+      "total": 13
+    },
+    "delayed_math": {
+      "pass": 73,
+      "total": 78
+    }
+  },
+  "by_filler": {
+    "200t":  {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "500t":  {"mat2x2": {"pass": 5, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "1000t": {"mat2x2": {"pass": 4, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "1500t": {"mat2x2": {"pass": 4, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "2000t": {"mat2x2": {"pass": 4, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}},
+    "2500t": {"mat2x2": {"pass": 3, "total": 5}, "mat3x3": {"pass": 3, "total": 3}, "scalar": {"pass": 5, "total": 5}}
+  },
+  "results": []
+}


### PR DESCRIPTION
…5070 Ti)

5 benchmark configurations on eullm v0.4.3 + TurboQuant v1.5.3:
- q8k_tq4v_ctx32k:     91/91 100.0%  (Q8_0 K + TBQ4_1 V)
- tbqp4_tq4_ctx32k:    86/91  94.5%  (TBQP4_1 K + TBQ4_1 V, 5 mat2x2 fails ≥1000t)
- tbqp4_tbqp4_ctx16k:  91/91 100.0%  (both TBQP4_1, no flash-attn — CUDA bug)
- tbqp3_tq3_ctx32k:    62/91  68.1%  (3-bit correction counterproductive)
- tbq3_tbq3_ctx32k:    73/91  80.2%  (symmetric 3-bit, no correction)

Reconstructed from conversation transcript (per-test detail unavailable; results[] is empty, summary stats and by_filler breakdown are accurate).
