### PR TITLE
feat(ci): Windows CUDA release uses Ninja + sccache S3 (0.5.14)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -113,10 +113,14 @@ store with no ref boundary → it hits across every release (proven on S3 in v0.
 release workflow's sccache back to the GitHub cache** — architecturally
 unsuitable for tag-triggered builds.
 
-### Windows CUDA: sccache has NEVER worked, and S3 vs GitHub cache is irrelevant
+### Windows CUDA: Ninja generator + S3 sccache (working as of v0.5.14)
 
-For Windows specifically, sccache caches **only Rust** — never C/C++, never CUDA.
-Proof from v0.5.9 (S3 + launcher fix in place, the run that fixed Linux CUDA):
+For years before v0.5.14, Windows CUDA was the long-pole of every release
+(~50 min cold, no warm path). The diagnosis sat in two layers and was only
+fully unblocked with a generator swap, not a backend swap.
+
+**Layer 1 — the diagnosis (proven on v0.5.9, S3 + CUDA launcher fix in place):**
+sccache cached **only Rust** on Windows, never C/C++, never CUDA.
 
 | 0.5.9 sccache stats | Linux CUDA | Windows CUDA |
 |---|---|---|
@@ -125,24 +129,55 @@ Proof from v0.5.9 (S3 + launcher fix in place, the run that fixed Linux CUDA):
 | Cache hits (CUDA) | 129 | **0** |
 | Wall-clock | 2m34s | ~50 min |
 
-**Root cause:** the CMake "Visual Studio" generator (MSBuild) silently ignores
+Root cause: the CMake "Visual Studio" generator (MSBuild) **silently ignores**
 `CMAKE_C_COMPILER_LAUNCHER` / `CMAKE_CXX_COMPILER_LAUNCHER` /
 `CMAKE_CUDA_COMPILER_LAUNCHER`. Those work only with the Makefile and Ninja
 generators. `llama-cpp-sys-2` on Windows defaults to the VS generator, so cl.exe
 and nvcc invocations bypass sccache entirely — no cache key is ever computed,
-no object is ever stored. Switching the backend (S3, GitHub, anything) cannot
-fix this; you'd need to switch generator to Ninja (requires installing ninja +
-properly activating the MSVC env on the runner — tried, finicky) or stop
-recompiling llama.cpp on Windows at all.
+no object is ever stored. Switching the cache backend (S3, GitHub, anything)
+cannot fix this; the launcher contract is at the generator level.
 
-**Therefore Windows CUDA gets its own fix: pre-build llama.cpp as a DLL once,
-link the engine against it.** That's the `build-llama-dll.yml` workflow + the
-B2 work on `llama-cpp-sys-2`'s build.rs. With the DLL in place Windows CUDA
-release builds drop to ~5-10 min (only Rust + linking, no C++/CUDA).
+**Layer 2 — the fix (proven on the try-windows-ninja experiment, run #2):**
+force `CMAKE_GENERATOR=Ninja` in the Windows CUDA job. Three small changes:
+
+1. `choco install ninja` (the binary must be on PATH before cargo builds).
+2. Activate MSVC x64 dev env via `vcvars64.bat` (found via `vswhere`).
+   Plain `windows-2022` runners do NOT activate it — that's only set up for
+   MSBuild. Without this, Ninja can't find `cl.exe` / `nvcc`.
+3. `CMAKE_GENERATOR: Ninja` as an env on the cargo build step.
+
+Experiment proof (build engine, cold):
+
+| Generator | Tracked by sccache | Wall-clock | Outcome |
+|---|---|---|---|
+| VS / MSBuild | 0 (no C/C++ line, no CUDA line in stats) | ~36 min | Re-builds from scratch forever |
+| **Ninja** | **205 C/C++ + 130 CUDA written to S3** | ~36 min | **Cache populated → next build warm** |
+
+After the experiment populated S3, the projection for the **second** Ninja
+build on Windows CUDA is ~5–10 min, mirroring exactly the Linux CUDA jump from
+0.5.9 (populate, 2m34s with hits) to 0.5.13 (rebuild, 2m47s with hits).
 
 **Rule of method:** never claim sccache "works" on a platform without reading
 that platform's `Cache hits (C/C++)` and `Cache hits (CUDA)` lines first. Don't
 extend Linux results to Windows.
+
+### Windows DLL strategy (B1) — still useful, no longer urgent
+
+The `build-llama-dll.yml` workflow + B2 (patching `llama-cpp-sys-2`'s build.rs
+to link a prebuilt DLL) was conceived when Ninja-on-Windows was thought
+intractable. With v0.5.14 the urgency is gone, but two values remain:
+
+- **Smaller release ZIPs**: linking against a separately-published DLL means
+  `eullm.exe` shrinks dramatically (the bulk of llama.cpp lives in the DLL).
+- **Self-update path**: updating the DLL independently of the engine binary
+  enables in-place llama.cpp upgrades without recompiling Rust.
+
+Treat B1/B2 as a future feature, not a speed fix. The B1 run #1 artefact
+(`llama-dll-windows-cuda-12.8.zip`, 122 MB) is already proven valid: 231
+`llama_*` symbols exported, all 5 critical ones (`llama_backend_init`,
+`llama_decode`, `llama_model_load_from_file`, `llama_model_load_from_splits`,
+`llama_tokenize`), plus `bindings.rs` already produced by bindgen — meaning
+B2 can skip the bindgen step entirely when it eventually lands.
 
 ### sccache resilience: keep S3 from killing the build
 

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -337,6 +337,17 @@ jobs:
         with:
           version: "17.0"
 
+      # Ninja is the key to caching C++/CUDA on Windows: the default CMake
+      # "Visual Studio" generator (MSBuild) silently ignores
+      # CMAKE_*_COMPILER_LAUNCHER, so cl.exe and nvcc bypass sccache entirely.
+      # Ninja honours those vars, which lets sccache content-hash every C++/CUDA
+      # compile and route it to/from S3 just like on Linux. Proven in the
+      # try-windows-ninja experiment (run #2): 205 C/C++ + 130 CUDA compiles
+      # were tracked and written to S3, vs 0 with the VS generator.
+      - name: Install Ninja
+        run: choco install ninja --no-progress --yes
+        shell: pwsh
+
       - name: Install CUDA toolkit 12.8
         uses: Jimver/cuda-toolkit@v0.2.35
         id: cuda-toolkit
@@ -348,6 +359,34 @@ jobs:
           # from Linux ("cudart"). Providing a Linux-style allowlist makes
           # the installer exit with code 3772776473. Letting Jimver install
           # the default set (~5 GB) is the most reliable path on Windows.
+
+      # MSVC env (vcvarsall) must be ACTIVE for Ninja to find cl.exe / nvcc.
+      # Plain `runs-on: windows-2022` does NOT activate it — that's only set up
+      # for MSBuild. We invoke vcvars64.bat directly (via vswhere to find the
+      # VS install dir) and diff the resulting environment into $GITHUB_ENV so
+      # every later step (cargo build → cmake → Ninja → cl.exe / nvcc) sees it.
+      - name: Activate MSVC x64 dev environment
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installPath = & $vswhere -latest -property installationPath
+          if (-not $installPath) { throw "vswhere did not find a Visual Studio install" }
+          $vcvars = "$installPath\VC\Auxiliary\Build\vcvars64.bat"
+          if (-not (Test-Path $vcvars)) { throw "vcvars64.bat not found at $vcvars" }
+          Write-Host "Activating: $vcvars"
+          $envBefore = @{}
+          foreach ($e in (Get-ChildItem env:)) { $envBefore[$e.Name] = $e.Value }
+          $output = cmd /c "`"$vcvars`" >NUL 2>&1 && set"
+          foreach ($line in $output) {
+              if ($line -match "^([^=]+)=(.*)$") {
+                  $name = $matches[1]
+                  $value = $matches[2]
+                  if ($envBefore[$name] -ne $value) {
+                      "$name=$value" | Add-Content -Path $env:GITHUB_ENV
+                  }
+              }
+          }
+          Write-Host "MSVC env activated."
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -392,6 +431,10 @@ jobs:
           CUDA_PATH: ${{ steps.cuda-toolkit.outputs.CUDA_PATH }}
           # Ampere (RTX 3000) + Ada (RTX 4000) + Blackwell (RTX 5000).
           CMAKE_CUDA_ARCHITECTURES: "86;89;120"
+          # Force the Ninja generator (instead of the default VS/MSBuild one)
+          # so sccache actually sees cl.exe + nvcc invocations and can cache
+          # them — see "Install Ninja" step above for the full rationale.
+          CMAKE_GENERATOR: Ninja
 
       - name: sccache stats (visibility into S3 hit/miss)
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.5.13"
+version = "0.5.14"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"


### PR DESCRIPTION
The years-long Windows CUDA bottleneck was a CMake-generator problem, not a cache-backend one. The 'Visual Studio' (MSBuild) generator silently ignores CMAKE_*_COMPILER_LAUNCHER, so cl.exe and nvcc bypass sccache entirely — no cache key is computed, no object is stored. Proven across v0.5.x: 0 Cache hits (C/C++) and 0 Cache hits (CUDA) on Windows for every release, regardless of S3 vs GitHub backend.

Fix (proven in try-windows-ninja experiment run #2):

  1. Install Ninja (choco)
  2. Activate MSVC x64 env via vcvars64.bat (vswhere → cmd /c → diff into $GITHUB_ENV) — windows-2022 runners only activate MSBuild env by default, Ninja needs the cl.exe / nvcc PATH explicitly.
  3. CMAKE_GENERATOR=Ninja on the cargo build step.

Experiment cold-build stats (build engine wall-clock):
  - VS / MSBuild generator: 35m 51s, sccache 0 C/C++ + 0 CUDA writes
  - Ninja generator:        36m 38s, sccache 205 C/C++ + 130 CUDA writes

Same wall-clock the FIRST time (both cold), but Ninja populates S3 with 335 content-hashed objects. Projection for v0.5.14 Windows CUDA: ~5-10 min wall-clock — same factor of improvement seen on Linux CUDA between 0.5.9 populate (2m34s) and 0.5.13 rebuild (2m47s).

The DLL strategy (B1/B2) is no longer urgent. Kept for binary size + self-update path; see CLAUDE.md.