### PR TITLE
ci(windows): drop sub-packages filter on CUDA install (wrong names ca…

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -509,7 +509,11 @@ jobs:
         with:
           cuda: "12.8.0"
           method: network
-          sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "curand", "curand_dev", "cufft", "cufft_dev", "cuda_runtime", "cuda_cudart"]'
+          # Sub-package filtering is deliberately omitted: NVIDIA's Windows
+          # installer uses component names like "cudart_12.8" which differ
+          # from Linux ("cudart"). Providing a Linux-style allowlist makes
+          # the installer exit with code 3772776473. Letting Jimver install
+          # the default set (~5 GB) is the most reliable path on Windows.
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -575,7 +579,9 @@ jobs:
         with:
           cuda: "12.8.0"
           method: network
-          sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "curand", "curand_dev", "cufft", "cufft_dev", "cuda_runtime", "cuda_cudart"]'
+          # See note in build-windows-cuda: sub-package filtering is unsafe
+          # on Windows because component names differ from Linux. Default
+          # set installs cleanly.
 
       - uses: actions/cache@v5
         with:


### PR DESCRIPTION
…use installer exit 3772776473)

The Jimver/cuda-toolkit action passes the sub-packages list to NVIDIA's native installer. On Windows the component IDs differ from Linux — e.g. 'cudart_12.8' vs 'cudart' — so the Linux-style allowlist we inherited makes the installer abort with exit code 3772776473 (this matches reports on Jimver/cuda-toolkit issue #388).

Letting the action install the default set (~5 GB instead of ~2 GB, plus a few extra minutes of install time) is the most reliable path on Windows runners. The resulting CUDA_PATH is identical, so the downstream build steps need no changes.

Applies to both build-windows-cuda and build-windows-cuda-turboquant.