### PR TITLE
chore: remove empty website/ directory (landing page lives at eullm.e…

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -387,7 +387,6 @@ eullm/
 │   ├── Cargo.toml
 │   ├── Dockerfile
 │   └── src/
-├── website/
 └── docs/
 ```
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,6 @@ build/
 *.md
 !README.md
 docs/
-website/
 notebooks/
 *.gguf
 .ruff_cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,8 +97,7 @@ eullm/
 ├── forge/      Python — Model verticalizzazione pipeline
 ├── hub/        Rust — EU model registry API
 ├── bench/      Benchmarks and stress tests
-├── docs/       Technical documentation
-└── website/    Landing page
+└── docs/       Technical documentation
 ```
 
 See [docs/architecture.md](docs/architecture.md) for detailed diagrams.


### PR DESCRIPTION
…u, separate repo)

The website/ dir held only a .gitkeep placeholder — the real landing page is hosted off-repo at https://www.eullm.eu. Removing dead structure and all references (.dockerignore, CLAUDE.md repo layout, CONTRIBUTING.md project tree) so the repo only documents what actually lives in it.