### PR TITLE
docs(readme): mark ARM64 + CUDA binary as tested (v0.6.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ curl http://localhost:11434/v1/chat/completions \
 | 🐧 Linux x64 (CPU) | `eullm-linux-x64` | ✅ Tested | – |
 | 🐧 Linux x64 (NVIDIA) | `eullm-linux-x64-cuda-12.8` | ✅ Tested | RTX 3000/4000/5000 |
 | 🐧 Linux ARM64 | `eullm-linux-arm64` | ✅ Tested (community) | Validated on Raspberry Pi 400; RPi 4/5, Orange Pi 5+, Jetson, etc. |
-| 🐧 Linux ARM64 (NVIDIA) | `eullm-linux-arm64-cuda-12.8` | 🆕 New (v0.6.8) — [testing wanted](#-platform-status--help-us-test) | ARM host + discrete NVIDIA GPU (sm_86/89/120), e.g. RTX 3060 on an ARM server |
+| 🐧 Linux ARM64 (NVIDIA) | `eullm-linux-arm64-cuda-12.8` | ✅ Tested | ARM host + discrete NVIDIA GPU (sm_86/89/120); validated on an RTX 3060 12GB ARM server, qwen3-14b Q4 at 33 tok/s |
 | 🍎 macOS Apple Silicon (Metal) | `eullm-macos-arm64` | ✅ Tested (community) | Validated on M2 Pro (Metal); M1/M2/M3/M4 |
 | 🍎 macOS Intel | `eullm-macos-x64` | 🧪 [Experimental — untested](#-platform-status--help-us-test) | Pre-Apple-Silicon Macs |
 | 🪟 Windows 11 x64 (CPU) | `eullm-windows-x64.exe` | ✅ Tested | Standalone binary, CLI/server |
@@ -71,7 +71,7 @@ curl http://localhost:11434/v1/chat/completions \
 
 ### 🧪 Platform status / help us test
 
-The Linux x64 and Windows x64 binaries are validated end-to-end by the maintainer. **macOS Apple Silicon (Metal)** and **Linux ARM64** are now **community-validated** (see the testers below). **macOS Intel (x64)** still compiles in CI but nobody has run it on that hardware yet — it remains **Experimental — untested**.
+The Linux x64, Windows x64, and Linux ARM64 (CUDA) binaries are validated end-to-end by the maintainer. **macOS Apple Silicon (Metal)** and **Linux ARM64 (CPU)** are now **community-validated** (see the testers below). **macOS Intel (x64)** still compiles in CI but nobody has run it on that hardware yet — it remains **Experimental — untested**.
 
 If you run local LLMs on a Mac or an ARM64 board (Raspberry Pi 4/5, Orange Pi 5+, Rock 5B, Jetson, …), **your help validating these binaries is hugely appreciated**. See the open testing call:
 
@@ -356,7 +356,7 @@ chmod +x eullm
 ./eullm run ./your-model.gguf
 ```
 
-Available for: Linux x64 (CPU, CUDA) ✅ · Windows x64 (CPU, CUDA) ✅ · Linux ARM64 + macOS Apple Silicon (Metal) ✅ *(community-validated)* · Linux ARM64 (CUDA) 🆕 *(new in v0.6.8)* · macOS x64 🧪 [community testing wanted](#-platform-status--help-us-test).
+Available for: Linux x64 (CPU, CUDA) ✅ · Windows x64 (CPU, CUDA) ✅ · Linux ARM64 (CUDA) ✅ · macOS Apple Silicon (Metal) + Linux ARM64 (CPU) ✅ *(community-validated)* · macOS x64 🧪 [community testing wanted](#-platform-status--help-us-test).
 
 ### Build from source
 


### PR DESCRIPTION
eullm-linux-arm64-cuda-12.8 validated end-to-end: qwen3-14b Q4_K_M, full GPU offload, 33.2 tok/s decode on an RTX 3060 12GB ARM server — and, because the run only needed the NVIDIA driver, confirms the NCCL runtime dependency fix (v0.6.9) actually holds on real ARM+GPU hardware.