### PR TITLE
chore(engine): 0.6.1 — multimodal vision fix (BOS) promoted to stable

### DIFF
--- a/catalog/v1/catalog.json
+++ b/catalog/v1/catalog.json
@@ -91,7 +91,7 @@
     {
       "id": "gemma-4-e4b",
       "name": "Gemma 4 E4B Instruct (vision-capable)",
-      "description": "Google Gemma 4, E4B effective-parameter variant. Apache 2.0, strong multilingual chat (140+ languages), multimodal text + image. Mixed SWA architecture (D=512/256): the engine auto-pins the KV cache to f16, which it requires. Released March 2026 — its mmproj uses the pre-unified projector type, so it works with the currently-shipped llama-cpp-2 (unlike the 12B Unified variant, whose newer `gemma4uv` projector awaits an upstream bump).",
+      "description": "Google Gemma 4, E4B effective-parameter variant. Apache 2.0, strong multilingual chat (140+ languages), multimodal text + image. Mixed SWA architecture (D=512/256): the engine auto-pins the KV cache to f16, which it requires. Released March 2026 — its mmproj uses the pre-unified projector type, so it works with the currently-shipped llama-cpp-2 (unlike the 12B Unified variant, whose newer `gemma4uv` projector is served by EULLM's vendored llama-cpp-rs build).",
       "params_b": 4.0,
       "quantization": "Q4_K_M",
       "size_bytes": 4977169568,

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.1-beta.4"
+version = "0.6.1"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -156,8 +156,8 @@ enum Commands {
         /// image or audio file to send together with the first prompt.
         /// Triggers the multimodal inference path (mtmd) which requires the
         /// model's mmproj projector to be available; for catalog models it
-        /// is auto-downloaded during `pull`. Currently CLI-only; the HTTP
-        /// API does not yet route media input.
+        /// is auto-downloaded during `pull`. The HTTP API also routes media
+        /// (web chat / `/api/chat` `images`); this flag is the CLI one-shot.
         #[arg(long, value_name = "PATH")]
         image: Option<PathBuf>,
     },


### PR DESCRIPTION
Vision is now correct on all images (portraits, vertical/dark shots, not just easy landscapes). Root cause was the missing <bos> token in the shared mtmd tokenize path (fixed in 0698e2c): Gemma requires BOS, and generate_multimodal sent the hand-built prompt without it, degrading the model into 'wall of text / line art' confabulation on harder subjects. Confirmed by an A/B of released binaries — beta.3 (no BOS) hallucinates, beta.4 (BOS) sees — on both the web/API and CLI one-shot paths.

Also refresh two stale docs: the CLI --image help (the HTTP API does route media now) and the E4B catalog blurb (the 12B gemma4uv projector is served by the vendored llama-cpp-rs, no upstream bump pending).