### PR TITLE
fix(cuda): drop NCCL so Linux CUDA binaries need only the driver

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -252,19 +252,12 @@ jobs:
           # archs, so adding two more arches grows the file by ~kernel
           # cubins only (~50-80 MB each), not 3x.
           CMAKE_CUDA_ARCHITECTURES: "86;89;120"
-          # llama-cpp-sys-2 0.1.146 compiles ggml-cuda with NCCL on (option
-          # GGML_CUDA_NCCL=ON in the vendored llama.cpp CMake). nvidia/cuda
-          # 12.8-devel ships nccl.h + libnccl.so, so find_package(NCCL)
-          # succeeds and GGML_USE_NCCL gets defined, pulling in
-          # ggml_backend_cuda_allreduce_tensor with refs to ncclCommInitAll,
-          # ncclAllReduce, ncclGroupStart/End, ncclGetErrorString. But the
-          # crate's build.rs never emits `cargo:rustc-link-lib=nccl`, and
-          # CMake links NCCL to ggml-cuda as PRIVATE, so the final rustc
-          # link call sees those symbols undefined. Closing the gap here
-          # keeps NCCL active (multi-GPU stays on the table) without
-          # forking llama-cpp-sys-2. v0.5.15 shipped without this and the
-          # build-cuda job failed at link.
-          RUSTFLAGS: "-C link-arg=-lnccl"
+          # NCCL is disabled at the CMake level in the vendored build.rs
+          # (GGML_CUDA_NCCL=OFF). It is a multi-GPU collective library that made
+          # the binary hard-depend on libnccl.so.2 at runtime — breaking
+          # single-GPU consumer machines that only have the driver. With it off,
+          # no nccl symbols are referenced, so no `-lnccl` link flag is needed
+          # and the binary depends only on libcuda.so.1 (the driver).
 
       - name: sccache stats (visibility into S3 hit/miss)
         if: always()
@@ -374,11 +367,10 @@ jobs:
           #   sm_89 = Ada Lovelace (RTX 4000)
           #   sm_120 = Blackwell (RTX 5000)
           CMAKE_CUDA_ARCHITECTURES: "86;89;120"
-          # Same NCCL link fix as build-cuda: the devel image defines
-          # GGML_USE_NCCL (find_package(NCCL) succeeds), but llama-cpp-sys-2
-          # never emits `cargo:rustc-link-lib=nccl`, so the final rustc link
-          # sees nccl* symbols undefined without this flag.
-          RUSTFLAGS: "-C link-arg=-lnccl"
+          # NCCL disabled at the CMake level (GGML_CUDA_NCCL=OFF in build.rs), so
+          # no `-lnccl` and no libnccl.so.2 runtime dependency — critical here,
+          # since an ARM host with only the driver (no NCCL, no sudo) otherwise
+          # can't start the binary. See the x64 job for the full rationale.
 
       - name: sccache stats (visibility into S3 hit/miss)
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.8"
+version = "0.6.9"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/vendor/llama-cpp-rs/llama-cpp-sys-2/build.rs
+++ b/engine/vendor/llama-cpp-rs/llama-cpp-sys-2/build.rs
@@ -854,6 +854,17 @@ fn main() {
     if cfg!(feature = "cuda") {
         config.define("GGML_CUDA", "ON");
 
+        // Disable NCCL. It is a multi-GPU collective-communication library; with
+        // GGML_CUDA_NCCL on (the ggml default) and NCCL present in the build
+        // image, ggml-cuda links libnccl.so.2, which the final binary then
+        // hard-depends on at runtime. That breaks single-GPU consumer machines
+        // that only have the NVIDIA driver installed (no NCCL package) — the
+        // binary won't even start (`libnccl.so.2: cannot open shared object
+        // file`). EuLLM targets single-GPU inference, so turn it off: the CUDA
+        // binary then needs only libcuda.so.1 (the driver); cudart/cublas are
+        // linked statically.
+        config.define("GGML_CUDA_NCCL", "OFF");
+
         if cfg!(feature = "cuda-no-vmm") {
             config.define("GGML_CUDA_NO_VMM", "ON");
         }


### PR DESCRIPTION
The Linux CUDA binaries hard-depended on libnccl.so.2 at runtime and would not start on a machine that only has the NVIDIA driver installed (no NCCL package) — e.g. an ARM host with a discrete GPU and a non-root user: 'error while loading shared libraries: libnccl.so.2: cannot open shared object file'.

Root cause: ggml-cuda's CMake defaults GGML_CUDA_NCCL=ON, and the nvidia/cuda devel build image ships NCCL, so find_package(NCCL) succeeded, GGML_USE_NCCL was defined, and the binary linked libnccl.so.2. A prior workaround (-C link-arg=-lnccl) only satisfied the link; it did not remove the runtime dependency.

NCCL is a multi-GPU collective-communication library; EuLLM targets single-GPU inference, so it is dead weight. Disable it at the CMake level (GGML_CUDA_NCCL=OFF in the vendored llama-cpp-sys-2 build.rs) and drop the now-unnecessary -lnccl RUSTFLAG from both Linux CUDA jobs. The binary then depends only on libcuda.so.1 (the driver); cudart/cublas remain statically linked. Windows CUDA was never affected (NCCL is Linux-only, so find_package(NCCL) already failed there).

Bumps engine to 0.6.9.