### PR TITLE
fix(engine,ci): keep clippy gate off vendored crates; fix CUDA submod…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,12 @@ jobs:
         run: cargo test
       - name: Clippy
         working-directory: engine
-        run: cargo clippy -- -D warnings -A dead-code -A unused-imports
+        # --no-deps: lint only our own crate, never dependencies. The vendored
+        # llama-cpp-rs crates are workspace members (a path dep under the
+        # workspace root is always a member), so without --no-deps the
+        # RUSTC_WORKSPACE_WRAPPER would run clippy on their build scripts and
+        # `-D warnings` would fail on upstream's pedantic/missing-docs findings.
+        run: cargo clippy --no-deps -- -D warnings -A dead-code -A unused-imports
 
   # ── Hub ──────────────────────────────────────────────────────────────
   hub:

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -164,6 +164,16 @@ jobs:
     container:
       image: nvidia/cuda:${{ matrix.cuda_tag }}
     steps:
+      # The nvidia/cuda image ships without git. actions/checkout then falls
+      # back to a REST API tarball download, which cannot fetch submodules
+      # ("Input 'submodules' not supported when falling back to download using
+      # the GitHub REST API"). Installing git BEFORE checkout lets it do a real
+      # clone and pull the llama.cpp submodule.
+      - name: Install git (container has none; required for submodule checkout)
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y git
+
       - uses: actions/checkout@v5
         with:
           # llama.cpp submodule under engine/vendor/llama-cpp-rs/llama-cpp-sys-2/
@@ -413,7 +423,14 @@ jobs:
           }
           Write-Host "MSVC env activated."
 
+      # continue-on-error: a transient failure of the GitHub Actions cache
+      # service during restore must not nuke this ~50 min long-pole job. On
+      # beta.7 the cache restore here errored and killed the whole build before
+      # a single object compiled. A cache miss/blip should degrade to a slower,
+      # cache-less build (sccache/S3 still carries the C++/CUDA objects anyway),
+      # never a hard failure.
       - uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           key: x86_64-pc-windows-msvc-cuda-12.8
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,47 +3,23 @@ resolver = "2"
 members = [
     "engine",
     "hub",
-    # Vendored llama-cpp-rs (ysimonson:support-gemma4-12b @ c491763b,
-    # upstream PR utilityai/llama-cpp-rs#1034). Absorbed into the root
-    # workspace so the upstream `workspace = true` inheritance in these
-    # crates resolves against the matching keys below — keeping the vendor
-    # tree byte-identical to upstream is preferable to rewriting it. The
-    # llama.cpp C++ source is a git submodule pinned to commit
-    # 7c158fbb4aec1bdc9c81d6ca0e785139f4826fae (first commit including the
-    # `gemma4uv` projector required by Gemma 4 12B Unified multimodal).
+    # Vendored llama-cpp-rs (ysimonson:support-gemma4-12b @ c491763b, upstream
+    # PR utilityai/llama-cpp-rs#1034) — the llama.cpp pin carries the `gemma4uv`
+    # projector that Gemma 4 12B Unified multimodal needs. These are members
+    # because a path dependency living under the workspace root is always
+    # promoted to a member regardless of `exclude` or a nested `[workspace]`
+    # (verified empirically). To keep EuLLM's `-D warnings` clippy gate off this
+    # third-party code, the CI/release clippy step uses `--no-deps` (lints only
+    # our own crates, never dependencies). The vendored manifests are
+    # self-contained (dependency versions inlined from upstream's
+    # `[workspace.dependencies]`), so no root inheritance table is needed.
     #
-    # When utilityai/llama-cpp-rs#1034 merges and llama-cpp-2 0.1.147+ is
-    # published, delete this vendor tree, drop these two members, drop the
-    # `[workspace.dependencies]` entries below, restore engine/Cargo.toml
-    # to the plain registry pin, and remove the llama.cpp submodule.
+    # llama.cpp C++ source is a git submodule pinned to
+    # 7c158fbb4aec1bdc9c81d6ca0e785139f4826fae.
+    #
+    # When utilityai/llama-cpp-rs#1034 merges and llama-cpp-2 0.1.147+ ships on
+    # crates.io: delete this vendor tree, drop these two members, remove the
+    # submodule, and restore engine/Cargo.toml to the registry pin.
     "engine/vendor/llama-cpp-rs/llama-cpp-2",
     "engine/vendor/llama-cpp-rs/llama-cpp-sys-2",
 ]
-
-# Workspace inheritance values consumed by the vendored llama-cpp-rs crates.
-# Copied verbatim from engine/vendor/llama-cpp-rs upstream so the
-# `dep = { workspace = true }` lines in the vendor manifests keep working
-# without any modification.
-[workspace.dependencies]
-thiserror = "2"
-tracing = "0.1"
-tracing-core = "0.1"
-hf-hub = { version = "0.5.0" }
-criterion = "0.5.1"
-pprof = "0.13.0"
-bindgen = "0.72.1"
-cc = "1.2.61"
-anyhow = "1.0.102"
-clap = "4.6.0"
-encoding_rs = "0.8.35"
-tracing-subscriber = { version = "0.3", features = ["json"] }
-
-# Lints applied only to crates that opt in via `[lints] workspace = true`.
-# Our own crates (engine, hub) do NOT opt in, so these strict warnings only
-# affect the vendored llama-cpp-rs crates — same behavior as upstream.
-[workspace.lints.rust]
-missing_docs = { level = "warn" }
-missing_debug_implementations = { level = "warn" }
-
-[workspace.lints.clippy]
-pedantic = { level = "warn" }

--- a/engine/vendor/llama-cpp-rs/llama-cpp-2/Cargo.toml
+++ b/engine/vendor/llama-cpp-rs/llama-cpp-2/Cargo.toml
@@ -6,23 +6,32 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/utilityai/llama-cpp-rs"
 
+# NOTE (EuLLM vendoring): this crate is EXCLUDED from the EuLLM root workspace
+# (see /Cargo.toml `exclude`) so Cargo treats it as an ordinary path dependency
+# with `--cap-lints allow` — our `-D warnings` clippy gate must never lint
+# third-party vendored code. Because it is no longer a workspace member, the
+# `{ workspace = true }` dependency inheritance and `[lints] workspace = true`
+# from upstream are de-inlined to the exact upstream values below, keeping the
+# crate self-contained. Values copied verbatim from upstream's
+# `[workspace.dependencies]` (ysimonson:support-gemma4-12b @ c491763b).
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 enumflags2 = "0.7.12"
 llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.147" }
-thiserror = { workspace = true }
-tracing = { workspace = true }
-tracing-core = { workspace = true }
-encoding_rs = { workspace = true }
+thiserror = "2"
+tracing = "0.1"
+tracing-core = "0.1"
+encoding_rs = "0.8.35"
 llguidance = { version = "1.7.2", optional = true }
 toktrie = { version = "1.7.5", optional = true }
 
 [dev-dependencies]
-encoding_rs = { workspace = true }
-hf-hub = { workspace = true }
+encoding_rs = "0.8.35"
+hf-hub = "0.5.0"
 serde_json = "1.0"
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["json"] }
 
 [features]
 default = ["openmp", "android-shared-stdcxx", "common"]
@@ -55,32 +64,14 @@ llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.147", features =
     "metal",
 ] }
 
-[lints]
-workspace = true
+# [lints] workspace = true removed: this crate is excluded from the EuLLM
+# workspace (cap-lints allow), so the upstream pedantic/missing_docs gate does
+# not apply here.
 
 [package.metadata.docs.rs]
 features = ["sampler"]
 
-[[example]]
-name = "usage"
-path = "../examples/usage.rs"
-
-[[example]]
-name = "tools"
-path = "../examples/tools.rs"
-required-features = ["common"]
-
-[[example]]
-name = "tools_reasoning"
-path = "../examples/tools_reasoning.rs"
-required-features = ["common"]
-
-[[example]]
-name = "openai_stream"
-path = "../examples/openai_stream.rs"
-required-features = ["common"]
-
-[[example]]
-name = "llguidance"
-path = "../examples/llguidance.rs"
-required-features = ["llguidance"]
+# Upstream's [[example]] targets (../examples/*.rs) are intentionally dropped:
+# the examples/ directory is not vendored, so those paths do not exist in this
+# tree and would only matter under `cargo build --examples`, which EuLLM never
+# runs against this crate.

--- a/engine/vendor/llama-cpp-rs/llama-cpp-sys-2/Cargo.toml
+++ b/engine/vendor/llama-cpp-rs/llama-cpp-sys-2/Cargo.toml
@@ -73,9 +73,12 @@ include = [
 
 [dependencies]
 
+# EuLLM vendoring: excluded from the root workspace (cap-lints allow), so the
+# upstream `{ workspace = true }` inheritance is de-inlined to upstream's exact
+# values (ysimonson:support-gemma4-12b @ c491763b workspace.dependencies).
 [build-dependencies]
-bindgen = { workspace = true }
-cc = { workspace = true, features = ["parallel"] }
+bindgen = "0.72.1"
+cc = { version = "1.2.61", features = ["parallel"] }
 cmake = "0.1"
 find_cuda_helper = "0.2.0"
 glob = "0.3.3"


### PR DESCRIPTION
…ule checkout

beta.7's release run surfaced three failures, all consequences of the vendoring landing without a real compile/CI pass (CI only runs on `main`, so the branch never exercised them). This fixes all three; the version stays at 0.6.0-beta.7 so the existing tag/release can be deleted and recreated.

1) CI Engine job (clippy) — the real blocker
   `cargo clippy -- -D warnings` linted the vendored llama-cpp-rs crates
   because a path dependency living under the workspace root is ALWAYS a
   workspace member (verified: cargo `exclude` and a nested `[workspace]`
   do NOT demote it), and RUSTC_WORKSPACE_WRAPPER runs clippy on every
   member. Upstream's build.rs then tripped clippy::uninlined_format_args
   and missing_docs, which `-D warnings` turned into hard errors.
   Fix: `cargo clippy --no-deps` (lint only our own crate). Proven locally
   — full CI-equivalent clippy now exits 0; the vendored crate's own
   warnings are shown but no longer gate. Belt-and-suspenders: the vendored
   manifests are now self-contained (dependency versions inlined from
   upstream's [workspace.dependencies]) and drop `[lints] workspace = true`,
   so even when compiled as members they carry no pedantic/missing-docs
   opt-in. The root workspace.dependencies/workspace.lints tables (added in
   beta.7) are removed as no longer needed. Dangling upstream `[[example]]`
   targets (pointing at a non-vendored examples/ dir) are dropped too.

2) build-cuda (Linux CUDA, container) — submodule checkout
   nvidia/cuda images ship without git, so actions/checkout fell back to the
   REST API tarball, which cannot fetch submodules ("Input 'submodules' not
   supported when falling back to download using the GitHub REST API"). Added
   a git-install step BEFORE checkout so it does a real clone. This is a
   container-only issue: the standard Linux/macOS/Windows runners have git and
   their builds passed (proving the vendored crates + new llama.cpp pin compile
   cross-platform).

3) build-windows-cuda — transient cache-service failure
   The job died at Swatinem/rust-cache restore (GitHub Actions cache backend
   blip), before any compile, nuking the ~50 min long-pole. Added
   `continue-on-error: true` so a cache outage degrades to a slower cacheless
   build (sccache/S3 still carries the C++/CUDA objects) instead of failing.