### PR TITLE
fix(ui+cli): reasoning default, web multi-turn, sticky /no_think, big…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -133,6 +133,12 @@ enum Commands {
         #[arg(long)]
         no_ui: bool,
 
+        /// Terminal-only: don't auto-open the browser chat on startup, just
+        /// drop into the CLI REPL. (The chat UI is still served on --ui-port
+        /// unless --no-ui is also given.) Alias: --no-chat.
+        #[arg(long, visible_alias = "no-chat")]
+        cli: bool,
+
         /// Port for the embedded chat UI (separate from the API port so
         /// the API surface on --port stays pure). Default 11435.
         #[arg(long, default_value_t = 11435)]
@@ -309,7 +315,7 @@ async fn main() {
                 threads: None, batch_size: 1, no_flash_attn: false,
                 n_batch: 2048, cache_type_k: "f16".into(),
                 cache_type_v: "f16".into(), web: false, no_ui: false,
-                ui_port: 11435, daemon: false,
+                cli: false, ui_port: 11435, daemon: false,
                 pidfile: DEFAULT_PIDFILE.into(),
             },
             Some(picker::Picked::Catalog(entry)) => Commands::Run {
@@ -318,7 +324,7 @@ async fn main() {
                 threads: None, batch_size: 1, no_flash_attn: false,
                 n_batch: 2048, cache_type_k: "f16".into(),
                 cache_type_v: "f16".into(), web: false, no_ui: false,
-                ui_port: 11435, daemon: false,
+                cli: false, ui_port: 11435, daemon: false,
                 pidfile: DEFAULT_PIDFILE.into(),
             },
             Some(picker::Picked::Url(_url)) => {
@@ -361,6 +367,7 @@ async fn main() {
             cache_type_v,
             web,
             no_ui,
+            cli,
             ui_port,
             daemon,
             pidfile,
@@ -409,7 +416,10 @@ async fn main() {
                 ctv = inference::KvCacheType::F16;
             }
             let ui_port_opt = if no_ui { None } else { Some(ui_port) };
-            cmd_run(&store, &model, port, replace, gpu_layers, ctx_size, threads, batch_size, !no_flash_attn, n_batch, ctk, ctv, web, ui_port_opt).await;
+            // Auto-open the browser chat unless the user asked for terminal-only
+            // (--cli / --no-chat) or disabled the UI entirely (--no-ui).
+            let open_chat = !cli && ui_port_opt.is_some();
+            cmd_run(&store, &model, port, replace, gpu_layers, ctx_size, threads, batch_size, !no_flash_attn, n_batch, ctk, ctv, web, ui_port_opt, open_chat).await;
         }
         Commands::List => cmd_list(&store),
         Commands::Show { model } => cmd_show(&store, &model),
@@ -707,6 +717,32 @@ async fn ensure_port_available(port: u16, replace: bool) {
     }
 }
 
+/// Open `url` in the user's default browser, cross-platform. Fire-and-forget:
+/// spawns the OS handler and returns immediately (the engine keeps running).
+fn open_browser(url: &str) -> std::io::Result<()> {
+    use std::process::Command;
+    #[cfg(target_os = "windows")]
+    let mut cmd = {
+        // `start` is a cmd builtin; the empty "" is the window-title argument.
+        let mut c = Command::new("cmd");
+        c.args(["/C", "start", "", url]);
+        c
+    };
+    #[cfg(target_os = "macos")]
+    let mut cmd = {
+        let mut c = Command::new("open");
+        c.arg(url);
+        c
+    };
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let mut cmd = {
+        let mut c = Command::new("xdg-open");
+        c.arg(url);
+        c
+    };
+    cmd.spawn().map(|_| ())
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn cmd_run(
     store: &ModelStore,
@@ -723,6 +759,7 @@ async fn cmd_run(
     cache_type_v: inference::KvCacheType,
     web: bool,
     ui_port: Option<u16>,
+    open_chat: bool,
 ) {
     ensure_port_available(port, replace).await;
     if let Some(p) = ui_port {
@@ -938,6 +975,16 @@ async fn cmd_run(
 
     // Give the API server a moment to bind.
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // Auto-open the browser chat (default). Suppressed by --cli / --no-chat
+    // (open_chat=false) or --no-ui (ui_port=None).
+    if open_chat && let Some(p) = ui_port {
+        let url = format!("http://localhost:{p}/");
+        match open_browser(&url) {
+            Ok(()) => println!("Opening chat in your browser: {url}\n  (use --cli to stay in the terminal)\n"),
+            Err(_) => println!("Open the chat in your browser: {url}\n"),
+        }
+    }
 
     if has_backend && is_tty {
         if let Some(sched) = repl_scheduler {
@@ -1429,6 +1476,11 @@ async fn interactive_chat(
 
     let mut temperature: f32 = 0.8;
     let mut max_reply_tokens: u32 = 2048;
+    // Sticky reasoning toggle. ON by default (reasoning models need it). When
+    // OFF we append the ` /no_think` soft-switch to each user turn — the
+    // mechanism the models actually honour (an injected empty <think></think>
+    // breaks reasoning models like DeepSeek-R1).
+    let mut think_mode = true;
 
     let mut history: Vec<ChatMessage> = vec![ChatMessage {
         role: "system",
@@ -1471,7 +1523,7 @@ async fn interactive_chat(
             }
         }
 
-        let input = input.trim().to_string();
+        let mut input = input.trim().to_string();
         if input.is_empty() {
             continue;
         }
@@ -1488,11 +1540,28 @@ async fn interactive_chat(
             println!("Commands:");
             println!("  /bye              Exit the chat");
             println!("  /clear            Clear conversation history");
+            println!("  /think            Enable reasoning (current: {})", if think_mode { "on" } else { "off" });
+            println!("  /no_think         Disable reasoning (sticky until /think)");
             println!("  /temp <0.0–2.0>   Set temperature (current: {temperature:.1})");
             println!("  /maxtokens <n>    Set max reply tokens (current: {max_reply_tokens})");
             println!("  /system <text>    Replace system prompt");
             println!("  /help             Show this help\n");
             continue;
+        } else if input == "/think" {
+            think_mode = true;
+            println!("Reasoning ON.\n");
+            continue;
+        } else if input == "/no_think" {
+            think_mode = false;
+            println!("Reasoning OFF (sticky — re-enable with /think).\n");
+            continue;
+        } else if let Some(rest) = input.strip_prefix("/no_think ") {
+            // Inline form: disable reasoning AND send this message.
+            think_mode = false;
+            input = rest.trim().to_string();
+        } else if let Some(rest) = input.strip_prefix("/think ") {
+            think_mode = true;
+            input = rest.trim().to_string();
         } else if let Some(val) = input.strip_prefix("/temp ") {
             match val.trim().parse::<f32>() {
                 Ok(t) if (0.0..=2.0).contains(&t) => {
@@ -1519,8 +1588,10 @@ async fn interactive_chat(
             continue;
         }
 
-        // Add user message to permanent history.
-        history.push(ChatMessage { role: "user", content: input.clone() });
+        // Add user message to permanent history. When reasoning is toggled
+        // off, append the ` /no_think` soft-switch the models actually honour.
+        let user_content = if think_mode { input.clone() } else { format!("{input} /no_think") };
+        history.push(ChatMessage { role: "user", content: user_content });
 
         // Build prompt using the model-appropriate chat template.
         // If web browsing is enabled, fetch URLs and inject content into a

--- a/engine/src/ui/app.js
+++ b/engine/src/ui/app.js
@@ -28,8 +28,17 @@
     system: "",
     temperature: 0.7,
     maxTokens: 2048,
-    think: false,
+    // Reasoning ON by default. Reasoning models (DeepSeek-R1, QwQ) are trained
+    // to always emit a <think> block; suppressing it (think:false injects an
+    // empty <think></think>) makes them degenerate into a canned greeting.
+    think: true,
   };
+
+  // Strip <think>…</think> from an assistant turn before storing it in history.
+  // Re-sending the model's own reasoning back as context confuses reasoning
+  // models and bloats the prompt; only the final answer belongs in history.
+  const stripThink = (s) =>
+    s.replace(/<think>[\s\S]*?<\/think>\s*/g, "").replace(/<think>[\s\S]*$/, "").trim();
 
   const history = []; // {role, content}
   let currentModel = "";
@@ -237,7 +246,7 @@
         }
       }
 
-      history.push({ role: "assistant", content: assistantText });
+      history.push({ role: "assistant", content: stripThink(assistantText) || assistantText });
       const dt = (performance.now() - t0) / 1000;
       const tps = tokenCount > 0 ? (tokenCount / dt).toFixed(1) : "—";
       metaEl.innerHTML = `<span>${tokenCount} chunks</span><span>${dt.toFixed(2)}s</span><span>~${tps} chunk/s</span>`;

--- a/engine/src/ui/index.html
+++ b/engine/src/ui/index.html
@@ -6,7 +6,7 @@
   <meta name="color-scheme" content="dark light">
   <title>EuLLM Chat</title>
   <link rel="stylesheet" href="/eullm-ui/style.css">
-  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%23003399'/%3E%3Ctext x='16' y='22' font-family='system-ui,sans-serif' font-size='18' font-weight='700' fill='%23ffd700' text-anchor='middle'%3EEu%3C/text%3E%3C/svg%3E">
+  <link rel="icon" type="image/png" href="/eullm-ui/logo-light.png">
 </head>
 <body>
   <header class="topbar">
@@ -14,7 +14,7 @@
       <a class="brand-link" href="https://www.eullm.eu" target="_blank" rel="noopener" title="EuLLM — European Sovereign LLM Platform">
         <picture>
           <source srcset="/eullm-ui/logo-dark.png" media="(prefers-color-scheme: dark)">
-          <img class="brand-logo" src="/eullm-ui/logo-light.png" alt="EuLLM" height="32">
+          <img class="brand-logo" src="/eullm-ui/logo-light.png" alt="EuLLM" height="44">
         </picture>
       </a>
       <span class="brand-tag">Engine</span>
@@ -81,8 +81,8 @@
         <input id="settings-max-tokens" type="number" min="1" max="32000" step="1" value="2048"/>
       </label>
       <label class="row">
-        <input id="settings-think" type="checkbox"/>
-        <span>Enable reasoning mode (Qwen3 <code>&lt;think&gt;</code> blocks)</span>
+        <input id="settings-think" type="checkbox" checked/>
+        <span>Enable reasoning mode (<code>&lt;think&gt;</code> blocks — needed by DeepSeek-R1 / QwQ)</span>
       </label>
       <div class="settings-actions">
         <button type="submit" value="cancel" class="btn-secondary">Cancel</button>

--- a/engine/src/ui/style.css
+++ b/engine/src/ui/style.css
@@ -86,7 +86,7 @@ body {
 .brand-link:hover { opacity: 0.85; }
 
 .brand-logo {
-  height: 32px;
+  height: 44px;
   width: auto;
   display: block;
 }
@@ -474,7 +474,7 @@ dialog#settings-modal::backdrop { background: rgba(0, 0, 0, 0.6); }
 
 @media (max-width: 540px) {
   .brand-tag { display: none; }
-  .brand-logo { height: 24px; }
+  .brand-logo { height: 32px; }
   .model-picker-label { display: none; }
   .model-picker select { min-width: 140px; }
   .topbar { padding: 8px 12px; }


### PR DESCRIPTION
…ger logo, auto-open browser

Web chat (app.js + index.html):
- Default reasoning ON (was think:false). For reasoning models (DeepSeek-R1, QwQ) the no-think path injects an empty <think></think>, which makes them degenerate into a canned greeting on every turn — the 'web chat repeats itself' bug. think:true matches the working CLI.
- Strip <think>…</think> from assistant turns before storing in history, so the model's own reasoning isn't re-sent as context (bloat + confusion).
- Bigger brand logo (32→44px, mobile 24→32). Favicon now uses the real brand logo instead of the placeholder 'Eu' square.

CLI REPL (main.rs):
- New sticky /think and /no_think commands (also inline: '/no_think <msg>'). Previously /no_think was only honoured by the model for that one turn; now it persists until /think. Implemented via the ' /no_think' soft-switch the models actually honour (an injected empty <think></think> breaks reasoning models), not the prompt-template think flag.

New: auto-open browser chat on 'eullm run' (default). Suppress with --cli / --no-chat (terminal-only REPL) or --no-ui (no UI served at all). Cross-platform open_browser() helper (start/open/xdg-open).

Bumps engine to 0.5.12.