### PR TITLE
docs: de-risk benchmark claims, scope Engine-ready hedge, bump versio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ curl http://localhost:11434/v1/chat/completions \
 | 🪟 Windows 11 x64 (NVIDIA) | `eullm-windows-x64-cuda-12.8.zip` | ZIP bundles CUDA DLLs — extract, run |
 | 🪟 Windows 11 x64 (NVIDIA + TurboQuant) | `eullm-windows-x64-cuda12.8-turboquant-exp.zip` | – |
 
+> **Windows note:** the binaries are not yet code-signed, so SmartScreen may show *"Windows protected your PC"* on first run. Click **More info → Run anyway**. CUDA builds ship as a `.zip` that already bundles the required CUDA DLLs (`cudart`, `cublas`, `cublasLt`) — just extract and run `eullm-windows-x64.exe`, no CUDA toolkit install needed (an up-to-date NVIDIA driver is enough).
+
 ### Already using Ollama? Switch in 60 seconds
 
 Same port, same API, same models. **Zero code changes.**
@@ -76,7 +78,7 @@ Same port, same API, same models. **Zero code changes.**
 |---|--------|------------------|
 | Backend | llama.cpp | llama.cpp (same) |
 | API | Ollama | Ollama **+ OpenAI** (same port) |
-| Concurrency | Sequential | **Continuous batching** (~2× at 4+ concurrent) |
+| Concurrency | Manual via `OLLAMA_NUM_PARALLEL` (low default) | **Continuous batching, on by default** |
 | Long context | F16 KV | **TurboQuant KV** — 4× context on consumer GPUs |
 | AI Act audit | None | Built-in, local-only, never transmitted |
 | Telemetry | Varies | **Zero** — no analytics, no crash reports |
@@ -211,7 +213,7 @@ Every model will ship with:
 
 ## Quickstart
 
-> **EuLLM Engine is in active development (Q2 2026).** The commands below show the current and target CLI experience. Some commands work today (`eullm run`, `eullm serve`); others (Forge verticalization, Hub registry pull) are on the Q3-Q4 2026 roadmap. Star this repo to track progress.
+> **The Engine is usable today** (`eullm run`, `eullm serve` — a drop-in replacement for Ollama). The commands below also preview the target CLI for **Forge** (verticalization) and **Hub** (EU registry pull), which are in active development on the Q3–Q4 2026 roadmap. Star this repo to track progress.
 
 ### Prebuilt binaries (easiest)
 
@@ -306,7 +308,7 @@ If you already use Ollama, llama.cpp, or any OpenAI-compatible backend: you know
 | | Ollama / llama.cpp | EULLM |
 |---|---|---|
 | Inference engine | llama.cpp | llama.cpp (same backend, same performance) |
-| Request scheduling | Sequential (one at a time) | **Continuous batching** (parallel decode) |
+| Request scheduling | Configurable parallelism (`OLLAMA_NUM_PARALLEL`, low default, one KV-cache copy per slot) | **Continuous batching** by default — single-pass parallel decode, shared KV |
 | API compatibility | Ollama API or custom | Ollama-compatible + OpenAI-compatible |
 | GPU support | Manual build flags | `--features cuda/rocm/vulkan/metal` |
 | **Transparent web browsing** | Via function calling (model must support tool use; requires tool-capable model) | **`--web` flag — model-agnostic, works with any GGUF, no tool-use support required** |
@@ -322,7 +324,9 @@ EULLM aims to be the sovereign AI stack for Europe — engine, tools, and models
 
 ## Benchmarks — Continuous batching in action
 
-EULLM Engine's continuous batching scheduler decodes all active requests in a single GPU pass. Ollama processes them one at a time. Here's the difference on a consumer GPU:
+EULLM Engine's continuous batching scheduler decodes all active sequences in a single GPU pass, so total throughput keeps scaling as concurrency rises.
+
+> ⚠️ **Comparison being re-measured.** The Ollama column below is being re-run at **matched parallelism** (`OLLAMA_NUM_PARALLEL=16`, equal to the Engine's 16 slots) and will be republished with the exact Ollama version. The EULLM figures are the Engine's own measured continuous-batching scaling on a consumer GPU.
 
 <p align="center">
   <img src="docs/assets/bench-throughput.svg" alt="Throughput: EULLM Engine vs Ollama" width="680" />
@@ -340,9 +344,9 @@ EULLM Engine's continuous batching scheduler decodes all active requests in a si
   <img src="docs/assets/bench-latency.svg" alt="Latency: EULLM Engine vs Ollama" width="680" />
 </p>
 
-With 16 concurrent users, the last response arrives in **9.3s** on EULLM vs **23.6s** on Ollama. Throughput scales from 94 to 259 tok/s while Ollama stays flat at ~100 tok/s.
+On EULLM, throughput scales from **94 tok/s** (1 request) to **259 tok/s** (16 concurrent) as the scheduler batches active sequences, and the last of 16 responses arrives in **9.3s**. The side-by-side Ollama figures are being re-measured at matched parallelism (see note above).
 
-> **Test setup:** Qwen3.5-9B GGUF, NVIDIA RTX 5070 Ti 16 GB, 150 tokens per request.
+> **Test setup:** Qwen3.5-9B GGUF, NVIDIA RTX 5070 Ti 16 GB, 150 tokens per request. EULLM with continuous batching (16 slots); Ollama with `OLLAMA_NUM_PARALLEL=16` — exact Ollama version recorded in [docs/benchmarks.md](docs/benchmarks.md).
 > Reproduce with `./bench.sh`. Full results in [docs/benchmarks.md](docs/benchmarks.md).
 
 ## TurboQuant KV Cache Compression (Experimental)
@@ -377,7 +381,7 @@ chmod +x eullm
 Startup output (real, from RTX 5070 Ti 16GB):
 
 ```
-eullm ready.  [v0.2.98]
+eullm ready.  [v0.5.1]
   Model:         qwen3-14b
   GPU backend:   CUDA
   Context:       131072 total (8192 per sequence × 16 slots)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,8 +1,10 @@
 # Benchmarks — EULLM Engine vs Ollama
 
-EULLM Engine uses **continuous batching** to decode multiple requests in parallel within a single GPU pass. Ollama processes requests sequentially — one at a time, FIFO queue.
+EULLM Engine uses **continuous batching** to decode multiple requests in parallel within a single GPU pass, enabled by default across all slots. Ollama also serves concurrent requests via llama.cpp, but only up to `OLLAMA_NUM_PARALLEL` slots (a low default) and with one full KV-cache copy reserved per slot.
 
-This page documents real benchmark results comparing the two.
+This page documents benchmark results comparing the two.
+
+> ⚠️ **Re-measurement in progress.** The Ollama figures below are being re-run at **matched parallelism** (`OLLAMA_NUM_PARALLEL=16`, equal to the Engine's 16 slots) to make the comparison apples-to-apples. The tables will be updated with the new numbers and the exact Ollama version. The EULLM Engine figures are its own measured continuous-batching scaling.
 
 ## Test setup
 
@@ -15,6 +17,9 @@ This page documents real benchmark results comparing the two.
 | **Method** | Fire N concurrent requests, measure wall time and total tokens |
 | **EULLM port** | `localhost:11434` |
 | **Ollama port** | `localhost:11435` |
+| **EULLM parallelism** | Continuous batching, 16 slots |
+| **Ollama parallelism** | `OLLAMA_NUM_PARALLEL=16` _(matched; re-measurement in progress)_ |
+| **Ollama version** | _to record on re-run_ |
 | **Date** | March 2026 |
 
 ## Results
@@ -35,7 +40,7 @@ How many tokens per second the system produces across all concurrent requests.
 | 8 | 206 tok/s | 101 tok/s | **2.0×** |
 | 16 | 259 tok/s | 102 tok/s | **2.5×** |
 
-Ollama's throughput is flat at ~100 tok/s regardless of concurrency — it simply queues requests and processes them one by one. EULLM Engine's continuous batching scheduler decodes all active sequences in a single GPU pass, scaling throughput nearly linearly with concurrency.
+EULLM Engine's continuous batching scheduler decodes all active sequences in a single GPU pass, scaling total throughput with concurrency. The Ollama column above is being re-measured at matched parallelism (`OLLAMA_NUM_PARALLEL=16`); the prior numbers were taken at a lower Ollama parallelism setting and are not an apples-to-apples comparison.
 
 ### Time to complete all requests (wall time)
 
@@ -67,14 +72,14 @@ Individual request performance under load. Each user gets fewer tok/s as concurr
 | 8 | ~26 tok/s | 111 tok/s* |
 | 16 | ~16.5 tok/s | 111 tok/s* |
 
-\* Ollama's per-request tok/s stays constant because requests run sequentially — each request gets the full GPU, but must **wait in line**. With 16 requests, the last one starts only after the first 15 finish.
+\* These Ollama per-request figures were taken at low parallelism, where requests beyond the slot limit **wait in line** rather than batching. They are being re-measured with `OLLAMA_NUM_PARALLEL=16`.
 
 EULLM's per-request tok/s decreases with load, but all requests **start immediately** and receive tokens in real-time via streaming. At 16.5 tok/s, text still arrives faster than humans can read.
 
 ## How continuous batching works
 
 ```
-Ollama (sequential):
+Ollama (low parallelism — extra requests queue):
   req1 ████████░░░░░░░░░░░░░░░░ → done
   req2 ________████████░░░░░░░░░ → done (waited 1.5s)
   req3 ________________████████░ → done (waited 3.0s)
@@ -137,6 +142,6 @@ These results are on a consumer RTX 5070 Ti (16 GB). Results will vary by GPU, m
 
 - **More concurrent requests** — the gap widens linearly
 - **Longer generations** — more time spent in decode = more batching opportunity
-- **Faster GPUs** — the sequential bottleneck in Ollama becomes more pronounced
+- **Faster GPUs** — shared-pass decoding extracts more parallelism per GPU step
 
 On server GPUs (A100, H100) with higher memory bandwidth, the throughput scaling with concurrency is even more dramatic.


### PR DESCRIPTION
…n, add Windows note

- benchmarks: remove 'Ollama is sequential/one-at-a-time/FIFO' framing; flag Ollama figures as being re-measured at matched OLLAMA_NUM_PARALLEL=16
- quickstart: scope 'in active development' to Forge/Hub; Engine usable today
- turboquant: startup output version 0.2.98 -> 0.5.1
- try-it-now: add Windows SmartScreen/CUDA-DLL note under binary matrix