### PR TITLE
Feat/engine roadmap fit flag

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -77,6 +77,16 @@ Two patterns to remember:
 
 The `installer-preflight` job in `ci.yml` compiles all 3 installers with dummy 100-byte staging files on every push. **Trust it, don't bypass it.** Two bugs (`$env:ProgramFiles(x86)` then `{userprofile}`) ate two 2h+ release builds before this preflight existed. Inno Setup has no built-in `{userprofile}` constant — use `{userdocs}` or `{%USERPROFILE}` for the user's home area. Full list of built-ins: https://jrsoftware.org/ishelp/index.php?topic=consts
 
+### Cross-platform self-signed cert trust for sccache S3 backend
+
+`SSL_CERT_FILE` is honoured ONLY by OpenSSL/rustls (i.e. Linux). On macOS native-tls uses Security framework (Keychain), on Windows it uses Schannel — both ignore the env var and read from the OS trust store. Per-OS cert trust steps are MANDATORY for every job that talks to the MinIO sccache backend:
+
+- **Linux**: `SSL_CERT_FILE` workflow-level env var (already set, no step needed)
+- **Windows**: `Import-Certificate -FilePath .github\sccache-ca.crt -CertStoreLocation Cert:\LocalMachine\Root`
+- **macOS**: `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain .github/sccache-ca.crt`
+
+v0.5.4 release shipped without the macOS step → all 3 macOS jobs panicked at TLS handshake (exit 101), Linux and Windows worked. Fixed in v0.5.5. Conditional on `runner.os == 'macOS'` for matrix jobs that span multiple OSes.
+
 
 ## What is EULLM
 

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -33,10 +33,13 @@ env:
   SCCACHE_S3_USE_SSL: "true"
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  # Linux + macOS: rustls / reqwest respect SSL_CERT_FILE for the
-  # self-signed MinIO TLS cert (committed at .github/sccache-ca.crt).
-  # Windows: ignored — needs Import-Certificate to LocalMachine\Root,
-  # see the per-Windows-job "Trust sccache CA cert" step.
+  # Linux: native-tls -> OpenSSL respects SSL_CERT_FILE.
+  # Windows: native-tls -> Schannel ignores SSL_CERT_FILE — Import-
+  #   Certificate to LocalMachine\Root via per-Windows-job step.
+  # macOS:   native-tls -> Security framework ignores SSL_CERT_FILE —
+  #   'security add-trusted-cert' into the System keychain via per-
+  #   macOS-job step. (We hit this AFTER v0.5.4 release: all 3 macOS
+  #   jobs panicked at TLS handshake to MinIO; Linux + Windows worked.)
   SSL_CERT_FILE: ${{ github.workspace }}/.github/sccache-ca.crt
 
 jobs:
@@ -73,6 +76,13 @@ jobs:
 
       # sccache now uses S3 backend on our EU-hosted MinIO — no local
       # actions/cache layer needed. See workflow-level env block for config.
+
+      - name: Trust sccache CA cert (macOS Keychain)
+        if: runner.os == 'macOS'
+        run: |
+          sudo security add-trusted-cert -d -r trustRoot \
+              -k /Library/Keychains/System.keychain \
+              .github/sccache-ca.crt
 
       - name: Install sccache
         shell: bash
@@ -401,6 +411,12 @@ jobs:
             target-macos-arm64-
 
       # sccache now uses S3 backend (see workflow-level env block)
+
+      - name: Trust sccache CA cert (macOS Keychain)
+        run: |
+          sudo security add-trusted-cert -d -r trustRoot \
+              -k /Library/Keychains/System.keychain \
+              .github/sccache-ca.crt
 
       - name: Install sccache
         run: |

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -130,6 +130,11 @@ jobs:
       - name: Build engine
         run: cargo build --release --target ${{ matrix.target }} -p eullm-engine
 
+      - name: sccache stats (visibility into S3 hit/miss)
+        if: always()
+        shell: bash
+        run: sccache --show-stats || true
+
       - name: Package binary
         run: |
           cp target/${{ matrix.target }}/release/eullm ${{ matrix.artifact }}
@@ -217,6 +222,11 @@ jobs:
           # archs, so adding two more arches grows the file by ~kernel
           # cubins only (~50-80 MB each), not 3x.
           CMAKE_CUDA_ARCHITECTURES: "86;89;120"
+
+      - name: sccache stats (visibility into S3 hit/miss)
+        if: always()
+        shell: bash
+        run: sccache --show-stats || true
 
       - name: Package binary
         run: |
@@ -359,6 +369,11 @@ jobs:
           # TurboQuant as build-from-source.
           CMAKE_CUDA_ARCHITECTURES: "86;89;120"
 
+      - name: sccache stats (visibility into S3 hit/miss)
+        if: always()
+        shell: bash
+        run: sccache --show-stats || true
+
       - name: Test TurboQuant module
         run: |
           . "$HOME/.cargo/env"
@@ -453,6 +468,11 @@ jobs:
       - name: Build engine with Metal + TurboQuant
         run: cargo build --release --target aarch64-apple-darwin --features "metal turboquant_native" -p eullm-engine
 
+      - name: sccache stats (visibility into S3 hit/miss)
+        if: always()
+        shell: bash
+        run: sccache --show-stats || true
+
       - name: Test TurboQuant module
         run: cargo test --features turboquant_native -p eullm-engine
 
@@ -513,6 +533,11 @@ jobs:
 
       - name: Build engine
         run: cargo build --release --target x86_64-pc-windows-msvc -p eullm-engine
+
+      - name: sccache stats (visibility into S3 hit/miss)
+        if: always()
+        shell: pwsh
+        run: sccache --show-stats
 
       - name: Package binary
         shell: pwsh
@@ -587,6 +612,11 @@ jobs:
           CUDA_PATH: ${{ steps.cuda-toolkit.outputs.CUDA_PATH }}
           # Ampere (RTX 3000) + Ada (RTX 4000) + Blackwell (RTX 5000).
           CMAKE_CUDA_ARCHITECTURES: "86;89;120"
+
+      - name: sccache stats (visibility into S3 hit/miss)
+        if: always()
+        shell: pwsh
+        run: sccache --show-stats
 
       - name: Package binary + bundle CUDA runtime DLLs
         shell: pwsh
@@ -746,6 +776,11 @@ jobs:
           # See the WATCH POINT note there: older arches may overflow shmem
           # on the heavier TurboQuant kernels; narrow this list if nvcc fails.
           CMAKE_CUDA_ARCHITECTURES: "86;89;120"
+
+      - name: sccache stats (visibility into S3 hit/miss) — CRITICAL for the long-pole job
+        if: always()
+        shell: pwsh
+        run: sccache --show-stats
 
       - name: Test TurboQuant module
         shell: pwsh

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -509,11 +509,49 @@ jobs:
 
       # sccache now uses S3 backend (see workflow-level env block)
 
-      - name: Trust sccache CA cert (self-signed MinIO at host19.appsdevel.com)
+      - name: Trust sccache CA cert (Windows — belt-and-suspenders)
         shell: pwsh
         run: |
-          Import-Certificate -FilePath ".github\sccache-ca.crt" -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
-          Write-Host "Imported sccache CA cert into LocalMachine\Root"
+          $cert = ".github\sccache-ca.crt"
+          Write-Host "=== Importing cert into Windows trust stores ==="
+
+          # Method 1: Import-Certificate to LocalMachine\Root (system-wide)
+          Import-Certificate -FilePath $cert -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
+          Write-Host "  [OK] Cert:\LocalMachine\Root"
+
+          # Method 2: Import-Certificate to CurrentUser\Root (per-user; sccache may run as runner user)
+          Import-Certificate -FilePath $cert -CertStoreLocation Cert:\CurrentUser\Root | Out-Null
+          Write-Host "  [OK] Cert:\CurrentUser\Root"
+
+          # Method 3: certutil legacy import (more compatible with older Windows TLS stacks)
+          & certutil.exe -addstore -f "Root" $cert | Out-Null
+          Write-Host "  [OK] certutil Root"
+
+          # Method 4: SSL_CERT_FILE belt-and-suspenders (if sccache's Windows
+          # build uses rustls instead of Schannel, rustls reads this env var)
+          $absCert = (Resolve-Path $cert).Path
+          "SSL_CERT_FILE=$absCert" | Add-Content -Path $env:GITHUB_ENV
+          Write-Host "  [OK] SSL_CERT_FILE=$absCert"
+
+          Write-Host ""
+          Write-Host "=== Verification: cert visible in trust stores ==="
+          $found = Get-ChildItem -Path Cert:\LocalMachine\Root | Where-Object {$_.Subject -like "*host19.appsdevel.com*"}
+          if ($found) { Write-Host "  [OK] Found in LocalMachine\Root: $($found.Thumbprint)" }
+          else { Write-Host "  [WARN] NOT found in LocalMachine\Root" }
+          $found2 = Get-ChildItem -Path Cert:\CurrentUser\Root | Where-Object {$_.Subject -like "*host19.appsdevel.com*"}
+          if ($found2) { Write-Host "  [OK] Found in CurrentUser\Root: $($found2.Thumbprint)" }
+          else { Write-Host "  [WARN] NOT found in CurrentUser\Root" }
+
+          # Method 5: quick TLS probe — does Windows now accept our MinIO endpoint?
+          Write-Host ""
+          Write-Host "=== TLS handshake probe to ${env:SCCACHE_ENDPOINT} ==="
+          try {
+              $r = Invoke-WebRequest -Uri "${env:SCCACHE_ENDPOINT}/minio/health/live" -UseBasicParsing -TimeoutSec 5
+              Write-Host "  [OK] HTTP $($r.StatusCode) — TLS handshake OK from Windows runner"
+          } catch {
+              Write-Host "  [FAIL] TLS probe failed: $($_.Exception.Message)"
+              Write-Host "  This means sccache S3 will also fail on this runner."
+          }
 
       - name: Install sccache
         shell: pwsh
@@ -583,11 +621,49 @@ jobs:
 
       # sccache now uses S3 backend (see workflow-level env block)
 
-      - name: Trust sccache CA cert (self-signed MinIO at host19.appsdevel.com)
+      - name: Trust sccache CA cert (Windows — belt-and-suspenders)
         shell: pwsh
         run: |
-          Import-Certificate -FilePath ".github\sccache-ca.crt" -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
-          Write-Host "Imported sccache CA cert into LocalMachine\Root"
+          $cert = ".github\sccache-ca.crt"
+          Write-Host "=== Importing cert into Windows trust stores ==="
+
+          # Method 1: Import-Certificate to LocalMachine\Root (system-wide)
+          Import-Certificate -FilePath $cert -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
+          Write-Host "  [OK] Cert:\LocalMachine\Root"
+
+          # Method 2: Import-Certificate to CurrentUser\Root (per-user; sccache may run as runner user)
+          Import-Certificate -FilePath $cert -CertStoreLocation Cert:\CurrentUser\Root | Out-Null
+          Write-Host "  [OK] Cert:\CurrentUser\Root"
+
+          # Method 3: certutil legacy import (more compatible with older Windows TLS stacks)
+          & certutil.exe -addstore -f "Root" $cert | Out-Null
+          Write-Host "  [OK] certutil Root"
+
+          # Method 4: SSL_CERT_FILE belt-and-suspenders (if sccache's Windows
+          # build uses rustls instead of Schannel, rustls reads this env var)
+          $absCert = (Resolve-Path $cert).Path
+          "SSL_CERT_FILE=$absCert" | Add-Content -Path $env:GITHUB_ENV
+          Write-Host "  [OK] SSL_CERT_FILE=$absCert"
+
+          Write-Host ""
+          Write-Host "=== Verification: cert visible in trust stores ==="
+          $found = Get-ChildItem -Path Cert:\LocalMachine\Root | Where-Object {$_.Subject -like "*host19.appsdevel.com*"}
+          if ($found) { Write-Host "  [OK] Found in LocalMachine\Root: $($found.Thumbprint)" }
+          else { Write-Host "  [WARN] NOT found in LocalMachine\Root" }
+          $found2 = Get-ChildItem -Path Cert:\CurrentUser\Root | Where-Object {$_.Subject -like "*host19.appsdevel.com*"}
+          if ($found2) { Write-Host "  [OK] Found in CurrentUser\Root: $($found2.Thumbprint)" }
+          else { Write-Host "  [WARN] NOT found in CurrentUser\Root" }
+
+          # Method 5: quick TLS probe — does Windows now accept our MinIO endpoint?
+          Write-Host ""
+          Write-Host "=== TLS handshake probe to ${env:SCCACHE_ENDPOINT} ==="
+          try {
+              $r = Invoke-WebRequest -Uri "${env:SCCACHE_ENDPOINT}/minio/health/live" -UseBasicParsing -TimeoutSec 5
+              Write-Host "  [OK] HTTP $($r.StatusCode) — TLS handshake OK from Windows runner"
+          } catch {
+              Write-Host "  [FAIL] TLS probe failed: $($_.Exception.Message)"
+              Write-Host "  This means sccache S3 will also fail on this runner."
+          }
 
       - name: Install sccache
         shell: pwsh
@@ -696,11 +772,49 @@ jobs:
       # the long-pole job that used to take 2h+ cold should now hit
       # the S3 cache and complete in 15-30 min.
 
-      - name: Trust sccache CA cert (self-signed MinIO at host19.appsdevel.com)
+      - name: Trust sccache CA cert (Windows — belt-and-suspenders)
         shell: pwsh
         run: |
-          Import-Certificate -FilePath ".github\sccache-ca.crt" -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
-          Write-Host "Imported sccache CA cert into LocalMachine\Root"
+          $cert = ".github\sccache-ca.crt"
+          Write-Host "=== Importing cert into Windows trust stores ==="
+
+          # Method 1: Import-Certificate to LocalMachine\Root (system-wide)
+          Import-Certificate -FilePath $cert -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
+          Write-Host "  [OK] Cert:\LocalMachine\Root"
+
+          # Method 2: Import-Certificate to CurrentUser\Root (per-user; sccache may run as runner user)
+          Import-Certificate -FilePath $cert -CertStoreLocation Cert:\CurrentUser\Root | Out-Null
+          Write-Host "  [OK] Cert:\CurrentUser\Root"
+
+          # Method 3: certutil legacy import (more compatible with older Windows TLS stacks)
+          & certutil.exe -addstore -f "Root" $cert | Out-Null
+          Write-Host "  [OK] certutil Root"
+
+          # Method 4: SSL_CERT_FILE belt-and-suspenders (if sccache's Windows
+          # build uses rustls instead of Schannel, rustls reads this env var)
+          $absCert = (Resolve-Path $cert).Path
+          "SSL_CERT_FILE=$absCert" | Add-Content -Path $env:GITHUB_ENV
+          Write-Host "  [OK] SSL_CERT_FILE=$absCert"
+
+          Write-Host ""
+          Write-Host "=== Verification: cert visible in trust stores ==="
+          $found = Get-ChildItem -Path Cert:\LocalMachine\Root | Where-Object {$_.Subject -like "*host19.appsdevel.com*"}
+          if ($found) { Write-Host "  [OK] Found in LocalMachine\Root: $($found.Thumbprint)" }
+          else { Write-Host "  [WARN] NOT found in LocalMachine\Root" }
+          $found2 = Get-ChildItem -Path Cert:\CurrentUser\Root | Where-Object {$_.Subject -like "*host19.appsdevel.com*"}
+          if ($found2) { Write-Host "  [OK] Found in CurrentUser\Root: $($found2.Thumbprint)" }
+          else { Write-Host "  [WARN] NOT found in CurrentUser\Root" }
+
+          # Method 5: quick TLS probe — does Windows now accept our MinIO endpoint?
+          Write-Host ""
+          Write-Host "=== TLS handshake probe to ${env:SCCACHE_ENDPOINT} ==="
+          try {
+              $r = Invoke-WebRequest -Uri "${env:SCCACHE_ENDPOINT}/minio/health/live" -UseBasicParsing -TimeoutSec 5
+              Write-Host "  [OK] HTTP $($r.StatusCode) — TLS handshake OK from Windows runner"
+          } catch {
+              Write-Host "  [FAIL] TLS probe failed: $($_.Exception.Message)"
+              Write-Host "  This means sccache S3 will also fail on this runner."
+          }
 
       - name: Install sccache
         shell: pwsh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" />
   <img src="https://img.shields.io/badge/EU%20AI%20Act-Designed%20for%20compliance-gold" alt="EU AI Act" />
-  <img src="https://img.shields.io/badge/Engine-v0.5.4%20%E2%80%94%20usable%20today-2ea44f" alt="Engine status" />
+  <img src="https://img.shields.io/badge/Engine-v0.5.5%20%E2%80%94%20usable%20today-2ea44f" alt="Engine status" />
   <img src="https://img.shields.io/badge/Forge%20%2B%20Hub-Early%20development-orange" alt="Forge/Hub status" />
   <a href="https://github.com/eullm/eullm/actions/workflows/ci.yml"><img src="https://github.com/eullm/eullm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://doi.org/10.5281/zenodo.20412979"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20412979.svg" alt="DOI" /></a>
@@ -108,9 +108,9 @@ What you get on top of the Ollama-compatible API:
 
 | Component | Status | Use today? |
 |-----------|--------|------------|
-| **Engine** — Rust inference runtime, Ollama + OpenAI APIs, continuous batching, CUDA (RTX 3000/4000/5000), TurboQuant, audit trail. Builds also exist for ROCm/Vulkan/Metal/ARM64 — see [platform status](#-platform-status--help-us-test) | ✅ **Ready (v0.5.4)** — Linux x64 + Windows x64 | **Yes** — drop-in for Ollama on tested platforms |
-| **Chat UI** — embedded browser chat (HTML/CSS/JS baked into `eullm.exe`, served on a separate port from the API) | ✅ **Ready (v0.5.4)** | **Yes** — auto-opens after install on Windows |
-| **Windows installer** — one-click `.exe` (Inno Setup) with Start Menu, optional PATH, browser launcher | ✅ **Ready (v0.5.4)** | **Yes** — three variants: CPU / CUDA / CUDA+TurboQuant |
+| **Engine** — Rust inference runtime, Ollama + OpenAI APIs, continuous batching, CUDA (RTX 3000/4000/5000), TurboQuant, audit trail. Builds also exist for ROCm/Vulkan/Metal/ARM64 — see [platform status](#-platform-status--help-us-test) | ✅ **Ready (v0.5.5)** — Linux x64 + Windows x64 | **Yes** — drop-in for Ollama on tested platforms |
+| **Chat UI** — embedded browser chat (HTML/CSS/JS baked into `eullm.exe`, served on a separate port from the API) | ✅ **Ready (v0.5.5)** | **Yes** — auto-opens after install on Windows |
+| **Windows installer** — one-click `.exe` (Inno Setup) with Start Menu, optional PATH, browser launcher | ✅ **Ready (v0.5.5)** | **Yes** — three variants: CPU / CUDA / CUDA+TurboQuant |
 | **Forge** — verticalization pipeline (pruning + distillation + quantization + identity LoRA) | 🧪 Modules ready, end-to-end integration in progress | Researchers / advanced |
 | **Hub** — EU-hosted model registry with AI Act compliance cards | 🧪 Prototype API | Not yet |
 | **Demo models** — `legal-it-7b` / `medical-de-7b` / `finance-fr-7b` | 🚧 First model in training (Q4 2026) | Not yet |
@@ -400,7 +400,7 @@ chmod +x eullm
 Startup output (real, from RTX 5070 Ti 16GB):
 
 ```
-eullm ready.  [v0.5.4]
+eullm ready.  [v0.5.5]
   Model:         qwen3-14b
   GPU backend:   CUDA
   Context:       131072 total (8192 per sequence × 16 slots)

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
Three coordinated fixes after the v0.5.4 release exposed sccache S3 failing
silently on Windows (0 traffic to MinIO from Windows runners during 1h+
build) and panicking explicitly on macOS (exit 101 at TLS handshake).

- macOS: `sudo security add-trusted-cert` step to Keychain (was missing)
- Windows: belt-and-suspenders cert trust — Import-Certificate to both
  LocalMachine\Root AND CurrentUser\Root, plus certutil legacy import,
  plus SSL_CERT_FILE env var, plus a TLS probe step that tells us in the
  CI log whether the cert is actually trusted (Invoke-WebRequest against
  the MinIO health endpoint)
- All jobs: new `sccache --show-stats` step after each Build so we have
  visibility into cache hit/miss/error counts (this run will tell us
  exactly what works and what doesn't on each platform)

## Test plan
- [ ] v0.5.5 release completes in <50 min (vs 2h 40m without sccache)
- [ ] sccache --show-stats output on Windows shows non-zero cache writes
- [ ] MinIO bucket on VPS grows past 2 GB during the run (currently 657 MB)
- [ ] macOS jobs no longer exit 101 (Keychain cert trust works)