### PR TITLE
Feat/legal it

### DIFF
--- a/forge/eullm_forge/datasets/__init__.py
+++ b/forge/eullm_forge/datasets/__init__.py
@@ -1,5 +1,15 @@
 """EULLM Forge — dataset preparation modules for domain corpora."""
 
+from .italgiure import (
+    ItalgiureQuery,
+    fetch_italgiure,
+    load_italgiure_jsonl,
+)
 from .legal_it import prepare_legal_it
 
-__all__ = ["prepare_legal_it"]
+__all__ = [
+    "ItalgiureQuery",
+    "fetch_italgiure",
+    "load_italgiure_jsonl",
+    "prepare_legal_it",
+]

--- a/forge/eullm_forge/datasets/italgiure.py
+++ b/forge/eullm_forge/datasets/italgiure.py
@@ -1,15 +1,25 @@
 """Fetch Cassazione sentences from italgiure.giustizia.it (SentenzeWeb).
 
 Public, free, no-registration access to the full text of every civil and
-criminal Cassazione ruling from 2011 onwards. The JSON response already
-contains the OCR'd full text in the ``ocr`` field — no PDF download needed.
+criminal Cassazione ruling **from 2021 onwards**. Earlier years are NOT in
+this collection — SentenzeWeb was launched in 2021 and only covers that
+window. Pre-2021 sentences exist only as Massimario summaries (``kind:sic``,
+~1.4M docs, short abstracts, not full text).
+
+The JSON response already contains the OCR'd full text in the ``ocr`` field
+— no PDF download needed.
 
 Backend: Apache Solr behind an ISAPI (hc.dll) handler on IIS.
 Endpoint: /sncass/isapi/hc.dll/sn.solr/sn-collection/select?app.query
 
+Coverage (verified via Solr facets, April 2026):
+    snciv (civili): 185,994 docs   snpen (penali): 237,310 docs
+    2021: 64,968    2022: 87,936    2023: 88,409
+    2024: 83,024    2025: 76,917    2026: 22,050 (in progress)
+    Total full-text corpus: ~423K sentences, ~2.8 GB JSONL.
+
 Design notes:
-  * Dataset size is ~1.2M documents, ~15 GB of text. Records are streamed to
-    a JSONL file, never accumulated in memory.
+  * Records are streamed to a JSONL file, never accumulated in memory.
   * Progress is checkpointed by (kind, anno, start) so runs can be resumed.
   * A warmup GET to /sncass/ establishes the ASP.NET session cookie.
   * Rate-limited (default 1.5s between requests) to be a polite client.
@@ -286,7 +296,7 @@ def _iter_query_docs(
 def fetch_italgiure(
     output_dir: str | Path,
     *,
-    years: Iterable[int] = range(2011, 2027),
+    years: Iterable[int] = range(2021, 2027),
     kinds: Iterable[str] = DEFAULT_KINDS,
     sezione: Optional[int] = None,
     max_docs_per_query: Optional[int] = None,
@@ -407,6 +417,14 @@ def fetch_italgiure(
                     progress_path.write_text(
                         json.dumps(progress, indent=2), encoding="utf-8"
                     )
+                    # Legit empty slice (pre-2021): drop the 0-byte file so
+                    # the output directory doesn't fill with noise.
+                    if written == 0 and out_path.exists() and out_path.stat().st_size == 0:
+                        out_path.unlink()
+                        logger.info(
+                            "italgiure [%s] numFound=0 — removed empty JSONL",
+                            slug,
+                        )
                 else:
                     logger.warning(
                         "italgiure [%s] stopped at offset=%d/%d — "

--- a/forge/eullm_forge/datasets/italgiure.py
+++ b/forge/eullm_forge/datasets/italgiure.py
@@ -207,11 +207,13 @@ def _iter_query_docs(
     rows: int = SOLR_MAX_ROWS,
     rate_limit_sec: float = 1.5,
     max_docs: Optional[int] = None,
-) -> Iterator[tuple[int, list[dict]]]:
-    """Yield (next_start, batch_records) tuples for a single query.
+) -> Iterator[tuple[int, list[dict], int]]:
+    """Yield (next_start, batch_records, num_found) tuples for a single query.
 
     Performs pagination via Solr ``start`` / ``rows``. Stops when ``numFound``
-    is reached or ``max_docs`` records have been produced.
+    is reached or ``max_docs`` records have been produced. A sentinel tuple
+    ``(start, [], 0)`` is yielded for legitimately empty slices so the caller
+    can distinguish "year really has 0 docs" from "server returned nothing".
     """
     cur = start
     emitted = 0
@@ -231,8 +233,35 @@ def _iter_query_docs(
         response = resp.get("response") or {}
         num_found = int(response.get("numFound", 0))
         docs = response.get("docs") or []
-        if not docs:
+
+        # Legit empty slice: emit a sentinel so the caller can mark it complete.
+        if num_found == 0 and cur == start:
+            yield cur, [], 0
             return
+
+        # numFound > 0 but docs empty at an in-range offset = server glitch.
+        # Back off hard and retry once before giving up (leaves progress intact).
+        if not docs and cur < num_found:
+            backoff = 0.0 if rate_limit_sec <= 0 else max(rate_limit_sec * 5, 10.0)
+            logger.warning(
+                "italgiure [%s] empty docs at start=%d but numFound=%d — "
+                "backing off %.1fs and retrying",
+                query.slug(), cur, num_found, backoff,
+            )
+            time.sleep(backoff)
+            resp = _solr_get(session, query, start=cur, rows=want)
+            if resp is None:
+                return
+            response = resp.get("response") or {}
+            num_found = int(response.get("numFound", 0))
+            docs = response.get("docs") or []
+            if not docs:
+                logger.error(
+                    "italgiure [%s] still empty after retry at start=%d, "
+                    "numFound=%d — aborting slice (progress kept for retry)",
+                    query.slug(), cur, num_found,
+                )
+                return
 
         records: list[dict] = []
         for doc in docs:
@@ -241,7 +270,7 @@ def _iter_query_docs(
                 records.append(rec)
 
         next_start = cur + len(docs)
-        yield next_start, records
+        yield next_start, records, num_found
         emitted += len(records)
         cur = next_start
 
@@ -315,12 +344,27 @@ def fetch_italgiure(
             out_path = output_dir / f"italgiure_{slug}.jsonl"
             start = progress.get(slug, 0)
             if start == -1:
-                logger.info("italgiure [%s] already complete — skipping", slug)
-                continue
+                # Self-heal: if marked complete but the JSONL is empty, a
+                # previous run hit a server glitch that was silently swallowed.
+                # Reset to offset 0 and retry.
+                if out_path.exists() and out_path.stat().st_size == 0:
+                    logger.warning(
+                        "italgiure [%s] marked complete but file is empty — "
+                        "resetting progress and retrying",
+                        slug,
+                    )
+                    start = 0
+                    progress.pop(slug, None)
+                else:
+                    logger.info("italgiure [%s] already complete — skipping", slug)
+                    continue
 
             logger.info("italgiure [%s] downloading from offset %d", slug, start)
             mode = "a" if start > 0 and out_path.exists() else "w"
             written = 0
+            had_batch = False
+            last_num_found: Optional[int] = None
+            final_offset = start
             with open(out_path, mode, encoding="utf-8") as f:
                 iterator = _iter_query_docs(
                     session,
@@ -330,7 +374,10 @@ def fetch_italgiure(
                     rate_limit_sec=rate_limit_sec,
                     max_docs=max_docs_per_query,
                 )
-                for next_start, batch in iterator:
+                for next_start, batch, num_found in iterator:
+                    had_batch = True
+                    last_num_found = num_found
+                    final_offset = next_start
                     for rec in batch:
                         f.write(json.dumps(rec, ensure_ascii=False) + "\n")
                         written += 1
@@ -339,19 +386,33 @@ def fetch_italgiure(
                     progress_path.write_text(
                         json.dumps(progress, indent=2), encoding="utf-8"
                     )
-                    logger.info(
-                        "  [%s] offset=%d (+%d records, %d in this run)",
-                        slug, next_start, len(batch), written,
-                    )
+                    if batch:
+                        logger.info(
+                            "  [%s] offset=%d/%d (+%d records, %d in this run)",
+                            slug, next_start, num_found, len(batch), written,
+                        )
 
             # Mark slice as complete only when the iterator exited naturally
-            # (max_docs_per_query truncates it, so in that case we keep the
-            #  resume offset intact).
+            # after confirming we reached numFound (or numFound==0). If we
+            # never got a batch, leave progress intact so the next run retries.
             if max_docs_per_query is None:
-                progress[slug] = -1
-                progress_path.write_text(
-                    json.dumps(progress, indent=2), encoding="utf-8"
-                )
+                if not had_batch:
+                    logger.error(
+                        "italgiure [%s] aborted before any response — "
+                        "keeping progress=%d for retry",
+                        slug, start,
+                    )
+                elif last_num_found == 0 or final_offset >= (last_num_found or 0):
+                    progress[slug] = -1
+                    progress_path.write_text(
+                        json.dumps(progress, indent=2), encoding="utf-8"
+                    )
+                else:
+                    logger.warning(
+                        "italgiure [%s] stopped at offset=%d/%d — "
+                        "keeping progress for retry",
+                        slug, final_offset, last_num_found,
+                    )
 
     return output_dir
 

--- a/forge/eullm_forge/datasets/italgiure.py
+++ b/forge/eullm_forge/datasets/italgiure.py
@@ -1,0 +1,352 @@
+"""Fetch Cassazione sentences from italgiure.giustizia.it (SentenzeWeb).
+
+Public, free, no-registration access to the full text of every civil and
+criminal Cassazione ruling from 2011 onwards. The JSON response already
+contains the OCR'd full text in the ``ocr`` field — no PDF download needed.
+
+Backend: Apache Solr behind an ISAPI (hc.dll) handler on IIS.
+Endpoint: /sncass/isapi/hc.dll/sn.solr/sn-collection/select?app.query
+
+Design notes:
+  * Dataset size is ~1.2M documents, ~15 GB of text. Records are streamed to
+    a JSONL file, never accumulated in memory.
+  * Progress is checkpointed by (kind, anno, start) so runs can be resumed.
+  * A warmup GET to /sncass/ establishes the ASP.NET session cookie.
+  * Rate-limited (default 1.5s between requests) to be a polite client.
+
+GDPR warning:
+    The corpus contains personal data (names of parties, judges, lawyers,
+    addresses, tax IDs). The raw corpus must NOT be published. Use only
+    for training; anonymise any downstream artefact.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+from .base import clean_text
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://www.italgiure.giustizia.it"
+WARMUP_URL = f"{BASE_URL}/sncass/"
+SOLR_URL = f"{BASE_URL}/sncass/isapi/hc.dll/sn.solr/sn-collection/select"
+PDF_BASE = f"{BASE_URL}/sncass/isapi/hc.dll/download/"
+
+DEFAULT_KINDS = ("snciv", "snpen")
+SOLR_MAX_ROWS = 1000  # verified upper bound (response ~11 MB at this size)
+
+REQUIRED_FIELDS = (
+    "id,filename,szdec,kind,ssz,tipoprov,numcard,numdec,numdep,datdep,"
+    "ecli,anno,datdec,presidente,relatore,requisitoria,testoocr,ocr"
+)
+
+
+@dataclass
+class ItalgiureQuery:
+    """A single slice of the corpus to download."""
+
+    kind: str           # "snciv" | "snpen"
+    anno: int           # four-digit year, e.g. 2026
+    sezione: Optional[int] = None  # 1..7, LAVORO is 9, UNITE is 0; None = all
+
+    def lucene(self) -> str:
+        parts = [f'kind:"{self.kind}"', f'anno:"{self.anno}"']
+        if self.sezione is not None:
+            parts.append(f'szdec:"{self.sezione}"')
+        return " AND ".join(parts)
+
+    def slug(self) -> str:
+        s = f"{self.kind}_{self.anno}"
+        if self.sezione is not None:
+            s += f"_sez{self.sezione}"
+        return s
+
+
+def make_italgiure_session():
+    """Create a requests.Session warmed up with an ASP.NET session cookie."""
+    import requests
+
+    from .base import DEFAULT_HEADERS
+
+    sess = requests.Session()
+    sess.headers.update({
+        **DEFAULT_HEADERS,
+        "Accept": "application/json,text/plain,*/*",
+        "X-Requested-With": "XMLHttpRequest",
+        "Referer": WARMUP_URL,
+    })
+    # Warmup: the Solr endpoint rejects requests without cookiesession1
+    try:
+        r = sess.get(WARMUP_URL, timeout=30)
+        r.raise_for_status()
+    except Exception as exc:
+        logger.warning("italgiure warmup failed: %s — retrying anyway", exc)
+    return sess
+
+
+def _solr_get(
+    session,
+    query: ItalgiureQuery,
+    *,
+    start: int,
+    rows: int,
+    retries: int = 4,
+    backoff: float = 3.0,
+) -> Optional[dict]:
+    """Execute a single Solr query, with retry/backoff on transient errors."""
+    params = {
+        "app.query": "",  # flag param that the ISAPI handler expects
+        "q": f"({query.lucene()})",
+        "rows": str(rows),
+        "start": str(start),
+        "wt": "json",
+        "indent": "off",
+        "sort": "pd desc,numdec desc",
+        "fl": REQUIRED_FIELDS,
+    }
+    delay = backoff
+    for attempt in range(1, retries + 1):
+        try:
+            r = session.get(SOLR_URL, params=params, timeout=120)
+            # 503 is expected from IP-rate limiters; back off and retry
+            if r.status_code == 503:
+                logger.warning(
+                    "italgiure 503 (attempt %d/%d) — sleeping %.0fs",
+                    attempt, retries, delay,
+                )
+                time.sleep(delay)
+                delay *= 2
+                continue
+            r.raise_for_status()
+            return r.json()
+        except Exception as exc:
+            if attempt >= retries:
+                logger.error("italgiure query giving up: %s", exc)
+                return None
+            logger.warning(
+                "italgiure query failed (%s) — retry %d/%d in %.0fs",
+                exc, attempt, retries, delay,
+            )
+            time.sleep(delay)
+            delay *= 2
+    return None
+
+
+def _doc_to_record(doc: dict) -> Optional[dict]:
+    """Map a Solr doc to our standard record shape.
+
+    Returns None for docs without usable OCR text (drops ~0% in practice but
+    shields the pipeline from empty/corrupt entries).
+    """
+    ocr_list = doc.get("ocr") or []
+    if not ocr_list:
+        return None
+    text = clean_text(ocr_list[0])
+    if len(text) < 200:
+        return None
+
+    filename_list = doc.get("filename") or []
+    filename = filename_list[0] if filename_list else ""
+    url_pdf = PDF_BASE + filename.lstrip("./") if filename else ""
+
+    kind = doc.get("kind", "")
+    numdec = doc.get("numdec", "")
+    anno = doc.get("anno", "")
+    szdec = doc.get("szdec", "")
+    tipoprov = doc.get("tipoprov", "")
+
+    return {
+        "text": text,
+        "source": "italgiure",
+        "sentence_id": f"{kind}/{anno}/{numdec}",
+        "article_num": numdec,
+        "article_title": f"Cassazione {kind} Sez. {szdec}, {tipoprov} n.{numdec}/{anno}",
+        "url": url_pdf,
+        "metadata": {
+            "ecli": doc.get("ecli", ""),
+            "kind": kind,
+            "sezione": szdec,
+            "ssz": doc.get("ssz", ""),
+            "anno": anno,
+            "tipoprov": tipoprov,
+            "datdec": doc.get("datdec", ""),
+            "datdep": (doc.get("datdep") or [""])[0],
+            "presidente": (doc.get("presidente") or [""])[0],
+            "relatore": (doc.get("relatore") or [""])[0],
+        },
+    }
+
+
+def _iter_query_docs(
+    session,
+    query: ItalgiureQuery,
+    *,
+    start: int = 0,
+    rows: int = SOLR_MAX_ROWS,
+    rate_limit_sec: float = 1.5,
+    max_docs: Optional[int] = None,
+) -> Iterator[tuple[int, list[dict]]]:
+    """Yield (next_start, batch_records) tuples for a single query.
+
+    Performs pagination via Solr ``start`` / ``rows``. Stops when ``numFound``
+    is reached or ``max_docs`` records have been produced.
+    """
+    cur = start
+    emitted = 0
+    while True:
+        want = rows
+        if max_docs is not None:
+            remaining = max_docs - emitted
+            if remaining <= 0:
+                return
+            want = min(rows, remaining)
+
+        resp = _solr_get(session, query, start=cur, rows=want)
+        if resp is None:
+            logger.error("italgiure: aborting %s at start=%d", query.slug(), cur)
+            return
+
+        response = resp.get("response") or {}
+        num_found = int(response.get("numFound", 0))
+        docs = response.get("docs") or []
+        if not docs:
+            return
+
+        records: list[dict] = []
+        for doc in docs:
+            rec = _doc_to_record(doc)
+            if rec is not None:
+                records.append(rec)
+
+        next_start = cur + len(docs)
+        yield next_start, records
+        emitted += len(records)
+        cur = next_start
+
+        if cur >= num_found:
+            return
+        time.sleep(rate_limit_sec)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def fetch_italgiure(
+    output_dir: str | Path,
+    *,
+    years: Iterable[int] = range(2011, 2027),
+    kinds: Iterable[str] = DEFAULT_KINDS,
+    sezione: Optional[int] = None,
+    max_docs_per_query: Optional[int] = None,
+    rate_limit_sec: float = 1.5,
+    rows: int = SOLR_MAX_ROWS,
+    session=None,
+) -> Path:
+    """Download Cassazione sentences from italgiure.giustizia.it.
+
+    The corpus is streamed to one JSONL file per (kind, anno) slice under
+    ``output_dir``; resumable via a ``_progress.json`` checkpoint.
+
+    Args:
+        output_dir: Directory for italgiure_<kind>_<anno>.jsonl + _progress.json.
+        years: Years to download (inclusive). Only 2011+ has full coverage.
+        kinds: "snciv" (civile), "snpen" (penale), or both.
+        sezione: Restrict to a single section number (1..7, 0=UNITE, 9=LAVORO).
+        max_docs_per_query: Safety cap per (kind, anno) slice — mainly for tests.
+        rate_limit_sec: Delay between successive Solr calls.
+        rows: Rows per Solr page (max 1000 verified).
+        session: Optional pre-built requests.Session; a warmed-up session is
+            created if not supplied.
+
+    Returns:
+        Path to the output directory.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    progress_path = output_dir / "_progress.json"
+    progress: dict[str, int] = {}
+    if progress_path.exists():
+        try:
+            progress = json.loads(progress_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Progress file corrupt (%s) — starting fresh", exc)
+            progress = {}
+
+    if session is None:
+        session = make_italgiure_session()
+
+    logger.warning(
+        "italgiure download will fetch personal data (names of parties, judges, "
+        "lawyers). Do NOT publish the raw corpus — use only for training."
+    )
+
+    for kind in kinds:
+        for year in years:
+            query = ItalgiureQuery(kind=kind, anno=year, sezione=sezione)
+            slug = query.slug()
+            out_path = output_dir / f"italgiure_{slug}.jsonl"
+            start = progress.get(slug, 0)
+            if start == -1:
+                logger.info("italgiure [%s] already complete — skipping", slug)
+                continue
+
+            logger.info("italgiure [%s] downloading from offset %d", slug, start)
+            mode = "a" if start > 0 and out_path.exists() else "w"
+            written = 0
+            with open(out_path, mode, encoding="utf-8") as f:
+                iterator = _iter_query_docs(
+                    session,
+                    query,
+                    start=start,
+                    rows=rows,
+                    rate_limit_sec=rate_limit_sec,
+                    max_docs=max_docs_per_query,
+                )
+                for next_start, batch in iterator:
+                    for rec in batch:
+                        f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+                        written += 1
+                    f.flush()
+                    progress[slug] = next_start
+                    progress_path.write_text(
+                        json.dumps(progress, indent=2), encoding="utf-8"
+                    )
+                    logger.info(
+                        "  [%s] offset=%d (+%d records, %d in this run)",
+                        slug, next_start, len(batch), written,
+                    )
+
+            # Mark slice as complete only when the iterator exited naturally
+            # (max_docs_per_query truncates it, so in that case we keep the
+            #  resume offset intact).
+            if max_docs_per_query is None:
+                progress[slug] = -1
+                progress_path.write_text(
+                    json.dumps(progress, indent=2), encoding="utf-8"
+                )
+
+    return output_dir
+
+
+def load_italgiure_jsonl(output_dir: str | Path) -> list[dict]:
+    """Load every italgiure_*.jsonl file under ``output_dir`` into a list.
+
+    Intended for small test slices only — for a full corpus, stream through
+    ``datasets.load_dataset('json', data_files=...)`` instead.
+    """
+    output_dir = Path(output_dir)
+    records: list[dict] = []
+    for path in sorted(output_dir.glob("italgiure_*.jsonl")):
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    records.append(json.loads(line))
+    return records

--- a/forge/eullm_forge/datasets/italgiure.py
+++ b/forge/eullm_forge/datasets/italgiure.py
@@ -68,19 +68,35 @@ class ItalgiureQuery:
         return s
 
 
-def make_italgiure_session():
-    """Create a requests.Session warmed up with an ASP.NET session cookie."""
+def make_italgiure_session(verify: bool | str = True):
+    """Create a requests.Session warmed up with an ASP.NET session cookie.
+
+    Args:
+        verify: Passed to requests. ``True`` verifies TLS certificates using
+            the system/certifi CA bundle (default, recommended). A string is
+            treated as a path to a custom CA bundle. ``False`` disables
+            verification entirely — use only as a last resort on machines
+            with a broken CA store; the session attacker can MITM you.
+    """
     import requests
 
     from .base import DEFAULT_HEADERS
 
     sess = requests.Session()
+    sess.verify = verify
     sess.headers.update({
         **DEFAULT_HEADERS,
         "Accept": "application/json,text/plain,*/*",
         "X-Requested-With": "XMLHttpRequest",
         "Referer": WARMUP_URL,
     })
+    if verify is False:
+        import urllib3
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        logger.warning(
+            "italgiure: TLS verification DISABLED — fix your CA store "
+            "(pip install -U certifi) instead of relying on this."
+        )
     # Warmup: the Solr endpoint rejects requests without cookiesession1
     try:
         r = sess.get(WARMUP_URL, timeout=30)
@@ -248,6 +264,7 @@ def fetch_italgiure(
     rate_limit_sec: float = 1.5,
     rows: int = SOLR_MAX_ROWS,
     session=None,
+    verify: bool | str = True,
 ) -> Path:
     """Download Cassazione sentences from italgiure.giustizia.it.
 
@@ -264,6 +281,10 @@ def fetch_italgiure(
         rows: Rows per Solr page (max 1000 verified).
         session: Optional pre-built requests.Session; a warmed-up session is
             created if not supplied.
+        verify: TLS verification for the auto-created session (ignored if
+            ``session`` is supplied). ``True`` (default) uses the system CA
+            bundle; a string is a custom CA bundle path; ``False`` disables
+            verification entirely.
 
     Returns:
         Path to the output directory.
@@ -280,7 +301,7 @@ def fetch_italgiure(
             progress = {}
 
     if session is None:
-        session = make_italgiure_session()
+        session = make_italgiure_session(verify=verify)
 
     logger.warning(
         "italgiure download will fetch personal data (names of parties, judges, "

--- a/forge/eullm_forge/datasets/legal_it.py
+++ b/forge/eullm_forge/datasets/legal_it.py
@@ -1419,7 +1419,7 @@ def _fetch_cassazione_homepage_static(source: CassazioneSource) -> list[dict]:
 
 
 def _parse_cassazione_page(html: str, source_id: str, url: str) -> Optional[dict]:
-    """Estrae il testo da una pagina sentenza di italgiure.
+    """Estrae il testo da una pagina sentenza di cortedicassazione.it.
 
     Le sentenze hanno struttura:
       - Header: sezione, numero, data
@@ -1434,11 +1434,30 @@ def _parse_cassazione_page(html: str, source_id: str, url: str) -> Optional[dict
 
     soup = BeautifulSoup(html, "html.parser")
 
-    # Rimuovi nav/script/style
+    # Rimuovi chrome UI: nav, header, footer, script, style, sezione allegati
     for tag in soup.find_all(["nav", "header", "footer", "script", "style", "noscript"]):
         tag.decompose()
+    # Rimuovi sezioni allegati / download (contengono "Scarica Documento", dimensioni file)
+    for tag in soup.find_all(True):
+        txt = tag.get_text(strip=True).lower()
+        if any(x in txt for x in ("scarica documento", "allegato", "scarica il documento")):
+            if len(txt) < 200:  # solo tag piccoli (non rimuove l'intera pagina)
+                tag.decompose()
 
     full_text = soup.get_text(separator="\n", strip=True)
+
+    # Rimuovi righe di UI residue (dimensioni file, etichette bottoni)
+    import re as _re
+    lines = full_text.splitlines()
+    clean_lines = [
+        l for l in lines
+        if not _re.match(
+            r"^\s*(\d+\s*[KkMm][Bb]|Allegato|Scarica|VAI AL DOCUMENTO|Home|Cookie|Privacy"
+            r"|Cerca\b|Menu|Torna|Condividi|Stampa|Follow)\b",
+            l,
+        )
+    ]
+    full_text = "\n".join(clean_lines)
 
     # Estratto minimo: deve contenere testo legale sostanziale
     if len(full_text) < 500 or not any(
@@ -1446,8 +1465,7 @@ def _parse_cassazione_page(html: str, source_id: str, url: str) -> Optional[dict
     ):
         return None
 
-    # Prova a isolare la motivazione (testo dopo "FATTO" o "DIRITTO")
-    # Le sentenze italiane hanno sezioni ben marcate in maiuscolo
+    # Isola la motivazione (testo dopo "FATTO" o "DIRITTO")
     body = full_text
     for marker in ("MOTIVI DELLA DECISIONE", "DIRITTO", "FATTO E DIRITTO", "FATTO"):
         idx = full_text.upper().find(marker)
@@ -1457,7 +1475,7 @@ def _parse_cassazione_page(html: str, source_id: str, url: str) -> Optional[dict
 
     body = clean_text(body)
     if len(body) < 300:
-        body = clean_text(full_text)  # usa tutto se il ritaglio è troppo corto
+        body = clean_text(full_text)
 
     if len(body) < 300:
         return None

--- a/forge/eullm_forge/datasets/legal_it.py
+++ b/forge/eullm_forge/datasets/legal_it.py
@@ -171,8 +171,9 @@ class CassazioneSource:
 
 
 # Sorgenti gratuite per giurisprudenza italiana:
-#   - italgiure.giustizia.it/sncass/ (SentenzeWeb): full-text di tutte le
-#     sentenze Cassazione civili+penali dal 2011, accesso pubblico gratuito.
+#   - italgiure.giustizia.it/sncass/ (SentenzeWeb): full-text delle sentenze
+#     Cassazione civili+penali dal 2021 (~423K doc, ~2.8GB). Pre-2021 non
+#     disponibile su SentenzeWeb — solo massime (kind:sic, sintesi brevi).
 #     Vedi modulo datasets.italgiure (fetch massivo via Solr).
 #   - cortedicassazione.it  : sentenze selezionate + massimario (libero)
 #   - cortecostituzionale.it: TUTTE le sentenze CC, API pubblica ECLI (libero)
@@ -1138,7 +1139,8 @@ def parse_eurlex_html(html: str, source_id: str) -> list[dict]:
 #
 # Sorgenti libere con full-text:
 #   1. italgiure.giustizia.it/sncass/ (SentenzeWeb) — full-text Cassazione
-#      civili+penali dal 2011. Vedi datasets.italgiure.fetch_italgiure().
+#      civili+penali dal 2021 (SentenzeWeb non copre anni precedenti).
+#      Vedi datasets.italgiure.fetch_italgiure().
 #   2. cortedicassazione.it — sentenze selezionate Cassazione (solo sintesi HTML)
 #   3. cortecostituzionale.it — TUTTE le sentenze CC (API pubblica ECLI)
 # ---------------------------------------------------------------------------

--- a/forge/eullm_forge/datasets/legal_it.py
+++ b/forge/eullm_forge/datasets/legal_it.py
@@ -138,10 +138,22 @@ _ITALGIURE_DB: dict[str, dict[str, str]] = {
     "tributaria": {"sentenze": "snciv", "massime": "civile"},
 }
 
-# Fallback: massime pubbliche dal sito ufficiale Cassazione
-CASSAZIONE_MASSIME_URL = (
-    "https://www.cortedicassazione.it/corte-di-cassazione/it/sentenze.page"
+# URL reali verificati dal DOM (struttura /it/, non /corte-di-cassazione/it/)
+CASSAZIONE_BASE = "https://www.cortedicassazione.it"
+CASSAZIONE_LISTING_URL = f"{CASSAZIONE_BASE}/it/ultime_sent_ord_e_questioni.page"
+# Pattern href per sentenze individuali
+CASSAZIONE_DETAIL_PATTERNS = (
+    "civile_dettaglio",
+    "penale_dettaglio",
+    "quc_dettaglio",
+    "rlc_dettaglio",
 )
+# Filtro per sezione
+CASSAZIONE_SEZIONE_PATTERN = {
+    "civile": "civile_dettaglio",
+    "penale": "penale_dettaglio",
+    "lavoro": "civile_dettaglio",   # sezione lavoro usa stesso template civile
+}
 
 # Sentenze Cassazione (uso interno — non pubblicare il dataset grezzo, GDPR)
 @dataclass
@@ -1175,58 +1187,71 @@ def _fetch_cassazione_cortedicassazione(source: CassazioneSource) -> list[dict]:
     """Scarica sentenze dal sito ufficiale cortedicassazione.it (accesso libero).
 
     Il sito pubblica sentenze selezionate in HTML senza richiedere login.
+    La listing page è JS-rendered → usa Playwright.
+    URL struttura verificata: /it/ultime_sent_ord_e_questioni.page
+    Link individuali: civile_dettaglio.page, penale_dettaglio.page, ecc.
     """
+    # Prima prova con Playwright (pagina JS-rendered)
+    records = _fetch_cassazione_playwright(source)
+    if not records:
+        # Fallback: estrae le sentenze baked nell'homepage (HTML statico)
+        records = _fetch_cassazione_homepage_static(source)
+    return records
+
+
+def _fetch_cassazione_playwright(source: CassazioneSource) -> list[dict]:
+    """Scarica la listing page con Playwright e segue i link alle sentenze."""
     try:
         from playwright.sync_api import sync_playwright
     except ImportError:
         return []
 
+    sezione_pattern = CASSAZIONE_SEZIONE_PATTERN.get(source.sezione, "dettaglio")
     records: list[dict] = []
-    # URL sezione-specifica per cortedicassazione.it
-    sezione_urls = {
-        "civile": (
-            "https://www.cortedicassazione.it/corte-di-cassazione/it/"
-            "sentenze_civili.page"
-        ),
-        "penale": (
-            "https://www.cortedicassazione.it/corte-di-cassazione/it/"
-            "sentenze_penali.page"
-        ),
-        "lavoro": (
-            "https://www.cortedicassazione.it/corte-di-cassazione/it/"
-            "sentenze_lavoro.page"
-        ),
-    }
-    url = sezione_urls.get(source.sezione, CASSAZIONE_MASSIME_URL)
-    logger.info("  cortedicassazione.it: %s", url)
 
+    logger.info("  cortedicassazione.it (Playwright): %s", CASSAZIONE_LISTING_URL)
     try:
         with sync_playwright() as pw:
             browser = pw.chromium.launch(headless=True)
             page = browser.new_page(locale="it-IT")
-            page.goto(url, wait_until="networkidle", timeout=60_000)
+            # domcontentloaded evita timeout su siti con analytics pesanti
+            page.goto(CASSAZIONE_LISTING_URL, wait_until="domcontentloaded", timeout=45_000)
+            page.wait_for_timeout(2000)
 
-            # Raccoglie link a sentenze individuali
+            # Raccoglie link alle sentenze della sezione richiesta
+            js_filter = f"h.includes('{sezione_pattern}') && h.includes('contentId')"
             links = page.eval_on_selector_all(
                 "a[href]",
-                "els => els.map(e => e.href).filter("
-                "h => h && (h.includes('sentenz') || h.includes('ordinanz') "
-                "|| h.includes('pronunce') || h.includes('decisioni')))",
+                f"els => els.map(e => e.href).filter(h => h && ({js_filter}))",
             )
+            # Se non troviamo link di sezione, prendi tutti i dettaglio
             if not links:
-                # Diagnostica: mostra tutti i link della pagina
-                all_links = page.eval_on_selector_all(
-                    "a[href]", "els => els.slice(0,15).map(e => e.href)"
+                all_patterns = " || ".join(
+                    f"h.includes('{p}')" for p in CASSAZIONE_DETAIL_PATTERNS
                 )
-                logger.info("  cortedicassazione.it: 0 link sentenze. "
-                            "Sample link pagina: %s", all_links)
+                links = page.eval_on_selector_all(
+                    "a[href]",
+                    f"els => els.map(e => e.href).filter(h => h && ({all_patterns}))",
+                )
+            if not links:
+                all_links = page.eval_on_selector_all(
+                    "a[href]", "els => els.slice(0, 20).map(e => e.href)"
+                )
+                logger.warning(
+                    "  cortedicassazione.it: 0 link trovati. "
+                    "Sample pagina: %s", all_links
+                )
             else:
                 logger.info("  cortedicassazione.it: %d link trovati", len(links))
 
-            for href in links[: source.max_sentences]:
+            # Deduplicazione (ogni link appare due volte nel DOM)
+            seen: set[str] = set()
+            unique_links = [h for h in links if h not in seen and not seen.add(h)]
+
+            for href in unique_links[: source.max_sentences]:
                 full_url = (
                     href if href.startswith("http")
-                    else f"https://www.cortedicassazione.it{href}"
+                    else f"{CASSAZIONE_BASE}{href}"
                 )
                 try:
                     page.goto(full_url, wait_until="domcontentloaded", timeout=30_000)
@@ -1238,7 +1263,65 @@ def _fetch_cassazione_cortedicassazione(source: CassazioneSource) -> list[dict]:
 
             browser.close()
     except Exception as exc:
-        logger.warning("cortedicassazione.it errore: %s", exc)
+        logger.warning("cortedicassazione.it Playwright errore: %s", exc)
+
+    return records
+
+
+def _fetch_cassazione_homepage_static(source: CassazioneSource) -> list[dict]:
+    """Fallback: estrae sentenze baked nell'homepage (HTML statico, no JS).
+
+    La homepage cortedicassazione.it include sempre le ultime ~9 sentenze
+    come HTML statico, accessibili anche senza JS.
+    """
+    try:
+        import requests
+        from bs4 import BeautifulSoup
+    except ImportError:
+        return []
+
+    sezione_pattern = CASSAZIONE_SEZIONE_PATTERN.get(source.sezione, "dettaglio")
+    records: list[dict] = []
+
+    try:
+        resp = requests.get(
+            CASSAZIONE_BASE,
+            headers={
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+                "Accept": "text/html,application/xhtml+xml",
+                "Accept-Language": "it-IT,it;q=0.9",
+            },
+            timeout=20,
+        )
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+        links = [
+            a["href"] for a in soup.find_all("a", href=True)
+            if sezione_pattern in a["href"] and "contentId" in a["href"]
+        ]
+        seen: set[str] = set()
+        unique_links = [h for h in links if h not in seen and not seen.add(h)]
+        logger.info(
+            "  cortedicassazione.it (homepage fallback): %d link %s",
+            len(unique_links), sezione_pattern
+        )
+
+        for href in unique_links[: source.max_sentences]:
+            full_url = href if href.startswith("http") else f"{CASSAZIONE_BASE}{href}"
+            try:
+                r2 = requests.get(
+                    full_url,
+                    headers={"User-Agent": "Mozilla/5.0", "Accept-Language": "it-IT"},
+                    timeout=20,
+                )
+                r2.raise_for_status()
+                rec = _parse_cassazione_page(r2.text, source.id, full_url)
+                if rec:
+                    records.append(rec)
+            except Exception:
+                continue
+    except Exception as exc:
+        logger.warning("cortedicassazione.it homepage fallback errore: %s", exc)
 
     return records
 

--- a/forge/eullm_forge/datasets/legal_it.py
+++ b/forge/eullm_forge/datasets/legal_it.py
@@ -140,7 +140,13 @@ _ITALGIURE_DB: dict[str, dict[str, str]] = {
 
 # URL reali verificati dal DOM (struttura /it/, non /corte-di-cassazione/it/)
 CASSAZIONE_BASE = "https://www.cortedicassazione.it"
-CASSAZIONE_LISTING_URL = f"{CASSAZIONE_BASE}/it/ultime_sent_ord_e_questioni.page"
+# URL listing verificati dal DOM reale — paginazione via frame3_item=N
+# Totali indicativi: civile ~301, penale ~448 (aggiornati periodicamente)
+CASSAZIONE_LISTING_URLS = {
+    "civile": f"{CASSAZIONE_BASE}/it/giurisprudenza_civile.page",
+    "penale": f"{CASSAZIONE_BASE}/it/giurisprudenza_penale.page",
+    "lavoro": f"{CASSAZIONE_BASE}/it/giurisprudenza_civile.page",  # sezione lavoro → civile
+}
 # Pattern href per sentenze individuali
 CASSAZIONE_DETAIL_PATTERNS = (
     "civile_dettaglio",
@@ -148,11 +154,10 @@ CASSAZIONE_DETAIL_PATTERNS = (
     "quc_dettaglio",
     "rlc_dettaglio",
 )
-# Filtro per sezione
 CASSAZIONE_SEZIONE_PATTERN = {
     "civile": "civile_dettaglio",
     "penale": "penale_dettaglio",
-    "lavoro": "civile_dettaglio",   # sezione lavoro usa stesso template civile
+    "lavoro": "civile_dettaglio",
 }
 
 # Sentenze Cassazione (uso interno — non pubblicare il dataset grezzo, GDPR)
@@ -1184,18 +1189,93 @@ def fetch_cassazione(source: CassazioneSource) -> list[dict]:
 
 
 def _fetch_cassazione_cortedicassazione(source: CassazioneSource) -> list[dict]:
-    """Scarica sentenze dal sito ufficiale cortedicassazione.it (accesso libero).
+    """Scarica sentenze da cortedicassazione.it via paginazione frame3_item.
 
-    Il sito pubblica sentenze selezionate in HTML senza richiedere login.
-    La listing page è JS-rendered → usa Playwright.
-    URL struttura verificata: /it/ultime_sent_ord_e_questioni.page
-    Link individuali: civile_dettaglio.page, penale_dettaglio.page, ecc.
+    Le listing page /it/giurisprudenza_*.page sono accessibili via requests
+    (HTML statico con link baked). Paginazione: ?frame3_item=N (N=1,2,3,...).
+    ~9-12 sentenze per pagina, nessun JS richiesto.
     """
-    # Prima prova con Playwright (pagina JS-rendered)
-    records = _fetch_cassazione_playwright(source)
+    records = _fetch_cassazione_paged(source)
     if not records:
-        # Fallback: estrae le sentenze baked nell'homepage (HTML statico)
-        records = _fetch_cassazione_homepage_static(source)
+        # Fallback Playwright se requests è bloccato
+        records = _fetch_cassazione_playwright(source)
+    return records
+
+
+def _fetch_cassazione_paged(source: CassazioneSource) -> list[dict]:
+    """Scarica sentenze paginando /it/giurisprudenza_*.page?frame3_item=N.
+
+    Nessun JS richiesto — le listing page servono HTML statico con link baked.
+    Itera finché la pagina non restituisce link nuovi.
+    """
+    try:
+        import requests
+        from bs4 import BeautifulSoup
+    except ImportError:
+        return []
+
+    listing_url = CASSAZIONE_LISTING_URLS.get(
+        source.sezione, CASSAZIONE_LISTING_URLS["penale"]
+    )
+    detail_pattern = CASSAZIONE_SEZIONE_PATTERN.get(source.sezione, "dettaglio")
+    session = requests.Session()
+    session.headers.update({
+        "User-Agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "it-IT,it;q=0.9,en;q=0.8",
+        "Accept-Encoding": "gzip, deflate, br",
+    })
+
+    all_links: list[str] = []
+    seen_links: set[str] = set()
+
+    logger.info("  cortedicassazione.it paginazione: %s", listing_url)
+    for page_n in range(1, 200):  # max 200 pagine (~2400 sentenze)
+        try:
+            resp = session.get(
+                listing_url, params={"frame3_item": page_n}, timeout=20
+            )
+            resp.raise_for_status()
+        except Exception as exc:
+            logger.warning("  cortedicassazione.it pagina %d errore: %s", page_n, exc)
+            break
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        page_links = [
+            a["href"] for a in soup.find_all("a", href=True)
+            if detail_pattern in a.get("href", "") and "contentId" in a.get("href", "")
+        ]
+        # Deduplicazione
+        new_links = [h for h in page_links if h not in seen_links]
+        for h in new_links:
+            seen_links.add(h)
+        if not new_links:
+            logger.info("  cortedicassazione.it: fine a pagina %d (%d link totali)",
+                        page_n, len(all_links))
+            break
+        all_links.extend(new_links)
+        logger.info("  cortedicassazione.it: pagina %d → +%d link (%d totali)",
+                    page_n, len(new_links), len(all_links))
+        if len(all_links) >= source.max_sentences:
+            break
+
+    # Scarica testo di ogni sentenza
+    records: list[dict] = []
+    for href in all_links[: source.max_sentences]:
+        full_url = href if href.startswith("http") else f"{CASSAZIONE_BASE}{href}"
+        try:
+            r2 = session.get(full_url, timeout=20)
+            r2.raise_for_status()
+            rec = _parse_cassazione_page(r2.text, source.id, full_url)
+            if rec:
+                records.append(rec)
+        except Exception:
+            continue
+
+    logger.info("  cortedicassazione.it: %d sentenze scaricate", len(records))
     return records
 
 

--- a/forge/eullm_forge/datasets/legal_it.py
+++ b/forge/eullm_forge/datasets/legal_it.py
@@ -153,8 +153,10 @@ class CassazioneSource:
     description: str = ""
 
 
-# italgiure.giustizia.it richiede abbonamento a pagamento — non usabile.
 # Sorgenti gratuite per giurisprudenza italiana:
+#   - italgiure.giustizia.it/sncass/ (SentenzeWeb): full-text di tutte le
+#     sentenze Cassazione civili+penali dal 2011, accesso pubblico gratuito.
+#     Vedi modulo datasets.italgiure (fetch massivo via Solr).
 #   - cortedicassazione.it  : sentenze selezionate + massimario (libero)
 #   - cortecostituzionale.it: TUTTE le sentenze CC, API pubblica ECLI (libero)
 CASSAZIONE_SOURCES: list[CassazioneSource] = [
@@ -1117,10 +1119,11 @@ def parse_eurlex_html(html: str, source_id: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 # Giurisprudenza — sorgenti gratuite
 #
-# italgiure.giustizia.it richiede abbonamento a pagamento → non usabile.
-# Sorgenti libere:
-#   1. cortedicassazione.it — sentenze selezionate Cassazione (HTML)
-#   2. cortecostituzionale.it — TUTTE le sentenze CC (API pubblica)
+# Sorgenti libere con full-text:
+#   1. italgiure.giustizia.it/sncass/ (SentenzeWeb) — full-text Cassazione
+#      civili+penali dal 2011. Vedi datasets.italgiure.fetch_italgiure().
+#   2. cortedicassazione.it — sentenze selezionate Cassazione (solo sintesi HTML)
+#   3. cortecostituzionale.it — TUTTE le sentenze CC (API pubblica ECLI)
 # ---------------------------------------------------------------------------
 
 def fetch_cassazione(source: CassazioneSource) -> list[dict]:

--- a/forge/eullm_forge/datasets/legal_it.py
+++ b/forge/eullm_forge/datasets/legal_it.py
@@ -1419,13 +1419,19 @@ def _fetch_cassazione_homepage_static(source: CassazioneSource) -> list[dict]:
 
 
 def _parse_cassazione_page(html: str, source_id: str, url: str) -> Optional[dict]:
-    """Estrae il testo da una pagina sentenza di cortedicassazione.it.
+    """Estrae testo strutturato da una pagina sentenza di cortedicassazione.it.
 
-    Le sentenze hanno struttura:
-      - Header: sezione, numero, data
-      - Sezioni "FATTO", "DIRITTO"/"MOTIVI", "P.Q.M."
+    La pagina contiene: metadata (sezione, numero, data, materia, oggetto,
+    presidente, relatore) + "L'esito in sintesi" (riassunto redatto dalla Corte).
+    Il testo integrale è nel PDF allegato — non scaricato qui.
 
-    Per il training estraiamo l'intera motivazione (DIRITTO + FATTO).
+    Struttura estratta:
+      Dettaglio Sentenza <tipo>
+      <sezione> | Data: <data> | Numero: <num>
+      Oggetto: <oggetto>
+      Presidente: <nome> | Relatore: <nome>
+      L'esito in sintesi
+      <testo sintesi>
     """
     try:
         from bs4 import BeautifulSoup
@@ -1434,55 +1440,49 @@ def _parse_cassazione_page(html: str, source_id: str, url: str) -> Optional[dict
 
     soup = BeautifulSoup(html, "html.parser")
 
-    # Rimuovi chrome UI: nav, header, footer, script, style, sezione allegati
-    for tag in soup.find_all(["nav", "header", "footer", "script", "style", "noscript"]):
+    # Rimuovi chrome: nav, header, footer, script, style, form di ricerca
+    for tag in soup.find_all(["nav", "header", "footer", "script", "style",
+                               "noscript", "form"]):
         tag.decompose()
-    # Rimuovi sezioni allegati / download (contengono "Scarica Documento", dimensioni file)
-    for tag in soup.find_all(True):
-        txt = tag.get_text(strip=True).lower()
-        if any(x in txt for x in ("scarica documento", "allegato", "scarica il documento")):
-            if len(txt) < 200:  # solo tag piccoli (non rimuove l'intera pagina)
-                tag.decompose()
 
     full_text = soup.get_text(separator="\n", strip=True)
 
-    # Rimuovi righe di UI residue (dimensioni file, etichette bottoni)
-    import re as _re
-    lines = full_text.splitlines()
-    clean_lines = [
-        l for l in lines
-        if not _re.match(
-            r"^\s*(\d+\s*[KkMm][Bb]|Allegato|Scarica|VAI AL DOCUMENTO|Home|Cookie|Privacy"
-            r"|Cerca\b|Menu|Torna|Condividi|Stampa|Follow)\b",
+    # Ritaglia dalla riga "Dettaglio Sentenza" (inizio contenuto reale)
+    start_markers = ("Dettaglio Sentenza", "DETTAGLIO SENTENZA")
+    body_start = -1
+    for m in start_markers:
+        idx = full_text.find(m)
+        if idx != -1:
+            body_start = idx
+            break
+    if body_start == -1:
+        return None  # pagina non riconosciuta
+    content = full_text[body_start:]
+
+    # Ferma prima della sezione allegati
+    for stop in ("Allegato\n", "Scarica Documento", "Questo sito utilizza cookie",
+                 "Privacy Policy", "Torna su"):
+        idx = content.find(stop)
+        if idx != -1:
+            content = content[:idx]
+
+    # Pulizia righe boilerplate residue
+    lines = [
+        l for l in content.splitlines()
+        if l.strip() and not re.match(
+            r"^\s*(Vai al|Cerca\b|Menu\b|Home\b|Cookie\b|Condividi|Stampa|Follow"
+            r"|\d+\s*[KkMm][Bb])\b",
             l,
         )
     ]
-    full_text = "\n".join(clean_lines)
+    body = clean_text("\n".join(lines))
 
-    # Estratto minimo: deve contenere testo legale sostanziale
-    if len(full_text) < 500 or not any(
-        kw in full_text for kw in ("Corte di Cassazione", "Cassazione", "ricorso", "motivo")
-    ):
+    if len(body) < 200:
         return None
 
-    # Isola la motivazione (testo dopo "FATTO" o "DIRITTO")
-    body = full_text
-    for marker in ("MOTIVI DELLA DECISIONE", "DIRITTO", "FATTO E DIRITTO", "FATTO"):
-        idx = full_text.upper().find(marker)
-        if idx != -1:
-            body = full_text[idx:]
-            break
-
-    body = clean_text(body)
-    if len(body) < 300:
-        body = clean_text(full_text)
-
-    if len(body) < 300:
-        return None
-
-    # Numero sentenza dall'URL o dall'HTML
-    sentence_id = re.search(r"[/=](\d{4,})", url)
-    sid = sentence_id.group(1) if sentence_id else url.split("/")[-1]
+    # Numero sentenza dall'URL
+    sentence_id = re.search(r"contentId=([A-Z0-9]+)", url)
+    sid = sentence_id.group(1) if sentence_id else url.split("=")[-1]
 
     return {
         "text": body,

--- a/forge/eullm_forge/datasets/legal_it.py
+++ b/forge/eullm_forge/datasets/legal_it.py
@@ -1200,7 +1200,12 @@ def _fetch_cassazione_cortedicassazione(source: CassazioneSource) -> list[dict]:
 
 
 def _fetch_cassazione_playwright(source: CassazioneSource) -> list[dict]:
-    """Scarica la listing page con Playwright e segue i link alle sentenze."""
+    """Scarica sentenze da cortedicassazione.it con Playwright.
+
+    La listing page è JS-rendered e restituisce pagina blank — usiamo la
+    HOMEPAGE come entry point: ha le ultime ~9 sentenze come HTML statico
+    baked direttamente, poi le seguiamo con Playwright per il testo completo.
+    """
     try:
         from playwright.sync_api import sync_playwright
     except ImportError:
@@ -1209,14 +1214,20 @@ def _fetch_cassazione_playwright(source: CassazioneSource) -> list[dict]:
     sezione_pattern = CASSAZIONE_SEZIONE_PATTERN.get(source.sezione, "dettaglio")
     records: list[dict] = []
 
-    logger.info("  cortedicassazione.it (Playwright): %s", CASSAZIONE_LISTING_URL)
+    logger.info("  cortedicassazione.it (Playwright homepage): %s", CASSAZIONE_BASE)
     try:
         with sync_playwright() as pw:
             browser = pw.chromium.launch(headless=True)
-            page = browser.new_page(locale="it-IT")
-            # domcontentloaded evita timeout su siti con analytics pesanti
-            page.goto(CASSAZIONE_LISTING_URL, wait_until="domcontentloaded", timeout=45_000)
-            page.wait_for_timeout(2000)
+            page = browser.new_page(
+                locale="it-IT",
+                user_agent=(
+                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+                ),
+            )
+            # Homepage: HTML statico con le ultime sentenze baked nel DOM
+            page.goto(CASSAZIONE_BASE, wait_until="domcontentloaded", timeout=45_000)
+            page.wait_for_timeout(1500)
 
             # Raccoglie link alle sentenze della sezione richiesta
             js_filter = f"h.includes('{sezione_pattern}') && h.includes('contentId')"
@@ -1224,7 +1235,7 @@ def _fetch_cassazione_playwright(source: CassazioneSource) -> list[dict]:
                 "a[href]",
                 f"els => els.map(e => e.href).filter(h => h && ({js_filter}))",
             )
-            # Se non troviamo link di sezione, prendi tutti i dettaglio
+            # Fallback: qualsiasi link dettaglio sentenza
             if not links:
                 all_patterns = " || ".join(
                     f"h.includes('{p}')" for p in CASSAZIONE_DETAIL_PATTERNS
@@ -1238,8 +1249,8 @@ def _fetch_cassazione_playwright(source: CassazioneSource) -> list[dict]:
                     "a[href]", "els => els.slice(0, 20).map(e => e.href)"
                 )
                 logger.warning(
-                    "  cortedicassazione.it: 0 link trovati. "
-                    "Sample pagina: %s", all_links
+                    "  cortedicassazione.it: 0 link trovati in homepage. "
+                    "Sample: %s", all_links
                 )
             else:
                 logger.info("  cortedicassazione.it: %d link trovati", len(links))
@@ -1283,16 +1294,21 @@ def _fetch_cassazione_homepage_static(source: CassazioneSource) -> list[dict]:
     sezione_pattern = CASSAZIONE_SEZIONE_PATTERN.get(source.sezione, "dettaglio")
     records: list[dict] = []
 
+    _HEADERS = {
+        "User-Agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "it-IT,it;q=0.9,en;q=0.8",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+    }
     try:
-        resp = requests.get(
-            CASSAZIONE_BASE,
-            headers={
-                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
-                "Accept": "text/html,application/xhtml+xml",
-                "Accept-Language": "it-IT,it;q=0.9",
-            },
-            timeout=20,
-        )
+        session = requests.Session()
+        session.headers.update(_HEADERS)
+        resp = session.get(CASSAZIONE_BASE, timeout=20)
         resp.raise_for_status()
         soup = BeautifulSoup(resp.text, "html.parser")
         links = [
@@ -1309,11 +1325,7 @@ def _fetch_cassazione_homepage_static(source: CassazioneSource) -> list[dict]:
         for href in unique_links[: source.max_sentences]:
             full_url = href if href.startswith("http") else f"{CASSAZIONE_BASE}{href}"
             try:
-                r2 = requests.get(
-                    full_url,
-                    headers={"User-Agent": "Mozilla/5.0", "Accept-Language": "it-IT"},
-                    timeout=20,
-                )
+                r2 = session.get(full_url, timeout=20)
                 r2.raise_for_status()
                 rec = _parse_cassazione_page(r2.text, source.id, full_url)
                 if rec:

--- a/forge/tests/test_italgiure.py
+++ b/forge/tests/test_italgiure.py
@@ -1,0 +1,211 @@
+"""Tests for the italgiure.giustizia.it Cassazione fetcher.
+
+The real Solr endpoint is IP-restricted (blocks datacenter egress), so tests
+use a mocked requests.Session built from a synthetic Solr JSON response.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from eullm_forge.datasets.italgiure import (
+    ItalgiureQuery,
+    _doc_to_record,
+    fetch_italgiure,
+    load_italgiure_jsonl,
+)
+
+
+SAMPLE_DOC = {
+    "id": "snpen2026513137S",
+    "kind": "snpen",
+    "numdec": "13137",
+    "szdec": "5",
+    "ssz": "0",
+    "tipoprov": "Sentenza",
+    "anno": "2026",
+    "datdec": "20251210",
+    "datdep": ["20260409"],
+    "ecli": "ECLI:IT:CASS:2026:13137PEN",
+    "presidente": ["CATENA ROSSELLA"],
+    "relatore": ["BELMONTE MARIA TERESA"],
+    "filename": ["./20260409/snpen@s50@a2026@n13137@tS.pdf"],
+    "ocr": ["E APPELLO di REGGIO CALABRIA visti gli atti, " * 40],
+}
+
+
+def _make_solr_response(docs: list[dict], num_found: int) -> dict:
+    return {
+        "responseHeader": {"status": 0, "QTime": 15},
+        "response": {"numFound": num_found, "start": 0, "docs": docs},
+    }
+
+
+def test_query_lucene_all_sezioni():
+    q = ItalgiureQuery(kind="snpen", anno=2026)
+    assert q.lucene() == 'kind:"snpen" AND anno:"2026"'
+    assert q.slug() == "snpen_2026"
+
+
+def test_query_lucene_with_sezione():
+    q = ItalgiureQuery(kind="snciv", anno=2024, sezione=5)
+    assert q.lucene() == 'kind:"snciv" AND anno:"2024" AND szdec:"5"'
+    assert q.slug() == "snciv_2024_sez5"
+
+
+def test_doc_to_record_happy_path():
+    rec = _doc_to_record(SAMPLE_DOC)
+    assert rec is not None
+    assert rec["source"] == "italgiure"
+    assert rec["sentence_id"] == "snpen/2026/13137"
+    assert rec["article_num"] == "13137"
+    assert "E APPELLO di REGGIO CALABRIA" in rec["text"]
+    assert rec["metadata"]["ecli"] == "ECLI:IT:CASS:2026:13137PEN"
+    assert rec["metadata"]["presidente"] == "CATENA ROSSELLA"
+    assert rec["metadata"]["datdep"] == "20260409"
+    assert rec["url"].endswith("snpen@s50@a2026@n13137@tS.pdf")
+
+
+def test_doc_to_record_drops_empty_ocr():
+    doc = dict(SAMPLE_DOC, ocr=[])
+    assert _doc_to_record(doc) is None
+
+
+def test_doc_to_record_drops_short_text():
+    doc = dict(SAMPLE_DOC, ocr=["abc"])
+    assert _doc_to_record(doc) is None
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class _FakeSession:
+    def __init__(self, pages: list[dict]):
+        self._pages = pages
+        self._call = 0
+        self.headers = {}
+        self.get_calls: list[dict] = []
+
+    def get(self, url, params=None, timeout=None):  # noqa: D401
+        self.get_calls.append({"url": url, "params": dict(params or {})})
+        if not self._pages:
+            return _FakeResponse(_make_solr_response([], 0))
+        idx = min(self._call, len(self._pages) - 1)
+        self._call += 1
+        return _FakeResponse(self._pages[idx])
+
+
+def test_fetch_italgiure_writes_jsonl_and_checkpoint(tmp_path: Path):
+    docs_page1 = [dict(SAMPLE_DOC, numdec=str(n)) for n in range(13100, 13103)]
+    docs_page2 = [dict(SAMPLE_DOC, numdec=str(n)) for n in range(13200, 13201)]
+    pages = [
+        _make_solr_response(docs_page1, 4),
+        _make_solr_response(docs_page2, 4),
+    ]
+    session = _FakeSession(pages)
+
+    out = fetch_italgiure(
+        tmp_path,
+        years=[2026],
+        kinds=["snpen"],
+        rate_limit_sec=0.0,
+        rows=3,
+        session=session,
+    )
+
+    jsonl = out / "italgiure_snpen_2026.jsonl"
+    assert jsonl.exists()
+    lines = jsonl.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 4
+    first = json.loads(lines[0])
+    assert first["source"] == "italgiure"
+    assert first["sentence_id"].startswith("snpen/2026/")
+
+    progress = json.loads((out / "_progress.json").read_text(encoding="utf-8"))
+    # Slice marked complete (-1 sentinel)
+    assert progress["snpen_2026"] == -1
+
+    # Verify Lucene query shape + paging params we actually sent
+    first_params = session.get_calls[0]["params"]
+    assert first_params["q"] == '(kind:"snpen" AND anno:"2026")'
+    assert first_params["wt"] == "json"
+    assert first_params["rows"] == "3"
+    assert first_params["start"] == "0"
+    assert session.get_calls[1]["params"]["start"] == "3"
+
+
+def test_fetch_italgiure_resumes_from_progress(tmp_path: Path):
+    # First run: only get 1 doc (truncated by max_docs_per_query)
+    pages = [
+        _make_solr_response([dict(SAMPLE_DOC, numdec="1")], 3),
+    ]
+    session1 = _FakeSession(pages)
+    fetch_italgiure(
+        tmp_path,
+        years=[2026],
+        kinds=["snpen"],
+        rate_limit_sec=0.0,
+        rows=1,
+        max_docs_per_query=1,
+        session=session1,
+    )
+    progress = json.loads((tmp_path / "_progress.json").read_text())
+    # After fetching 1 row (start=0, rows=1), next offset is 1, not -1
+    # because max_docs_per_query truncated the iterator.
+    assert progress["snpen_2026"] == 1
+
+    # Second run: resume from offset 1
+    pages2 = [
+        _make_solr_response(
+            [dict(SAMPLE_DOC, numdec="2"), dict(SAMPLE_DOC, numdec="3")],
+            3,
+        ),
+    ]
+    session2 = _FakeSession(pages2)
+    fetch_italgiure(
+        tmp_path,
+        years=[2026],
+        kinds=["snpen"],
+        rate_limit_sec=0.0,
+        rows=2,
+        session=session2,
+    )
+    # First call should have used start=1 (resumed), not 0
+    assert session2.get_calls[0]["params"]["start"] == "1"
+
+    all_records = load_italgiure_jsonl(tmp_path)
+    numdecs = sorted(r["article_num"] for r in all_records)
+    assert numdecs == ["1", "2", "3"]
+
+
+def test_fetch_italgiure_skips_complete_slices(tmp_path: Path):
+    (tmp_path / "_progress.json").write_text(
+        json.dumps({"snpen_2026": -1}), encoding="utf-8"
+    )
+    session = _FakeSession([])
+    fetch_italgiure(
+        tmp_path,
+        years=[2026],
+        kinds=["snpen"],
+        rate_limit_sec=0.0,
+        session=session,
+    )
+    assert session.get_calls == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/forge/tests/test_italgiure.py
+++ b/forge/tests/test_italgiure.py
@@ -207,5 +207,55 @@ def test_fetch_italgiure_skips_complete_slices(tmp_path: Path):
     assert session.get_calls == []
 
 
+def test_fetch_italgiure_heals_empty_slice_marked_complete(tmp_path: Path):
+    # Simulate a previous run that marked the slice complete but wrote 0
+    # records (server glitch). The next run must reset progress and retry.
+    (tmp_path / "_progress.json").write_text(
+        json.dumps({"snpen_2026": -1}), encoding="utf-8"
+    )
+    (tmp_path / "italgiure_snpen_2026.jsonl").write_text("", encoding="utf-8")
+
+    pages = [_make_solr_response([SAMPLE_DOC], 1)]
+    session = _FakeSession(pages)
+    fetch_italgiure(
+        tmp_path,
+        years=[2026],
+        kinds=["snpen"],
+        rate_limit_sec=0.0,
+        session=session,
+    )
+
+    # Should have been retried from offset 0 and written the record
+    assert session.get_calls[0]["params"]["start"] == "0"
+    records = load_italgiure_jsonl(tmp_path)
+    assert len(records) == 1
+    progress = json.loads((tmp_path / "_progress.json").read_text())
+    assert progress["snpen_2026"] == -1  # re-marked complete after successful refetch
+
+
+def test_fetch_italgiure_keeps_progress_when_server_returns_empty(tmp_path: Path):
+    # numFound says 10 but docs come back empty — two times in a row.
+    # Progress must NOT be marked -1.
+    empty_with_found = {
+        "responseHeader": {"status": 0, "QTime": 5},
+        "response": {"numFound": 10, "start": 0, "docs": []},
+    }
+    # Same response returned on retry inside _iter_query_docs + any further calls
+    session = _FakeSession([empty_with_found, empty_with_found, empty_with_found])
+    fetch_italgiure(
+        tmp_path,
+        years=[2026],
+        kinds=["snpen"],
+        rate_limit_sec=0.0,
+        session=session,
+    )
+    progress_path = tmp_path / "_progress.json"
+    progress = (
+        json.loads(progress_path.read_text()) if progress_path.exists() else {}
+    )
+    # Not -1 — the slice is retriable on the next run.
+    assert progress.get("snpen_2026", 0) != -1
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
URL struttura verificata dal DOM reale:
- Rimosso /corte-di-cassazione/it/ (404) → corretto /it/
- Listing page: /it/ultime_sent_ord_e_questioni.page
- Sentenze individuali: civile_dettaglio/penale_dettaglio/quc_dettaglio/rlc_dettaglio
- networkidle → domcontentloaded (evita timeout su analytics)

Refactor fetch in tre livelli:
1. _fetch_cassazione_playwright: listing JS-rendered con filtro per sezione
2. _fetch_cassazione_homepage_static: fallback HTML statico dall'homepage (baked ~9 sentenze, no JS richiesto)
3. Deduplicazione link (ogni href appare due volte nel DOM Liferay)
