### PR TITLE
fix(ci): link NCCL on Linux CUDA build (v0.5.16)

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -234,6 +234,19 @@ jobs:
           # archs, so adding two more arches grows the file by ~kernel
           # cubins only (~50-80 MB each), not 3x.
           CMAKE_CUDA_ARCHITECTURES: "86;89;120"
+          # llama-cpp-sys-2 0.1.146 compiles ggml-cuda with NCCL on (option
+          # GGML_CUDA_NCCL=ON in the vendored llama.cpp CMake). nvidia/cuda
+          # 12.8-devel ships nccl.h + libnccl.so, so find_package(NCCL)
+          # succeeds and GGML_USE_NCCL gets defined, pulling in
+          # ggml_backend_cuda_allreduce_tensor with refs to ncclCommInitAll,
+          # ncclAllReduce, ncclGroupStart/End, ncclGetErrorString. But the
+          # crate's build.rs never emits `cargo:rustc-link-lib=nccl`, and
+          # CMake links NCCL to ggml-cuda as PRIVATE, so the final rustc
+          # link call sees those symbols undefined. Closing the gap here
+          # keeps NCCL active (multi-GPU stays on the table) without
+          # forking llama-cpp-sys-2. v0.5.15 shipped without this and the
+          # build-cuda job failed at link.
+          RUSTFLAGS: "-C link-arg=-lnccl"
 
       - name: sccache stats (visibility into S3 hit/miss)
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.5.15"
+version = "0.5.16"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.5.15"
+version = "0.5.16"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"


### PR DESCRIPTION
llama-cpp-sys-2 0.1.146 compiles ggml-cuda with NCCL detection enabled (GGML_CUDA_NCCL=ON in the vendored llama.cpp CMake). The nvidia/cuda 12.8-devel container ships nccl.h and libnccl.so, so find_package(NCCL) succeeds and GGML_USE_NCCL is defined, pulling in the NCCL paths of ggml_backend_cuda_allreduce_tensor (ncclCommInitAll, ncclAllReduce, ncclGroupStart/End, ncclGetErrorString). But the crate build.rs never emits cargo:rustc-link-lib=nccl, and CMake links NCCL to ggml-cuda as PRIVATE, so the final rustc link call left those symbols undefined. v0.5.15 shipped without binaries for linux-x64-cuda because of this.

Close the link gap from the workflow side with RUSTFLAGS=-C link-arg=-lnccl on the Build engine with CUDA step. Keeps NCCL active so real multi-GPU remains supported, and avoids a [patch.crates-io] fork of llama-cpp-sys-2.

Windows CUDA is unaffected: NCCL does not exist on Windows, find_package fails there, GGML_USE_NCCL stays undefined, no NCCL symbols are emitted.

Cache impact: none. sccache caches compile output (content-addressed), not link; the cargo target/registry caches key on Cargo.lock which only changes from the version bump, so a target rebuild is expected but the heavy C/C++/CUDA compile cache stays warm.

Also bumps engine to 0.5.16.