### PR TITLE
docs+bench: shift comparison axis to quality-at-equal-bit-width

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
   <a href="#try-it-now">Try it now</a> ·
   <a href="#whats-ready-today-whats-coming">Status</a> ·
   <a href="#the-solution">Engine</a> ·
-  <a href="#benchmarks--continuous-batching-in-action">Benchmarks</a> ·
-  <a href="#why-eullm">vs Ollama</a> ·
+  <a href="#benchmarks--continuous-batching-scaling">Benchmarks</a> ·
+  <a href="#why-eullm">Why EULLM</a> ·
   <a href="#turboquant-kv-cache-compression-experimental">TurboQuant</a> ·
   <a href="#planned-verticalized-models-q4-2026-roadmap">Roadmap</a> ·
   <a href="#contributing">Contributing</a> ·
@@ -20,7 +20,8 @@
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" />
   <img src="https://img.shields.io/badge/EU%20AI%20Act-Designed%20for%20compliance-gold" alt="EU AI Act" />
-  <img src="https://img.shields.io/badge/status-Early%20Development-orange" alt="Status" />
+  <img src="https://img.shields.io/badge/Engine-v0.5.1%20%E2%80%94%20usable%20today-2ea44f" alt="Engine status" />
+  <img src="https://img.shields.io/badge/Forge%20%2B%20Hub-Early%20development-orange" alt="Forge/Hub status" />
   <a href="https://github.com/eullm/eullm/actions/workflows/ci.yml"><img src="https://github.com/eullm/eullm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://doi.org/10.5281/zenodo.20412980"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20412980.svg" alt="DOI" /></a>
 </p>
@@ -64,27 +65,27 @@ curl http://localhost:11434/v1/chat/completions \
 
 > **Windows note:** the binaries are not yet code-signed, so SmartScreen may show *"Windows protected your PC"* on first run. Click **More info → Run anyway**. CUDA builds ship as a `.zip` that already bundles the required CUDA DLLs (`cudart`, `cublas`, `cublasLt`) — just extract and run `eullm-windows-x64.exe`, no CUDA toolkit install needed (an up-to-date NVIDIA driver is enough).
 
-### Already using Ollama? Switch in 60 seconds
+### Drop-in for Ollama-compatible clients
 
-Same port, same API, same models. **Zero code changes.**
+Same port (11434), same Ollama API, plus OpenAI-compatible API on the same binary. Existing tooling (Open WebUI, LangChain, n8n, any OpenAI client) works without code changes:
 
 ```bash
 # Was:   ollama run llama3
 # Now:   eullm run ./your-model.gguf --port 11434
-# Done. Open WebUI, LangChain, n8n, any OpenAI client — all work unchanged.
 ```
 
-| | Ollama | **EULLM Engine** |
-|---|--------|------------------|
-| Backend | llama.cpp | llama.cpp (same) |
-| API | Ollama | Ollama **+ OpenAI** (same port) |
-| Concurrency | Manual via `OLLAMA_NUM_PARALLEL` (low default) | **Continuous batching, on by default** |
-| Long context | F16 KV | **TurboQuant KV** — 4× context on consumer GPUs |
-| AI Act audit | None | Built-in, local-only, never transmitted |
-| Telemetry | Varies | **Zero** — no analytics, no crash reports |
-| Migration cost | — | **Drop-in** |
+What you get on top of the Ollama-compatible API:
 
-[→ Full benchmarks](#benchmarks--continuous-batching-in-action) · [→ Detailed comparison](#why-eullm) · [→ Engine deep dive](#the-solution)
+| Capability | EULLM Engine |
+|---|---|
+| **Continuous batching** scheduler — single-pass parallel decode across all active slots, shared KV pool (no per-slot KV pre-allocation) | ✅ on by default |
+| **TurboQuant KV cache compression** — 4× context length on the same GPU (~1% accuracy delta on matrix ops only) | ✅ flag `--cache-type-k tq4_0` |
+| **AI Act audit trail** — local-only JSONL of every request/response, never transmitted | ✅ on by default |
+| **Zero telemetry** — no analytics, no crash reports, no usage stats | ✅ enforced |
+| **Single binary** — Rust, no Go runtime, no Python runtime, no Docker | ✅ |
+| **EU-hosted model registry** (Forge/Hub) | 🚧 in development |
+
+[→ Engine scaling](#benchmarks--continuous-batching-scaling) · [→ Why EULLM](#why-eullm) · [→ TurboQuant](#turboquant-kv-cache-compression-experimental)
 
 ## What's ready today, what's coming
 
@@ -322,32 +323,29 @@ If you already use Ollama, llama.cpp, or any OpenAI-compatible backend: you know
 
 EULLM aims to be the sovereign AI stack for Europe — engine, tools, and models in one platform.
 
-## Benchmarks — Continuous batching in action
+## Benchmarks — Continuous batching scaling
 
-EULLM Engine's continuous batching scheduler decodes all active sequences in a single GPU pass, so total throughput keeps scaling as concurrency rises.
-
-> ⚠️ **Comparison being re-measured.** The Ollama column below is being re-run at **matched parallelism** (`OLLAMA_NUM_PARALLEL=16`, equal to the Engine's 16 slots) and will be republished with the exact Ollama version. The EULLM figures are the Engine's own measured continuous-batching scaling on a consumer GPU.
+EULLM Engine's continuous batching scheduler decodes all active sequences in a single GPU pass, so total throughput scales with concurrency instead of being capped by a per-slot pre-allocated KV cache.
 
 <p align="center">
-  <img src="docs/assets/bench-throughput.svg" alt="Throughput: EULLM Engine vs Ollama" width="680" />
+  <img src="docs/assets/bench-throughput.svg" alt="EULLM Engine throughput scaling 1→16 concurrent" width="680" />
 </p>
 
-| Concurrent requests | EULLM Engine | Ollama | Speedup |
+| Concurrent requests | EULLM Engine throughput | Per-request | Wall time (16×150 tok) |
 |:---:|:---:|:---:|:---:|
-| 1 | 94 tok/s | 93 tok/s | 1.0× |
-| 2 | 143 tok/s | 97 tok/s | **1.5×** |
-| 4 | 183 tok/s | 100 tok/s | **1.8×** |
-| 8 | 206 tok/s | 101 tok/s | **2.0×** |
-| 16 | 259 tok/s | 102 tok/s | **2.5×** |
+| 1 | 94 tok/s | 94 tok/s | 1.6 s |
+| 2 | 143 tok/s | ~71 tok/s | 2.1 s |
+| 4 | 183 tok/s | ~46 tok/s | 3.3 s |
+| 8 | 206 tok/s | ~26 tok/s | 5.8 s |
+| 16 | **259 tok/s** | ~16.5 tok/s | **9.3 s** |
 
 <p align="center">
-  <img src="docs/assets/bench-latency.svg" alt="Latency: EULLM Engine vs Ollama" width="680" />
+  <img src="docs/assets/bench-latency.svg" alt="EULLM wall time vs concurrency" width="680" />
 </p>
 
-On EULLM, throughput scales from **94 tok/s** (1 request) to **259 tok/s** (16 concurrent) as the scheduler batches active sequences, and the last of 16 responses arrives in **9.3s**. The side-by-side Ollama figures are being re-measured at matched parallelism (see note above).
+Throughput scales **2.75×** from 1 to 16 concurrent requests, and with 16 active requests every user starts receiving tokens immediately via SSE streaming instead of queueing for a slot.
 
-> **Test setup:** Qwen3.5-9B GGUF, NVIDIA RTX 5070 Ti 16 GB, 150 tokens per request. EULLM with continuous batching (16 slots); Ollama with `OLLAMA_NUM_PARALLEL=16` — exact Ollama version recorded in [docs/benchmarks.md](docs/benchmarks.md).
-> Reproduce with `./bench.sh`. Full results in [docs/benchmarks.md](docs/benchmarks.md).
+> **Test setup:** Qwen3.5-9B GGUF, NVIDIA RTX 5070 Ti 16 GB, 150 tokens per request, continuous batching with 16 slots. Reproduce with `./bench.sh`. Methodology in [docs/benchmarks.md](docs/benchmarks.md).
 
 ## TurboQuant KV Cache Compression (Experimental)
 
@@ -422,21 +420,25 @@ No compilation. No patch to llama.cpp. Download the binary, add two flags, done.
   <img src="bench/results/turboquant_20260329_224511/chart_ttft.png" alt="TTFT comparison" width="680" />
 </p>
 
-### Quality impact
+### Quality impact — at equal bit-width
 
-100 verified tests, temperature=0. The only variable: KV cache type.
+100 verified tests, temperature=0, fixed seed, identical prompts. **The only variable is the KV cache type.** The interesting comparison is at equal bit-width: **TQ4_0 (4-bit TurboQuant) vs Q4_0 (4-bit native llama.cpp)** — same memory budget, different quantization algorithm (Walsh-Hadamard + Lloyd-Max vs round-to-nearest). Q8_0 is included as a near-lossless reference.
 
 <p align="center">
-  <img src="bench/results/chart_quality_comparison.png" alt="Quality: F16=86%, TQ4_0=85%, TQ3_0=85%" width="720" />
+  <img src="bench/results/chart_quality_comparison.png" alt="KV cache quality comparison across F16, Q8_0, Q4_0, TQ4_0, TQ3_0" width="720" />
 </p>
 
-| Cache | Score | Matrix | Math | Factual | Logic | Code |
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| F16 | **86%** | 18/20 | 18/20 | 15/20 | 17/20 | 18/20 |
-| TQ4_0 | **85%** | 17/20 | 18/20 | 15/20 | 17/20 | 18/20 |
-| TQ3_0 | **85%** | 17/20 | 18/20 | 15/20 | 17/20 | 18/20 |
+| Cache | Bits | Score | Matrix | Math | Factual | Logic | Code |
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| F16 (baseline) | 16 | **86%** | 18/20 | 18/20 | 15/20 | 17/20 | 18/20 |
+| Q8_0 (native) | 8 | _re-measuring_ | – | – | – | – | – |
+| Q4_0 (native) | 4 | _re-measuring_ | – | – | – | – | – |
+| **TQ4_0** (TurboQuant) | 4 | **85%** | 17/20 | 18/20 | 15/20 | 17/20 | 18/20 |
+| TQ3_0 (TurboQuant) | 3 | **85%** | 17/20 | 18/20 | 15/20 | 17/20 | 18/20 |
 
-**1% degradation, isolated to matrix operations.** Math, factual, logic, and code are identical across all cache types. Full test-by-test analysis: [docs/turboquant-quality-report.md](docs/turboquant-quality-report.md).
+> The Q8_0 and Q4_0 rows are being measured with the same harness — see `bench/run_quality_arms.sh` to reproduce on your own hardware. The comparison that matters for TurboQuant's claim is **TQ4_0 vs Q4_0** (same 4-bit memory budget); if TQ4_0 does not beat Q4_0 at the same bit budget, the numbers will be published unmodified.
+
+Full test-by-test analysis: [docs/turboquant-quality-report.md](docs/turboquant-quality-report.md).
 
 ### Trade-off
 

--- a/bench/generate_quality_charts.py
+++ b/bench/generate_quality_charts.py
@@ -1,102 +1,178 @@
 #!/usr/bin/env python3
-"""Generate quality comparison chart for TurboQuant README."""
+"""Generate quality comparison charts from per-arm JSON results.
+
+Reads bench/results/quality_*.json (produced by `turboquant_quality.py collect`)
+and emits chart_quality_comparison.png + chart_quality_radar.png.
+
+Arms recognized (any subset can be present):
+  F16, Q8_0, Q4_0, TQ4_0, TQ3_0
+
+The label inside each JSON drives ordering and styling.
+"""
+
+import glob
+import json
+import os
+import sys
 
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
-import os
 
-OUTPUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "results")
-os.makedirs(OUTPUT_DIR, exist_ok=True)
+RESULTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "results")
 
-# ── Data from 100-test benchmark ─────────────────────────────────────────────
+# Display order + style for each known arm.
+ARM_STYLE = {
+    "F16":   {"color": "#6c757d", "label": "F16 (baseline)"},
+    "Q8_0":  {"color": "#212529", "label": "Q8_0 (8-bit native llama.cpp)"},
+    "Q4_0":  {"color": "#dc3545", "label": "Q4_0 (4-bit native llama.cpp)"},
+    "TQ4_0": {"color": "#0d6efd", "label": "TQ4_0 (4-bit TurboQuant)"},
+    "TQ3_0": {"color": "#198754", "label": "TQ3_0 (3-bit TurboQuant)"},
+}
+ARM_ORDER = ["F16", "Q8_0", "Q4_0", "TQ4_0", "TQ3_0"]
 
-categories = ["Matrix", "Math", "Factual", "Logic", "Code", "TOTAL"]
+CATEGORIES = ["matrix", "math", "factual", "logic", "code"]
+CATEGORY_DISPLAY = ["Matrix", "Math", "Factual", "Logic", "Code"]
 
-f16   = [18, 18, 15, 17, 18, 86]
-tq4_0 = [17, 18, 15, 17, 18, 85]
-tq3_0 = [17, 18, 15, 17, 18, 85]
 
-totals = [20, 20, 20, 20, 20, 100]
+def load_arms(pattern: str) -> dict:
+    """Load every quality_*.json matching the pattern. Returns {label: data}."""
+    arms = {}
+    for path in sorted(glob.glob(pattern)):
+        with open(path) as fh:
+            data = json.load(fh)
+        label = data.get("label", os.path.basename(path))
+        arms[label.upper()] = data
+    return arms
 
-f16_pct   = [v/t*100 for v, t in zip(f16, totals)]
-tq4_pct   = [v/t*100 for v, t in zip(tq4_0, totals)]
-tq3_pct   = [v/t*100 for v, t in zip(tq3_0, totals)]
 
-# ── Chart: Quality comparison bar chart ──────────────────────────────────────
+def ordered_arms(arms: dict) -> list:
+    """Return arms in canonical display order; unknown labels appended at end."""
+    known = [a for a in ARM_ORDER if a in arms]
+    extra = [a for a in arms if a not in ARM_ORDER]
+    return known + extra
 
-fig, ax = plt.subplots(figsize=(14, 7))
-x = np.arange(len(categories))
-width = 0.25
 
-bars1 = ax.bar(x - width, f16_pct, width, label="F16 (baseline)", color="#6c757d", edgecolor="white")
-bars2 = ax.bar(x, tq4_pct, width, label="TQ4_0 (4-bit KV)", color="#0d6efd", edgecolor="white")
-bars3 = ax.bar(x + width, tq3_pct, width, label="TQ3_0 (3-bit KV)", color="#198754", edgecolor="white")
+def bar_chart(arms: dict, out_path: str) -> None:
+    labels = ordered_arms(arms)
+    if not labels:
+        print("No arms to plot — skipping bar chart.")
+        return
 
-# Add value labels
-for bars, values, total_vals in [(bars1, f16, totals), (bars2, tq4_0, totals), (bars3, tq3_0, totals)]:
-    for bar, val, tot in zip(bars, values, total_vals):
-        pct = val/tot*100
-        ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 0.5,
-                f"{val}/{tot}", ha="center", va="bottom", fontsize=10, fontweight="bold")
+    # Build matrix [arm][category] of passed counts and totals.
+    passed = {a: [] for a in labels}
+    totals = {a: [] for a in labels}
+    for a in labels:
+        cats = arms[a].get("categories", {})
+        for c in CATEGORIES:
+            v = cats.get(c, {"passed": 0, "total": 0})
+            passed[a].append(v["passed"])
+            totals[a].append(v["total"])
 
-# Styling
-ax.set_ylabel("Accuracy (%)", fontsize=13)
-ax.set_title("TurboQuant Quality Impact — 100 Verified Tests\n"
-             "Qwen3-14B Q4_K_M, temperature=0, RTX 5070 Ti 16GB",
-             fontsize=15, fontweight="bold")
-ax.set_xticks(x)
-ax.set_xticklabels(categories, fontsize=12)
-ax.set_ylim(0, 105)
-ax.legend(fontsize=12, loc="lower right")
-ax.grid(axis="y", alpha=0.3)
-ax.set_axisbelow(True)
+    # Add TOTAL column
+    cat_display = CATEGORY_DISPLAY + ["TOTAL"]
+    for a in labels:
+        passed[a].append(sum(passed[a]))
+        totals[a].append(sum(totals[a]))
 
-# Add annotation
-ax.annotate("1% degradation\n4.3× more context",
-            xy=(5, 87), fontsize=14, fontweight="bold",
-            color="#198754", ha="center",
-            bbox=dict(boxstyle="round,pad=0.3", facecolor="#d4edda", edgecolor="#198754", alpha=0.8))
+    n_arms = len(labels)
+    width = 0.8 / max(n_arms, 1)
+    x = np.arange(len(cat_display))
 
-plt.tight_layout()
-plt.savefig(os.path.join(OUTPUT_DIR, "chart_quality_comparison.png"), dpi=150)
-print(f"Saved: {OUTPUT_DIR}/chart_quality_comparison.png")
+    fig, ax = plt.subplots(figsize=(15, 7.5))
+    for i, a in enumerate(labels):
+        style = ARM_STYLE.get(a, {"color": "#888", "label": a})
+        offset = (i - (n_arms - 1) / 2) * width
+        pcts = [p / t * 100 if t else 0 for p, t in zip(passed[a], totals[a])]
+        bars = ax.bar(x + offset, pcts, width, label=style["label"],
+                      color=style["color"], edgecolor="white")
+        for bar, p, t in zip(bars, passed[a], totals[a]):
+            ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.5,
+                    f"{p}/{t}", ha="center", va="bottom",
+                    fontsize=9, fontweight="bold")
 
-# ── Chart 2: Radar/spider chart ──────────────────────────────────────────────
+    # Metadata from any arm
+    meta = next(iter(arms.values()))
+    model = meta.get("model", "unknown model")
+    temp = meta.get("temperature", "?")
+    total_tests = meta.get("score", {}).get("total", "?")
 
-cats_radar = ["Matrix", "Math", "Factual", "Logic", "Code"]
-f16_r = [90, 90, 75, 85, 90]
-tq4_r = [85, 90, 75, 85, 90]
-tq3_r = [85, 90, 75, 85, 90]
+    ax.set_ylabel("Accuracy (%)", fontsize=13)
+    ax.set_title(
+        f"KV Cache Quality Impact — {total_tests} Verified Tests\n"
+        f"{model}, temperature={temp}",
+        fontsize=15, fontweight="bold",
+    )
+    ax.set_xticks(x)
+    ax.set_xticklabels(cat_display, fontsize=12)
+    ax.set_ylim(0, 110)
+    ax.legend(fontsize=11, loc="lower right", ncol=1)
+    ax.grid(axis="y", alpha=0.3)
+    ax.set_axisbelow(True)
 
-angles = np.linspace(0, 2 * np.pi, len(cats_radar), endpoint=False).tolist()
-angles += angles[:1]  # close the polygon
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=150)
+    print(f"Saved: {out_path}")
 
-f16_r += f16_r[:1]
-tq4_r += tq4_r[:1]
-tq3_r += tq3_r[:1]
 
-fig, ax = plt.subplots(figsize=(8, 8), subplot_kw=dict(polar=True))
+def radar_chart(arms: dict, out_path: str) -> None:
+    labels = ordered_arms(arms)
+    if not labels:
+        print("No arms to plot — skipping radar chart.")
+        return
 
-ax.plot(angles, f16_r, 'o-', linewidth=2.5, label='F16', color='#6c757d', markersize=8)
-ax.fill(angles, f16_r, alpha=0.1, color='#6c757d')
+    angles = np.linspace(0, 2 * np.pi, len(CATEGORIES), endpoint=False).tolist()
+    angles += angles[:1]
 
-ax.plot(angles, tq4_r, 's-', linewidth=2.5, label='TQ4_0', color='#0d6efd', markersize=8)
-ax.fill(angles, tq4_r, alpha=0.1, color='#0d6efd')
+    fig, ax = plt.subplots(figsize=(8, 8), subplot_kw=dict(polar=True))
+    for a in labels:
+        style = ARM_STYLE.get(a, {"color": "#888", "label": a})
+        cats = arms[a].get("categories", {})
+        vals = []
+        for c in CATEGORIES:
+            v = cats.get(c, {"passed": 0, "total": 1})
+            vals.append(v["passed"] / max(v["total"], 1) * 100)
+        vals += vals[:1]
+        ax.plot(angles, vals, "o-", linewidth=2.5, label=style["label"],
+                color=style["color"], markersize=7)
+        ax.fill(angles, vals, alpha=0.08, color=style["color"])
 
-ax.plot(angles, tq3_r, '^-', linewidth=2.5, label='TQ3_0', color='#198754', markersize=8)
-ax.fill(angles, tq3_r, alpha=0.1, color='#198754')
+    ax.set_xticks(angles[:-1])
+    ax.set_xticklabels(CATEGORY_DISPLAY, fontsize=12)
+    ax.set_ylim(0, 100)
+    ax.set_yticks([25, 50, 75, 100])
+    ax.set_yticklabels(["25%", "50%", "75%", "100%"], fontsize=9)
 
-ax.set_xticks(angles[:-1])
-ax.set_xticklabels(cats_radar, fontsize=13)
-ax.set_ylim(0, 100)
-ax.set_yticks([25, 50, 75, 100])
-ax.set_yticklabels(["25%", "50%", "75%", "100%"], fontsize=9)
-ax.set_title("Quality by Category\n100 Tests, Qwen3-14B", fontsize=14, fontweight="bold", pad=20)
-ax.legend(loc="lower right", fontsize=11, bbox_to_anchor=(1.15, -0.05))
-ax.grid(True, alpha=0.3)
+    meta = next(iter(arms.values()))
+    model = meta.get("model", "unknown model")
+    total_tests = meta.get("score", {}).get("total", "?")
+    ax.set_title(
+        f"Quality by Category — {total_tests} Tests, {model}",
+        fontsize=13, fontweight="bold", pad=20,
+    )
+    ax.legend(loc="lower right", fontsize=10, bbox_to_anchor=(1.25, -0.05))
+    ax.grid(True, alpha=0.3)
 
-plt.tight_layout()
-plt.savefig(os.path.join(OUTPUT_DIR, "chart_quality_radar.png"), dpi=150)
-print(f"Saved: {OUTPUT_DIR}/chart_quality_radar.png")
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=150)
+    print(f"Saved: {out_path}")
+
+
+def main() -> int:
+    pattern = sys.argv[1] if len(sys.argv) > 1 else os.path.join(RESULTS_DIR, "quality_*.json")
+    arms = load_arms(pattern)
+    if not arms:
+        print(f"ERROR: no JSON files matched {pattern}", file=sys.stderr)
+        print("Run `bench/run_quality_arms.sh` first to produce per-arm results.",
+              file=sys.stderr)
+        return 1
+
+    print(f"Loaded arms: {', '.join(ordered_arms(arms))}")
+    bar_chart(arms, os.path.join(RESULTS_DIR, "chart_quality_comparison.png"))
+    radar_chart(arms, os.path.join(RESULTS_DIR, "chart_quality_radar.png"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/run_quality_arms.sh
+++ b/bench/run_quality_arms.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Run the KV cache quality benchmark across 5 arms (F16, Q8_0, Q4_0, TQ4_0, TQ3_0)
+# against the same model with the same prompts and seed.
+#
+# Usage:
+#   ./bench/run_quality_arms.sh <model.gguf> [<eullm-binary>] [<model-name>]
+#
+# Defaults:
+#   eullm-binary = ./target/release/eullm (or 'eullm' from PATH if missing)
+#   model-name   = qwen3-14b
+#   ctx-size     = 8192
+#   port         = 11434
+#
+# Requires the engine to be built with --features turboquant_native for TQ arms.
+
+set -uo pipefail
+
+MODEL_PATH="${1:?Usage: ./bench/run_quality_arms.sh <model.gguf> [<eullm-bin>] [<model-name>]}"
+EULLM_BIN="${2:-./target/release/eullm}"
+MODEL_NAME="${3:-qwen3-14b}"
+CTX_SIZE="${CTX_SIZE:-8192}"
+PORT="${PORT:-11434}"
+TEMPERATURE="${TEMPERATURE:-0.0}"
+
+if [[ ! -x "$EULLM_BIN" ]]; then
+  if command -v eullm >/dev/null 2>&1; then
+    EULLM_BIN="$(command -v eullm)"
+    echo "Using eullm from PATH: $EULLM_BIN"
+  else
+    echo "ERROR: eullm binary not found at '$EULLM_BIN' and not in PATH." >&2
+    exit 1
+  fi
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESULTS_DIR="$REPO_ROOT/bench/results"
+LOG_DIR="$RESULTS_DIR/quality_arm_logs"
+mkdir -p "$RESULTS_DIR" "$LOG_DIR"
+
+# Arms: (label, cache-type-k, cache-type-v, requires-turboquant)
+ARMS=(
+  "F16:f16:f16:0"
+  "Q8_0:q8_0:q8_0:0"
+  "Q4_0:q4_0:q4_0:0"
+  "TQ4_0:tq4_0:tq4_0:1"
+  "TQ3_0:tq3_0:tq3_0:1"
+)
+
+cleanup() {
+  if [[ -n "${ENGINE_PID:-}" ]] && kill -0 "$ENGINE_PID" 2>/dev/null; then
+    echo "Stopping engine (pid $ENGINE_PID)..."
+    kill -TERM "$ENGINE_PID" 2>/dev/null || true
+    sleep 1
+    kill -KILL "$ENGINE_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+wait_for_engine() {
+  local url="http://localhost:${PORT}/api/tags"
+  for _ in $(seq 1 60); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: engine did not come up on port $PORT within 60s." >&2
+  return 1
+}
+
+echo "Quality benchmark — 5 arms"
+echo "  Binary:  $EULLM_BIN"
+echo "  Model:   $MODEL_PATH ($MODEL_NAME)"
+echo "  Ctx:    $CTX_SIZE  Port: $PORT  Temp: $TEMPERATURE"
+echo "  Results: $RESULTS_DIR/quality_<arm>.json"
+echo
+
+for entry in "${ARMS[@]}"; do
+  IFS=':' read -r LABEL CK CV NEEDS_TQ <<<"$entry"
+  echo "==================================================================="
+  echo "ARM: $LABEL  (cache-type-k=$CK, cache-type-v=$CV)"
+  echo "==================================================================="
+
+  ENGINE_LOG="$LOG_DIR/engine_${LABEL}.log"
+  OUT_JSON="$RESULTS_DIR/quality_${LABEL}.json"
+
+  # Start engine
+  "$EULLM_BIN" run "$MODEL_PATH" \
+      --port "$PORT" \
+      --ctx-size "$CTX_SIZE" \
+      --cache-type-k "$CK" \
+      --cache-type-v "$CV" \
+      > "$ENGINE_LOG" 2>&1 &
+  ENGINE_PID=$!
+  echo "  engine pid=$ENGINE_PID  log=$ENGINE_LOG"
+
+  if ! wait_for_engine; then
+    echo "  Tail of engine log:"
+    tail -n 30 "$ENGINE_LOG" || true
+    if [[ "$NEEDS_TQ" == "1" ]]; then
+      echo "  SKIP — TurboQuant arm; engine likely not built with --features turboquant_native."
+      kill -TERM "$ENGINE_PID" 2>/dev/null || true
+      wait "$ENGINE_PID" 2>/dev/null || true
+      continue
+    else
+      exit 1
+    fi
+  fi
+
+  # Run the prompts
+  python3 "$REPO_ROOT/bench/turboquant_quality.py" collect \
+      --url "http://localhost:${PORT}" \
+      --model "$MODEL_NAME" \
+      --label "$LABEL" \
+      --temperature "$TEMPERATURE" \
+      --output "$OUT_JSON"
+
+  # Stop engine
+  kill -TERM "$ENGINE_PID" 2>/dev/null || true
+  wait "$ENGINE_PID" 2>/dev/null || true
+  unset ENGINE_PID
+  echo
+done
+
+echo "All arms complete. Regenerating charts..."
+python3 "$REPO_ROOT/bench/generate_quality_charts.py" "$RESULTS_DIR/quality_*.json"
+
+echo
+echo "Markdown summary:"
+python3 "$REPO_ROOT/bench/turboquant_quality.py" compare \
+    "$RESULTS_DIR"/quality_*.json --markdown | tail -n 20
+
+echo
+echo "Done. Send to repo:"
+echo "  bench/results/quality_*.json"
+echo "  bench/results/chart_quality_comparison.png"
+echo "  bench/results/chart_quality_radar.png"

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,10 +1,8 @@
-# Benchmarks — EULLM Engine vs Ollama
+# Benchmarks — EULLM Engine continuous batching
 
-EULLM Engine uses **continuous batching** to decode multiple requests in parallel within a single GPU pass, enabled by default across all slots. Ollama also serves concurrent requests via llama.cpp, but only up to `OLLAMA_NUM_PARALLEL` slots (a low default) and with one full KV-cache copy reserved per slot.
+EULLM Engine uses **continuous batching** to decode multiple requests in parallel within a single GPU pass, enabled by default across all slots. The scheduler runs a dedicated decode loop on an OS thread; each iteration calls `llama_decode` with a batch containing tokens from every active sequence, so requests start receiving tokens immediately instead of queueing for a slot.
 
-This page documents benchmark results comparing the two.
-
-> ⚠️ **Re-measurement in progress.** The Ollama figures below are being re-run at **matched parallelism** (`OLLAMA_NUM_PARALLEL=16`, equal to the Engine's 16 slots) to make the comparison apples-to-apples. The tables will be updated with the new numbers and the exact Ollama version. The EULLM Engine figures are its own measured continuous-batching scaling.
+This page documents how that scaling behaves on a consumer GPU.
 
 ## Test setup
 
@@ -15,88 +13,63 @@ This page documents benchmark results comparing the two.
 | **Tokens per request** | 150 (`num_predict=150`) |
 | **Benchmark script** | [`bench.sh`](../bench.sh) |
 | **Method** | Fire N concurrent requests, measure wall time and total tokens |
-| **EULLM port** | `localhost:11434` |
-| **Ollama port** | `localhost:11435` |
-| **EULLM parallelism** | Continuous batching, 16 slots |
-| **Ollama parallelism** | `OLLAMA_NUM_PARALLEL=16` _(matched; re-measurement in progress)_ |
-| **Ollama version** | _to record on re-run_ |
+| **Engine port** | `localhost:11434` |
+| **Engine parallelism** | Continuous batching, 16 slots, shared KV cache pool |
 | **Date** | March 2026 |
 
-## Results
+## Results — Engine scaling
 
 ### Total throughput
 
 How many tokens per second the system produces across all concurrent requests.
 
 <p align="center">
-  <img src="assets/bench-throughput.svg" alt="Throughput: EULLM vs Ollama" width="720" />
+  <img src="assets/bench-throughput.svg" alt="Engine throughput scaling 1→16 concurrent" width="720" />
 </p>
 
-| Concurrent requests | EULLM Engine | Ollama | Speedup |
-|:---:|:---:|:---:|:---:|
-| 1 | 94 tok/s | 93 tok/s | 1.0× |
-| 2 | 143 tok/s | 97 tok/s | **1.5×** |
-| 4 | 183 tok/s | 100 tok/s | **1.8×** |
-| 8 | 206 tok/s | 101 tok/s | **2.0×** |
-| 16 | 259 tok/s | 102 tok/s | **2.5×** |
+| Concurrent requests | Engine throughput | Speedup vs N=1 |
+|:---:|:---:|:---:|
+| 1 | 94 tok/s | 1.0× |
+| 2 | 143 tok/s | **1.5×** |
+| 4 | 183 tok/s | **1.9×** |
+| 8 | 206 tok/s | **2.2×** |
+| 16 | **259 tok/s** | **2.75×** |
 
-EULLM Engine's continuous batching scheduler decodes all active sequences in a single GPU pass, scaling total throughput with concurrency. The Ollama column above is being re-measured at matched parallelism (`OLLAMA_NUM_PARALLEL=16`); the prior numbers were taken at a lower Ollama parallelism setting and are not an apples-to-apples comparison.
+Continuous batching extracts more throughput per GPU step as concurrency rises because the same forward pass amortises across multiple sequences.
 
 ### Time to complete all requests (wall time)
 
-How long until all N concurrent requests have finished — the metric that matters for user experience.
+How long until every concurrent request has finished — the metric that matters for user experience.
 
 <p align="center">
-  <img src="assets/bench-latency.svg" alt="Latency: EULLM vs Ollama" width="720" />
+  <img src="assets/bench-latency.svg" alt="Engine wall time vs concurrency" width="720" />
 </p>
 
-| Concurrent requests | EULLM Engine | Ollama | |
-|:---:|:---:|:---:|:---:|
-| 1 | 1.6s | 1.6s | identical |
-| 2 | 2.1s | 3.1s | 1.5× faster |
-| 4 | 3.3s | 6.0s | 1.8× faster |
-| 8 | 5.8s | 11.9s | **2.0× faster** |
-| 16 | 9.3s | 23.6s | **2.5× faster** |
+| Concurrent requests | Engine wall time (16×150 tok) |
+|:---:|:---:|
+| 1 | 1.6 s |
+| 2 | 2.1 s |
+| 4 | 3.3 s |
+| 8 | 5.8 s |
+| 16 | **9.3 s** |
 
-With 16 concurrent users, the last user on Ollama waits **23.6 seconds**. On EULLM Engine, everyone gets their response within **9.3 seconds**.
+With 16 concurrent users, the slowest of the 16 responses still finishes within ~9 seconds, and every user starts receiving tokens via SSE streaming immediately — no slot queueing.
 
 ### Per-request latency
 
-Individual request performance under load. Each user gets fewer tok/s as concurrency increases (the GPU time is shared), but tokens arrive steadily via SSE streaming.
+Individual request performance under load. Each user gets fewer tok/s as concurrency increases (the GPU time is shared between active sequences), but tokens arrive steadily via SSE streaming.
 
-| Concurrent requests | EULLM per-request | Ollama per-request |
-|:---:|:---:|:---:|
-| 1 | 97.6 tok/s | 111 tok/s |
-| 2 | ~74 tok/s | 111 tok/s* |
-| 4 | ~47 tok/s | 111 tok/s* |
-| 8 | ~26 tok/s | 111 tok/s* |
-| 16 | ~16.5 tok/s | 111 tok/s* |
+| Concurrent requests | Engine per-request |
+|:---:|:---:|
+| 1 | 97.6 tok/s |
+| 2 | ~71 tok/s |
+| 4 | ~46 tok/s |
+| 8 | ~26 tok/s |
+| 16 | ~16.5 tok/s |
 
-\* These Ollama per-request figures were taken at low parallelism, where requests beyond the slot limit **wait in line** rather than batching. They are being re-measured with `OLLAMA_NUM_PARALLEL=16`.
+At ~16 tok/s text still arrives faster than humans can read; the trade-off chosen by continuous batching is "everyone gets tokens in real-time" rather than "one user at full speed, the rest queued."
 
-EULLM's per-request tok/s decreases with load, but all requests **start immediately** and receive tokens in real-time via streaming. At 16.5 tok/s, text still arrives faster than humans can read.
-
-## How continuous batching works
-
-```
-Ollama (low parallelism — extra requests queue):
-  req1 ████████░░░░░░░░░░░░░░░░ → done
-  req2 ________████████░░░░░░░░░ → done (waited 1.5s)
-  req3 ________________████████░ → done (waited 3.0s)
-  req4 ________________________█ → done (waited 4.5s)
-  Wall time: ~6.0s for 4 requests
-
-EULLM Engine (continuous batching):
-  req1 ██████████████ → done
-  req2 ██████████████ → done     (all start immediately)
-  req3 ██████████████ → done
-  req4 ██████████████ → done
-  Wall time: ~3.3s for 4 requests
-```
-
-The scheduler runs a dedicated decode loop on an OS thread. Each iteration calls `llama_decode` with a batch containing tokens from all active sequences. Per-sequence KV cache is managed independently, so sequences can start and finish at any time without blocking others.
-
-## Reproduce these benchmarks
+## Reproduce
 
 ### Stress test with parallelism verification (recommended)
 
@@ -105,16 +78,8 @@ The [`bench/stress_test.py`](../bench/stress_test.py) script uses streaming to t
 ```bash
 pip install aiohttp
 
-# Test EULLM (streaming, with parallelism analysis)
 python bench/stress_test.py --url http://localhost:11434 --model Qwen3.5-9B-Q4_K_M \
     --concurrency 1,2,4,8,16 --tokens 150 --warmup --json results_eullm.json
-
-# Test Ollama
-python bench/stress_test.py --url http://localhost:11435 --model qwen3.5:9b \
-    --concurrency 1,2,4,8,16 --tokens 150 --warmup --json results_ollama.json
-
-# Or compare both at once
-./bench/compare.sh Qwen3.5-9B-Q4_K_M qwen3.5:9b --concurrency 1,2,4,8,16 --tokens 150
 ```
 
 ### Quick throughput benchmark
@@ -122,26 +87,22 @@ python bench/stress_test.py --url http://localhost:11435 --model qwen3.5:9b \
 The [`bench.sh`](../bench.sh) script fires N concurrent non-streaming requests and measures wall time. Simpler but does not verify parallelism.
 
 ```bash
-# Build EULLM Engine with CUDA
+# Build Engine with CUDA
 cargo build --release --features cuda
 
-# Run EULLM Engine
+# Run Engine
 ./target/release/eullm run ./Qwen3.5-9B-Q4_K_M.gguf --batch-size 16
 
 # In another terminal, run the benchmark
 ./bench.sh http://localhost:11434 Qwen3.5-9B-GGUF
-
-# Compare with Ollama (on a different port)
-ollama serve  # default port 11435 or configure
-./bench.sh http://localhost:11435 qwen3.5:9b
 ```
 
 ## Hardware notes
 
-These results are on a consumer RTX 5070 Ti (16 GB). Results will vary by GPU, model size, and quantization level. The relative advantage of continuous batching increases with:
+These results are on a consumer RTX 5070 Ti (16 GB). Results will vary by GPU, model size, and quantization level. The relative gain of continuous batching grows with:
 
-- **More concurrent requests** — the gap widens linearly
+- **More concurrent requests** — the speedup vs N=1 widens
 - **Longer generations** — more time spent in decode = more batching opportunity
 - **Faster GPUs** — shared-pass decoding extracts more parallelism per GPU step
 
-On server GPUs (A100, H100) with higher memory bandwidth, the throughput scaling with concurrency is even more dramatic.
+On server GPUs (A100, H100) with higher memory bandwidth, the throughput scaling with concurrency is more dramatic still.


### PR DESCRIPTION
Strategic repositioning of the Ollama framing:

README
- Hero badges split: Engine v0.5.1 'usable today' (green) + Forge+Hub 'Early development' (orange) — instead of a single platform-wide hedge
- 'Already using Ollama? Switch in 60 seconds' -> 'Drop-in for Ollama-compatible clients' — adoption-friction framing, not race framing
- Benchmarks section: head-to-head throughput table removed; replaced with Engine-only scaling story (1->16 concurrent: 94->259 tok/s, 1.6->9.3s)
- TurboQuant Quality impact: table extended with Q8_0 (8-bit native) and Q4_0 (4-bit native) rows; framed explicitly as TQ4_0 vs Q4_0 at equal bit-width. New rows marked 're-measuring' until hardware run produces numbers; commitment to publish unmodified even if TQ4_0 does not beat Q4_0
- Nav links updated for new anchors

docs/benchmarks.md
- Removed all head-to-head Ollama columns and prose
- Refocused as 'Engine continuous batching scaling' (single-system)
- Per-N speedup vs N=1 instead of vs Ollama

bench/generate_quality_charts.py
- Rewritten data-driven: loads bench/results/quality_*.json and emits both bar chart and radar with whatever arms are present (F16/Q8_0/Q4_0/TQ4_0/TQ3_0)
- Previously hard-coded 3-arm static values

bench/run_quality_arms.sh (new)
- Orchestrator: starts Engine 5 times with each cache-type-k/v combination, runs turboquant_quality.py collect for each arm, regenerates charts at the end, emits markdown summary for the README

CLI already supports q4_0/q8_0 via parse_cache_type (no Rust changes needed).