### PR TITLE
feat(engine): add auto GPU layer fitting to Phase 1 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ We deliberately exclude Llama from the EULLM catalog because its license require
 * OpenAI + Ollama API compatibility (drop-in replacement)
 * Single binary distribution (Linux/macOS, CUDA/ROCm/Vulkan/Metal)
 * GGUF model support, transparent web browsing, audit trail
+* **Planned — auto GPU layer fitting** (`--fit` flag): query available VRAM at startup, estimate per-layer + KV cache memory cost from the GGUF header, compute the maximum `n-gpu-layers` that fits, fall back to partial CPU offload otherwise. Targets large dense models (14B–32B at Q4) and MoE models (e.g. Qwen3-30B-A3B, Gemma-4-26B-A4B) on consumer GPUs without manual tuning. Cross-platform (CUDA/ROCm/Vulkan/Metal).
 * Public launch on HackerNews, [dev.to](http://dev.to), Hashnode, LinkedIn
 * GitHub repository active, contributor onboarding
 * Community feedback collection


### PR DESCRIPTION
Adds a planned --fit flag to the Engine that auto-computes n-gpu-layers from available VRAM and per-layer/KV cache cost, enabling large dense models (14B-32B Q4) and MoE models (Qwen3-30B-A3B, Gemma-4-26B-A4B) to run on consumer GPUs without manual tuning. Cross-backend (CUDA/ROCm/Vulkan/Metal).

Not implementing now — priority remains the verticalization pipeline and first demo model (legal-it-7b). Tracked here so it surfaces for design + scheduling once Phase 1 of the modeling work is complete.