### PR TITLE
ci(release): add ARM64 + CUDA build (build-cuda-arm64)

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -283,6 +283,120 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
 
+  # ARM64 + CUDA. Same recipe as build-cuda, on GitHub's free aarch64 runners
+  # (ubuntu-24.04-arm) with the sbsa (aarch64) nvidia/cuda image — the tag is a
+  # multi-arch manifest, so the arm64 variant is pulled automatically here.
+  # Targets ARM hosts with a discrete NVIDIA GPU (Ampere Altra / Grace + RTX,
+  # ARM dev kits, etc.). Compiling CUDA needs only nvcc, not a GPU on the runner.
+  build-cuda-arm64:
+    strategy:
+      matrix:
+        include:
+          - cuda: "12.8.1"
+            artifact: eullm-linux-arm64-cuda-12.8
+            cuda_tag: "12.8.1-devel-ubuntu22.04"
+
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: nvidia/cuda:${{ matrix.cuda_tag }}
+    steps:
+      - name: Install git (container has none; required for submodule checkout)
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y git
+
+      - uses: actions/checkout@v5
+        with:
+          # llama.cpp submodule under engine/vendor/llama-cpp-rs/llama-cpp-sys-2/
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y curl cmake build-essential pkg-config libssl-dev git libclang-dev
+
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      # Cache cargo registry (arch-specific key so it never collides with x64)
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-registry-cuda-arm64-${{ hashFiles('Cargo.lock') }}
+          restore-keys: cargo-registry-cuda-arm64-
+
+      # Cache Rust target/ directory (arch-specific: arm64 objects differ from x64)
+      - uses: actions/cache@v5
+        with:
+          path: target
+          key: target-cuda-arm64-${{ matrix.cuda }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: target-cuda-arm64-${{ matrix.cuda }}-
+
+      - name: Install sccache
+        run: |
+          SCCACHE_VER=0.8.0
+          TMPSC=$(mktemp -d)
+          curl -sSfL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-aarch64-unknown-linux-musl.tar.gz" \
+            -o "${TMPSC}/sccache.tar.gz"
+          tar -xzf "${TMPSC}/sccache.tar.gz" -C "${TMPSC}"
+          find "${TMPSC}" -maxdepth 2 -name sccache -type f -exec mv {} /usr/local/bin/ \;
+          chmod +x /usr/local/bin/sccache
+          rm -rf "${TMPSC}"
+          # Same S3 reachability probe as the x64 job: a backend outage degrades
+          # to a cache-less build, never a failed one.
+          if curl -sSf -m 10 "${SCCACHE_ENDPOINT}/minio/health/live" >/dev/null 2>&1; then
+            echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+            echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+            echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+            echo "CMAKE_CUDA_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+            echo "sccache: S3 backend reachable — caching enabled."
+          else
+            echo "::warning::sccache S3 backend (${SCCACHE_ENDPOINT}) unreachable — building WITHOUT cache (slower, but the build will not fail)."
+          fi
+          sccache --version
+          sccache --start-server || true
+
+      - name: Build engine with CUDA + multimodal (mtmd)
+        run: |
+          . "$HOME/.cargo/env"
+          export PATH="/usr/local/cuda/bin:$PATH"
+          cargo build --release --features "cuda,multimodal" -p eullm-engine
+        env:
+          CUDA_PATH: /usr/local/cuda
+          CUDACXX: /usr/local/cuda/bin/nvcc
+          CMAKE_CUDA_COMPILER: /usr/local/cuda/bin/nvcc
+          # Same consumer NVIDIA set as the x64 CUDA job:
+          #   sm_86 = Ampere (RTX 3000, e.g. the RTX 3060 on ARM hosts)
+          #   sm_89 = Ada Lovelace (RTX 4000)
+          #   sm_120 = Blackwell (RTX 5000)
+          CMAKE_CUDA_ARCHITECTURES: "86;89;120"
+          # Same NCCL link fix as build-cuda: the devel image defines
+          # GGML_USE_NCCL (find_package(NCCL) succeeds), but llama-cpp-sys-2
+          # never emits `cargo:rustc-link-lib=nccl`, so the final rustc link
+          # sees nccl* symbols undefined without this flag.
+          RUSTFLAGS: "-C link-arg=-lnccl"
+
+      - name: sccache stats (visibility into S3 hit/miss)
+        if: always()
+        shell: bash
+        run: sccache --show-stats || true
+
+      - name: Package binary
+        run: |
+          cp target/release/eullm ${{ matrix.artifact }}
+          strip --strip-all ${{ matrix.artifact }} || true
+          chmod +x ${{ matrix.artifact }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
   build-windows:
     runs-on: windows-2022
     steps:
@@ -526,6 +640,7 @@ jobs:
     needs:
       - build
       - build-cuda
+      - build-cuda-arm64
       - build-windows
       - build-windows-cuda
     # Run as long as at least one upstream job built something. We never
@@ -569,6 +684,7 @@ jobs:
             artifacts/eullm-linux-x64/eullm-linux-x64
             artifacts/eullm-linux-x64-cuda-12.8/eullm-linux-x64-cuda-12.8
             artifacts/eullm-linux-arm64/eullm-linux-arm64
+            artifacts/eullm-linux-arm64-cuda-12.8/eullm-linux-arm64-cuda-12.8
             artifacts/eullm-macos-x64/eullm-macos-x64
             artifacts/eullm-macos-arm64/eullm-macos-arm64
             artifacts/eullm-windows-x64/eullm-windows-x64.exe


### PR DESCRIPTION
Adds an aarch64 Linux + CUDA release binary (eullm-linux-arm64-cuda-12.8) for ARM hosts with a discrete NVIDIA GPU. Mirrors the x64 build-cuda job on GitHub's free ubuntu-24.04-arm runners with the sbsa nvidia/cuda devel image (multi-arch tag → arm64 variant pulled automatically). Compiling CUDA needs only nvcc, so no GPU runner is required.

Same CUDA arch set (86;89;120 — sm_86 covers RTX 3060), same NCCL link fix, same S3 sccache with an arch-specific cache key so it never collides with the x64 target/ cache. Wired into the release job's needs + files; graceful degradation still applies, so a failure here won't block the other binaries.