### PR TITLE
fix(cli): don't spawn a nested tokio runtime when pulling a model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.5.8"
+version = "0.5.10"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.5.8"
+version = "0.5.10"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -451,11 +451,11 @@ async fn main() {
 /// to catalog selections; otherwise just call `cmd_pull` synchronously.
 async fn cmd_pull_maybe(store: &ModelStore, model: Option<&str>) {
     if let Some(name) = model {
-        cmd_pull(store, name);
+        cmd_pull(store, name).await;
         return;
     }
     match picker::pick(store).await {
-        Some(picker::Picked::Catalog(entry)) => cmd_pull(store, &entry.id),
+        Some(picker::Picked::Catalog(entry)) => cmd_pull(store, &entry.id).await,
         Some(picker::Picked::Local(p)) => {
             println!("That model is already local: {}", p.display());
         }
@@ -472,7 +472,7 @@ async fn cmd_pull_maybe(store: &ModelStore, model: Option<&str>) {
     }
 }
 
-fn cmd_pull(store: &ModelStore, model: &str) {
+async fn cmd_pull(store: &ModelStore, model: &str) {
     let entry = match catalog::find_model(model) {
         Some(e) => e,
         None => {
@@ -527,8 +527,10 @@ fn cmd_pull(store: &ModelStore, model: &str) {
     let hf_filename = entry.hf_filename.clone();
     let entry_clone = entry.clone();
 
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let result = rt.block_on(async {
+    // Download directly on the current async runtime — we're already inside
+    // `#[tokio::main]`, so spawning a nested `Runtime::new().block_on()` here
+    // panics with "Cannot start a runtime from within a runtime".
+    let result = {
         use crate::registry::{download_from_huggingface, format_progress};
         use std::sync::atomic::{AtomicU64, Ordering};
         use std::sync::Arc;
@@ -546,7 +548,7 @@ fn cmd_pull(store: &ModelStore, model: &str) {
         });
 
         download_from_huggingface(&hf_repo, &hf_filename, &gguf_dest, Some(progress)).await
-    });
+    };
 
     eprintln!(); // newline after progress
 
@@ -747,7 +749,7 @@ async fn cmd_run(
         if !store.exists(model) {
             if catalog::find_model(model).is_some() {
                 println!("Model not found locally. Pulling...");
-                cmd_pull(store, model);
+                cmd_pull(store, model).await;
             } else {
                 eprintln!("Error: model '{model}' not found.");
                 eprintln!();


### PR DESCRIPTION
`eullm` is #[tokio::main], so the whole command dispatch already runs inside an async runtime. cmd_pull built a second runtime with `tokio::runtime::Runtime::new().block_on(...)` for the HuggingFace download, which panics at runtime:

  Cannot start a runtime from within a runtime ... block_on attempted
  to block the current thread while the thread is being used to drive
  asynchronous tasks.

This made the interactive picker's 'download a catalog model' path (and `eullm run <catalog-id>` / `eullm pull <id>`) crash the moment a download started — exactly the headline feature of the catalog.

Fix: make cmd_pull async and .await the download directly on the existing runtime; await it from all three call sites (cmd_pull_maybe, the picker dispatch, and cmd_run's auto-pull). Smoke-tested: the pull path now reaches the actual HTTP download instead of panicking.

Also bumps engine to 0.5.10 (main's Cargo.toml was still 0.5.8; the 0.5.9 tag was cut from a branch commit whose bump never merged, so the 0.5.9 binary mis-reported 0.5.8 — this corrects the version string).