### PR TITLE
fix(engine): pass placeholder arg to MtmdBitmap::from_buffer

### DIFF
--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -1004,7 +1004,9 @@ impl InferenceEngine {
         // ── 3. Decode media bytes into mtmd bitmaps ─────────────────────
         let mut bitmaps: Vec<MtmdBitmap> = Vec::with_capacity(media.len());
         for (i, bytes) in media.iter().enumerate() {
-            match MtmdBitmap::from_buffer(mtmd_ctx, bytes) {
+            // llama-cpp-2 0.1.151 added a `placeholder` flag to from_buffer:
+            // false = decode and load the actual media (what we need for inference).
+            match MtmdBitmap::from_buffer(mtmd_ctx, bytes, false) {
                 Ok(b) => bitmaps.push(b),
                 Err(e) => {
                     let _ = tx.blocking_send(StreamEvent::Error(format!(


### PR DESCRIPTION
llama-cpp-2 0.1.151 added a third `placeholder: bool` parameter to MtmdBitmap::from_buffer. Pass false (decode and load the actual media), matching the prior 0.1.147 behavior. Only the cuda,multimodal release jobs compile this path, so the break surfaced solely on the CUDA builds.