### PR TITLE
fix(forge): rename ambiguous 'l' to 'line' in cassazione parser

### DIFF
--- a/forge/eullm_forge/datasets/legal_it.py
+++ b/forge/eullm_forge/datasets/legal_it.py
@@ -1473,11 +1473,11 @@ def _parse_cassazione_page(html: str, source_id: str, url: str) -> Optional[dict
 
     # Pulizia righe boilerplate residue
     lines = [
-        l for l in content.splitlines()
-        if l.strip() and not re.match(
+        line for line in content.splitlines()
+        if line.strip() and not re.match(
             r"^\s*(Vai al|Cerca\b|Menu\b|Home\b|Cookie\b|Condividi|Stampa|Follow"
             r"|\d+\s*[KkMm][Bb])\b",
-            l,
+            line,
         )
     ]
     body = clean_text("\n".join(lines))


### PR DESCRIPTION
Ruff E741 failure in CI: single-char lowercase 'l' is forbidden because it is visually indistinguishable from '1' and 'I' in most fonts. Rename the list-comprehension variable to 'line' for clarity.