### PR TITLE
feat(forge): training scaffolding (smoke + production configs)

### DIFF
--- a/forge/scripts/install_training_deps.sh
+++ b/forge/scripts/install_training_deps.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Install LLaMA-Factory and the training stack into the active Python env.
+#
+# Idempotent: if LLaMA-Factory is already installed at $LF_DIR, it just
+# pulls the latest changes and re-runs `pip install -e .` which is a
+# no-op if nothing changed.
+#
+# Usage:
+#   bash forge/scripts/install_training_deps.sh
+#
+# After running, you can verify with:
+#   llamafactory-cli version
+
+set -euo pipefail
+
+LF_DIR="${LF_DIR:-$HOME/LLaMA-Factory}"
+LF_REPO="${LF_REPO:-https://github.com/hiyouga/LLaMA-Factory.git}"
+
+err() { printf '\033[31m[err]\033[0m %s\n' "$*" >&2; exit 1; }
+ok()  { printf '\033[32m[ok]\033[0m  %s\n' "$*"; }
+log() { printf '\033[34m[..]\033[0m  %s\n' "$*"; }
+
+PYTHON="${PYTHON:-python3}"
+log "Using $($PYTHON --version)"
+$PYTHON -m pip install --quiet --upgrade pip wheel
+
+# 1. Clone or update LLaMA-Factory
+if [ -d "$LF_DIR/.git" ]; then
+    log "LLaMA-Factory at $LF_DIR — pulling latest"
+    git -C "$LF_DIR" pull --quiet --ff-only
+else
+    log "Cloning LLaMA-Factory into $LF_DIR"
+    git clone --depth 1 "$LF_REPO" "$LF_DIR"
+fi
+
+# 2. Install LLaMA-Factory in editable mode + the extras we need.
+#    torch       — already installed by the eullm-forge dep, so this is a no-op
+#    metrics     — required for eval (rouge / bleu / perplexity)
+#    bitsandbytes— for 8-bit optimizer + future QLoRA
+log "Installing LLaMA-Factory + extras (torch, metrics, bitsandbytes)"
+(cd "$LF_DIR" && $PYTHON -m pip install --quiet -e ".[torch,metrics,bitsandbytes]")
+
+# 3. Sanity check.
+if command -v llamafactory-cli >/dev/null; then
+    ok "LLaMA-Factory installed: $(llamafactory-cli version 2>&1 | head -1)"
+else
+    err "llamafactory-cli not on PATH after install"
+fi
+
+# 4. Optional: wandb for live training metrics.
+if [ "${INSTALL_WANDB:-1}" = "1" ]; then
+    log "Installing wandb (optional, run 'wandb disabled' to opt out)"
+    $PYTHON -m pip install --quiet wandb
+fi
+
+cat <<EOF
+
+================================================================================
+ Training stack installed.
+   LLaMA-Factory: $LF_DIR
+
+ Next:
+   bash forge/scripts/train.sh \\
+       forge/training/configs/smoke_qwen3_1.7b.yaml \\
+       ~/italgiure_corpus/pretraining
+
+ See forge/training/README.md for the full flow.
+================================================================================
+EOF

--- a/forge/scripts/train.sh
+++ b/forge/scripts/train.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Universal LLaMA-Factory training launcher.
+#
+# Handles three things on top of `llamafactory-cli train`:
+#   1. Copies forge/training/configs/dataset_info.json next to the
+#      dataset files so LLaMA-Factory can discover the corpus.
+#   2. Auto-detects the most recent checkpoint inside the YAML's
+#      output_dir and passes --resume_from_checkpoint, so a re-run
+#      after a preemption picks up where it left off.
+#   3. Logs the resolved command before launching, so you can copy/
+#      paste it later for debugging.
+#
+# Usage:
+#   bash forge/scripts/train.sh <config.yaml> [data-dir]
+#
+# If <data-dir> is omitted, defaults to:
+#   - $TRAINING_DATA_DIR if set
+#   - ~/italgiure_corpus/pretraining (smoke-test default)
+#
+# Examples:
+#   # Smoke test on the local 5070 Ti workstation
+#   bash forge/scripts/train.sh \\
+#       forge/training/configs/smoke_qwen3_1.7b.yaml
+#
+#   # Production continued PT on a rented 96 GB instance
+#   bash forge/scripts/train.sh \\
+#       forge/training/configs/continued_pt_qwen3_32b.yaml \\
+#       ~/datasets/legal_it
+#
+#   # Resume after a preemption — same command, no special flag needed
+#   bash forge/scripts/train.sh \\
+#       forge/training/configs/continued_pt_qwen3_32b.yaml \\
+#       ~/datasets/legal_it
+
+set -euo pipefail
+
+CONFIG="${1:?Usage: $0 <config.yaml> [data-dir]}"
+DATA_DIR="${2:-${TRAINING_DATA_DIR:-$HOME/italgiure_corpus/pretraining}}"
+
+err() { printf '\033[31m[err]\033[0m %s\n' "$*" >&2; exit 1; }
+ok()  { printf '\033[32m[ok]\033[0m  %s\n' "$*"; }
+log() { printf '\033[34m[..]\033[0m  %s\n' "$*"; }
+
+[ -f "$CONFIG" ]    || err "config not found: $CONFIG"
+[ -d "$DATA_DIR" ]  || err "data dir not found: $DATA_DIR"
+[ -f "$DATA_DIR/train.jsonl" ] || err "missing $DATA_DIR/train.jsonl"
+[ -f "$DATA_DIR/val.jsonl" ]   || err "missing $DATA_DIR/val.jsonl"
+command -v llamafactory-cli >/dev/null || \
+    err "llamafactory-cli not on PATH — run forge/scripts/install_training_deps.sh"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DATASET_INFO_SRC="$REPO_ROOT/forge/training/configs/dataset_info.json"
+DATASET_INFO_DST="$DATA_DIR/dataset_info.json"
+
+[ -f "$DATASET_INFO_SRC" ] || err "missing $DATASET_INFO_SRC"
+
+# Copy the LLaMA-Factory dataset registration next to the dataset
+# files. cp is unconditional so a doc-update on dataset_info.json
+# always propagates.
+cp "$DATASET_INFO_SRC" "$DATASET_INFO_DST"
+ok "dataset_info.json copied to $DATASET_INFO_DST"
+
+# Extract output_dir from the YAML to look for an existing checkpoint
+# WITHOUT requiring yaml/python deps.
+OUTPUT_DIR=$(grep -E '^output_dir:' "$CONFIG" \
+    | head -1 | sed -E 's/output_dir:[[:space:]]*//; s/[[:space:]]+#.*$//; s/^["'\'']//; s/["'\'']$//')
+
+if [ -z "$OUTPUT_DIR" ]; then
+    err "could not extract output_dir from $CONFIG"
+fi
+
+RESUME_ARG=()
+if [ -d "$OUTPUT_DIR" ]; then
+    LATEST_CKPT=$(find "$OUTPUT_DIR" -maxdepth 1 -type d -name 'checkpoint-*' \
+        -printf '%T@ %p\n' 2>/dev/null \
+        | sort -rn | awk 'NR==1{print $2}')
+    if [ -n "$LATEST_CKPT" ]; then
+        log "found existing checkpoint: $LATEST_CKPT — resuming"
+        RESUME_ARG=(--resume_from_checkpoint "$LATEST_CKPT")
+    else
+        log "$OUTPUT_DIR exists but no checkpoint inside — starting fresh"
+    fi
+else
+    log "no $OUTPUT_DIR yet — starting fresh"
+fi
+
+CMD=(llamafactory-cli train "$CONFIG"
+     --dataset_dir "$DATA_DIR"
+     "${RESUME_ARG[@]}")
+
+echo
+log "Launching:"
+printf '   %s\n' "${CMD[*]}"
+echo
+
+exec "${CMD[@]}"

--- a/forge/training/README.md
+++ b/forge/training/README.md
@@ -1,0 +1,99 @@
+# EULLM Forge — Training scaffolding
+
+Minimal scaffolding for the `legal-it-7b` training pipeline. Three
+moving parts:
+
+1. **Configs** — YAMLs for LLaMA-Factory, one per training run.
+2. **`install_training_deps.sh`** — installs LLaMA-Factory + the runtime stack.
+3. **`train.sh`** — universal launcher: handles dataset registration,
+   auto-resume, and command logging.
+
+The end-to-end strategy lives in
+[`docs/legal-it-7b-strategy.md`](../../docs/legal-it-7b-strategy.md).
+
+## Configs
+
+| Config | Phase | Model | Hardware target | Wall time |
+|--------|-------|-------|-----------------|----------:|
+| `smoke_qwen3_1.7b.yaml` | smoke | `Qwen/Qwen3-1.7B-Base` + LoRA r=8 | RTX 5070 Ti 16 GB | ~5-8 min |
+| `continued_pt_qwen3_32b.yaml` | Phase 1 | `Qwen/Qwen3-32B-Base` + LoRA r=128 | 96 GB GPU | 2.5-3.5 days |
+
+The smoke config exists only to validate the wiring (dataset registration,
+checkpoint write, resume-from-checkpoint). Train it once, kill it
+mid-run with Ctrl-C, run the same command again — the launcher should
+auto-detect the most recent checkpoint and resume. If both runs produce
+a final adapter under `checkpoints/smoke_qwen3_1.7b/`, the production
+config will work the same way on the rented instance.
+
+## First-time setup
+
+```bash
+# From the repo root, with conda env active:
+bash forge/scripts/install_training_deps.sh
+```
+
+This clones LLaMA-Factory into `~/LLaMA-Factory` (override via `LF_DIR`)
+and installs `llamafactory-cli` plus the training stack.
+
+## Smoke test (5070 Ti)
+
+Prereq: anonymized + chunked corpus already at
+`~/italgiure_corpus/pretraining/{train,val}.jsonl` (the output of
+`format_pretraining.py`).
+
+```bash
+bash forge/scripts/train.sh \
+    forge/training/configs/smoke_qwen3_1.7b.yaml
+```
+
+What you should see:
+- A line `dataset_info.json copied to …/pretraining/dataset_info.json`
+- LLaMA-Factory loads Qwen3-1.7B-Base, applies LoRA r=8.
+- Training starts; loss prints every 5 steps.
+- A checkpoint is written every 50 steps to
+  `./checkpoints/smoke_qwen3_1.7b/checkpoint-50`.
+- After 100 steps the run completes with the final adapter saved.
+
+### Verify resume
+
+```bash
+# 1. Start the run
+bash forge/scripts/train.sh forge/training/configs/smoke_qwen3_1.7b.yaml
+
+# 2. Kill it after step ~70 (Ctrl-C). The checkpoint at step 50 stays.
+
+# 3. Re-run the same command
+bash forge/scripts/train.sh forge/training/configs/smoke_qwen3_1.7b.yaml
+# Expected: log line "found existing checkpoint: …/checkpoint-50 — resuming"
+# Training resumes at step 50 and runs to step 100.
+```
+
+## Production run (96 GB rented instance)
+
+Prereq: instance bootstrapped via `forge/scripts/setup_training_env.sh`
+(clones the repo, installs deps, downloads dataset tarball from HF Hub,
+extracts to `~/datasets/legal_it/`).
+
+```bash
+bash forge/scripts/train.sh \
+    forge/training/configs/continued_pt_qwen3_32b.yaml \
+    ~/datasets/legal_it
+```
+
+The launcher passes `--resume_from_checkpoint <last>` automatically
+whenever it finds a checkpoint under the YAML's `output_dir`. So if the
+instance is preempted, just re-run the same command on the new instance
+after pulling the latest checkpoint from the off-instance backup
+(see strategy doc §6).
+
+## Troubleshooting
+
+- **`llamafactory-cli not on PATH`** — run `install_training_deps.sh`
+  in the same Python env you'll launch training from.
+- **Out-of-memory at start** — drop `cutoff_len` from 2048 to 1024 in
+  the YAML, or lower `lora_rank`.
+- **`dataset_info.json` not found** — confirm `train.sh` reported
+  copying it; if not, the data dir doesn't exist or is wrong.
+- **Tokenizer mismatch on resume** — make sure you're resuming with the
+  same model name as the original run; LLaMA-Factory stores tokenizer
+  files alongside checkpoints to detect this.

--- a/forge/training/configs/continued_pt_qwen3_32b.yaml
+++ b/forge/training/configs/continued_pt_qwen3_32b.yaml
@@ -1,0 +1,59 @@
+# Phase 1 — Continued pre-training of the teacher.
+#
+# Target: Qwen3-32B-Base + LoRA r=128 on the full 700M-token Italian
+# legal corpus (Cassazione + codici + Costituzione). Runs on a single
+# GPU of the 96 GB class.
+#
+# Expected wall time: 2.5–3.5 days on a 96 GB GPU.
+# Expected peak VRAM: ~78 GB (see docs/legal-it-7b-strategy.md §4.1).
+
+### model
+model_name_or_path: Qwen/Qwen3-32B-Base
+trust_remote_code: false
+
+### method (continued pre-training with LoRA)
+stage: pt
+do_train: true
+finetuning_type: lora
+# Cover the full attention block + the down_proj of MLP — empirical
+# sweet spot from Qwen3 fine-tuning recipes for domain adaptation.
+lora_target: q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj
+lora_rank: 128
+lora_alpha: 256
+lora_dropout: 0.05
+
+### dataset
+# dataset_dir is set by forge/scripts/train.sh.
+dataset: legal_it_train
+eval_dataset: legal_it_val
+cutoff_len: 2048
+preprocessing_num_workers: 8
+overwrite_cache: false
+
+### training
+output_dir: ./checkpoints/qwen3_32b_legal_it_continued_pt
+overwrite_output_dir: false
+per_device_train_batch_size: 1
+gradient_accumulation_steps: 16        # effective batch ≈ 16
+learning_rate: 1.0e-5
+num_train_epochs: 1
+lr_scheduler_type: cosine
+warmup_ratio: 0.03
+weight_decay: 0.01
+max_grad_norm: 1.0
+bf16: true
+gradient_checkpointing: true
+optim: adamw_torch_8bit
+
+### checkpointing (every 500 steps as per strategy doc §6)
+logging_steps: 10
+save_steps: 500
+save_total_limit: 2
+save_strategy: steps
+plot_loss: true
+
+### eval (perplexity on val every 500 steps)
+per_device_eval_batch_size: 1
+eval_strategy: steps
+eval_steps: 500
+val_size: 0

--- a/forge/training/configs/dataset_info.json
+++ b/forge/training/configs/dataset_info.json
@@ -1,0 +1,17 @@
+{
+  "_README": "LLaMA-Factory dataset registration. Copied next to train.jsonl/val.jsonl by forge/scripts/train.sh so LLaMA-Factory can discover the corpus. The 'pretrain' formatting tells LF to treat the 'text' column as raw text for next-token-prediction (no instruction/response template).",
+  "legal_it_train": {
+    "file_name": "train.jsonl",
+    "columns": {
+      "prompt": "text"
+    },
+    "formatting": "pretrain"
+  },
+  "legal_it_val": {
+    "file_name": "val.jsonl",
+    "columns": {
+      "prompt": "text"
+    },
+    "formatting": "pretrain"
+  }
+}

--- a/forge/training/configs/smoke_qwen3_1.7b.yaml
+++ b/forge/training/configs/smoke_qwen3_1.7b.yaml
@@ -1,0 +1,61 @@
+# Smoke test: validate the training pipeline on a 5070 Ti before
+# provisioning the production GPU.
+#
+# Goal:
+#   * confirm LLaMA-Factory + dataset_info.json + our train.sh launcher
+#     all wire up correctly
+#   * confirm LoRA continued pre-training runs on Qwen3-1.7B-Base
+#     (proxy for the full Qwen3-32B teacher)
+#   * confirm checkpoints are written and resume_from_checkpoint works
+#
+# Expected wall time: ~5-8 min on RTX 5070 Ti (16 GB VRAM).
+# Expected peak VRAM: ~5-6 GB (Qwen3-1.7B BF16 + LoRA r=8 + grad ckpt).
+
+### model
+model_name_or_path: Qwen/Qwen3-1.7B-Base
+trust_remote_code: false
+
+### method (continued pre-training with LoRA)
+stage: pt
+do_train: true
+finetuning_type: lora
+lora_target: q_proj,k_proj,v_proj,o_proj
+lora_rank: 8
+lora_alpha: 16
+lora_dropout: 0.0
+
+### dataset
+# dataset_dir is set by forge/scripts/train.sh (overrides this YAML).
+dataset: legal_it_train
+eval_dataset: legal_it_val
+cutoff_len: 1024
+max_samples: 5000          # smoke: only first 5k records of train.jsonl
+preprocessing_num_workers: 4
+overwrite_cache: false
+
+### training
+output_dir: ./checkpoints/smoke_qwen3_1.7b
+overwrite_output_dir: false
+per_device_train_batch_size: 1
+gradient_accumulation_steps: 8
+learning_rate: 5.0e-5
+num_train_epochs: 1
+max_steps: 100
+lr_scheduler_type: cosine
+warmup_ratio: 0.05
+bf16: true
+gradient_checkpointing: true
+optim: adamw_torch_8bit
+
+### checkpointing (every 50 steps so we can test resume by ctrl-c)
+logging_steps: 5
+save_steps: 50
+save_total_limit: 2
+save_strategy: steps
+plot_loss: true
+
+### eval (light — every 50 steps on val.jsonl head)
+per_device_eval_batch_size: 1
+eval_strategy: steps
+eval_steps: 50
+val_size: 0


### PR DESCRIPTION
Three artifacts that together make the next training step a single command, both on the local 5070 Ti for smoke validation and on the rented 96 GB GPU for the real Phase 1 run:

  forge/scripts/install_training_deps.sh
    Idempotent installer that clones LLaMA-Factory into ~/LLaMA-Factory
    and pip-installs it editable with the [torch,metrics,bitsandbytes]
    extras. Sanity-checks llamafactory-cli is on PATH afterwards.
    Optional wandb install gated by INSTALL_WANDB env var.

  forge/scripts/train.sh
    Universal launcher: takes one positional arg (the YAML config) and
    an optional second arg (data dir). It (a) copies the
    dataset_info.json registration next to train.jsonl/val.jsonl so
    LLaMA-Factory can discover the corpus, (b) scans the YAML's
    output_dir for the most recent checkpoint and passes
    --resume_from_checkpoint when one exists (idempotent re-run after
    preemption), (c) logs the resolved command before launching.

  forge/training/configs/
    dataset_info.json         — LF dataset registration with formatting
                                "pretrain", points at train.jsonl /
                                val.jsonl by name.
    smoke_qwen3_1.7b.yaml     — Qwen3-1.7B-Base + LoRA r=8, 100 steps,
                                cutoff 1024, max_samples 5k. Designed
                                for ~5-8 min on 16 GB VRAM. Same
                                family as the Qwen3-7B-Base student so
                                tokenizer + arch behaviour transfer.
    continued_pt_qwen3_32b.yaml — Phase 1 production: Qwen3-32B-Base
                                + LoRA r=128/alpha 256 over q/k/v/o +
                                gate/up/down_proj, cutoff 2048,
                                grad_accum 16, lr 1e-5 cosine, save
                                every 500 steps as per strategy §6.

  forge/training/README.md
    First-time setup, smoke flow with explicit ctrl-c-then-resume
    recipe to verify checkpointing works, and the production launch
    command. Cross-references docs/legal-it-7b-strategy.md.