### PR TITLE
feat(engine): add --cpu-moe for MoE models on small GPUs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" />
   <img src="https://img.shields.io/badge/EU%20AI%20Act-Designed%20for%20compliance-gold" alt="EU AI Act" />
-  <img src="https://img.shields.io/badge/Engine-v0.6.10-2ea44f" alt="Engine status" />
+  <img src="https://img.shields.io/badge/Engine-v0.6.11-2ea44f" alt="Engine status" />
   <img src="https://img.shields.io/badge/Forge%20%2B%20Hub-Early%20development-orange" alt="Forge/Hub status" />
   <a href="https://github.com/eullm/eullm/actions/workflows/ci.yml"><img src="https://github.com/eullm/eullm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://doi.org/10.5281/zenodo.20412979"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20412979.svg" alt="DOI" /></a>
@@ -164,7 +164,34 @@ curl -s http://localhost:11434/api/generate \
 EULLM extension, not part of the Ollama API) — call the endpoint directly
 from any language/script that already talks to the API port.
 
+### Run MoE models on a small GPU (`--cpu-moe`, new in v0.6.11)
+
+MoE models (Qwen3-30B-A3B, Qwen3.6-35B-A3B, …) route each token through only
+a handful of experts, but the expert weights make up most of the file on
+disk — `--gpu-layers`/`--fit` can only offload whole layers (all their
+experts included), so a 20+ GB MoE model still needs 20+ GB of VRAM to run
+mostly on GPU.
+
+`--cpu-moe` keeps just the expert tensors (`*.ffn_(up|down|gate)_exps`) on
+CPU RAM, while attention, embeddings, and — critically — the whole KV cache
+stay on GPU. Since only a few experts fire per token, this trades a small
+CPU-matmul cost for VRAM headroom `--gpu-layers` can't reach: a 22 GB MoE
+Q4_K_M can run at near-GPU speed on a 12 GB card, as long as system RAM
+holds the rest.
+
+```bash
+# Qwen3.6-35B-A3B, Q4_K_M (~22 GB) on a 12 GB GPU + enough system RAM
+eullm run hf.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF:Q4_K_M --cpu-moe --fit
+```
+
+Combines with `--gpu-layers`/`--fit` (which still size the non-expert
+tensors) and `--ctx-size` as usual. No effect on dense (non-MoE) models —
+the tensor pattern simply matches nothing. Available on `eullm run` and
+`eullm serve` (applied to every model the server loads or swaps to).
+
 ## What's ready today, what's coming
+
+**New in v0.6.11** — **`--cpu-moe`**: run MoE models (Qwen3-30B-A3B, Qwen3.6-35B-A3B, …) on a small GPU by keeping expert tensors on CPU RAM while attention, embeddings, and the KV cache stay on GPU — VRAM headroom whole-layer `--gpu-layers` offload can't reach. See "Run MoE models on a small GPU" above.
 
 **New in v0.6.10** — consumer-GPU and operations pass on top of v0.6.3:
 - **`--fit`** auto-sizes GPU-offloaded layers to free VRAM (CUDA), charging each layer its weight share *and* its KV-cache slice for the chosen context/cache type — quantizing the KV (`--cache-type-k/v q4_0`) frees room for more layers, the gain growing with context length. On by default from the interactive picker; opt-in on the scriptable CLI. Falls back to partial offload, or to a manual `--gpu-layers`, when it can't size the model.
@@ -229,6 +256,7 @@ eullm run ./model.gguf                    # Local GGUF file
 eullm run ./model.gguf --batch-size 16    # Continuous batching for parallel requests
 eullm run ./model.gguf --web              # Transparent web browsing (URLs in messages auto-fetched)
 eullm run legal-it-7b                     # From EU registry (coming soon)
+eullm run big-moe-model.gguf --cpu-moe --fit  # MoE: experts on CPU RAM, rest on GPU
 
 # CLI
 eullm list                                # Show local and available models

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -57,6 +57,9 @@ pub struct AppState {
     pub cache_type_v: crate::inference::KvCacheType,
     /// 0 = sequential, >0 = continuous batching with this many slots.
     pub batch_size: usize,
+    /// Keep MoE expert tensors on CPU RAM (see `InferenceConfig::cpu_moe`).
+    /// Applied to every model this server loads or swaps to.
+    pub cpu_moe: bool,
 
     /// Enable transparent web fetching: URLs in user messages are fetched
     /// and their content is injected into the prompt before inference.
@@ -141,6 +144,7 @@ impl AppState {
             // `engine.generate_multimodal()`. Models without an mmproj keep
             // the text-only fast path (None → no extra VRAM, no init cost).
             mmproj_path: mmproj_path.clone(),
+            cpu_moe: self.cpu_moe,
         };
 
         // The continuous-batching scheduler is text-only — it does not route
@@ -328,6 +332,7 @@ pub struct ServeConfig {
     pub cache_type_k: crate::inference::KvCacheType,
     pub cache_type_v: crate::inference::KvCacheType,
     pub batch_size: usize,
+    pub cpu_moe: bool,
     pub web_enabled: bool,
     pub store: ModelStore,
     /// Optional embedded chat UI. When `Some(port)`, a second listener is
@@ -358,6 +363,7 @@ pub async fn serve(cfg: ServeConfig) -> Result<(), Box<dyn std::error::Error>> {
         cache_type_k: cfg.cache_type_k,
         cache_type_v: cfg.cache_type_v,
         batch_size: cfg.batch_size,
+        cpu_moe: cfg.cpu_moe,
         web_enabled: cfg.web_enabled,
         api_port: cfg.port,
         store: cfg.store,

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -140,6 +140,16 @@ pub struct InferenceConfig {
     /// image / audio input. When `None` or the feature is off, the engine
     /// runs text-only exactly as before.
     pub mmproj_path: Option<PathBuf>,
+    /// Keep MoE expert tensors (`*.ffn_(up|down|gate)_exps`) on CPU RAM
+    /// while everything else — attention, embeddings, shared/dense layers,
+    /// and the KV cache — loads onto GPU as usual. Equivalent to llama.cpp's
+    /// `--cpu-moe`. For MoE models the expert tensors are the bulk of the
+    /// file but only a handful fire per token, so this trades a small
+    /// compute-bandwidth cost (CPU matmul for the routed experts) for a much
+    /// smaller VRAM footprint than offloading whole layers via `gpu_layers`.
+    /// No effect on dense (non-MoE) models — the tensor pattern simply
+    /// matches nothing.
+    pub cpu_moe: bool,
 }
 
 impl Default for InferenceConfig {
@@ -158,6 +168,7 @@ impl Default for InferenceConfig {
             cache_type_k: KvCacheType::F16,
             cache_type_v: KvCacheType::F16,
             mmproj_path: None,
+            cpu_moe: false,
         }
     }
 }
@@ -406,7 +417,11 @@ impl InferenceEngine {
             // -1 = offload all layers
             LlamaModelParams::default().with_n_gpu_layers(1000)
         };
-        let model_params = pin!(model_params);
+        let mut model_params = pin!(model_params);
+        if config.cpu_moe {
+            tracing::info!("--cpu-moe: keeping MoE expert tensors on CPU RAM");
+            model_params.as_mut().add_cpu_moe_override();
+        }
 
         tracing::info!("Loading model: {}", config.model_path.display());
         let model = LlamaModel::load_from_file(&backend, &config.model_path, &model_params)

--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -293,7 +293,11 @@ fn run_scheduler_loop(
     } else {
         LlamaModelParams::default().with_n_gpu_layers(1000)
     };
-    let model_params = pin!(model_params);
+    let mut model_params = pin!(model_params);
+    if config.cpu_moe {
+        tracing::info!("--cpu-moe: keeping MoE expert tensors on CPU RAM");
+        model_params.as_mut().add_cpu_moe_override();
+    }
 
     tracing::info!("Loading model: {}", config.model_path.display());
     let model = match LlamaModel::load_from_file(&backend, &config.model_path, &model_params) {

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -102,6 +102,17 @@ enum Commands {
         #[arg(long)]
         fit_strict: bool,
 
+        /// For MoE models (e.g. Qwen3-30B-A3B): keep expert tensors
+        /// (`*.ffn_(up|down|gate)_exps`) on CPU RAM while attention,
+        /// embeddings, and the KV cache stay on GPU. Only a few experts fire
+        /// per token, so this trades a small compute cost for VRAM headroom
+        /// far beyond what --gpu-layers' whole-layer offload can reach — a
+        /// 20+ GB MoE model can run mostly-GPU-speed on a 12 GB card. No
+        /// effect on dense (non-MoE) models. Combines with --gpu-layers/--fit
+        /// (which still control the non-expert tensors) and --ctx-size.
+        #[arg(long)]
+        cpu_moe: bool,
+
         /// Context window size
         #[arg(short, long, default_value_t = 4096)]
         ctx_size: u32,
@@ -209,6 +220,12 @@ enum Commands {
         /// Enable continuous batching with N max concurrent requests (0 = sequential)
         #[arg(long, default_value_t = 8)]
         batch_size: usize,
+
+        /// For MoE models: keep expert tensors on CPU RAM, attention +
+        /// embeddings + KV cache on GPU. Applied to every model this server
+        /// loads or swaps to. See `eullm run --help` for the full rationale.
+        #[arg(long)]
+        cpu_moe: bool,
 
         /// Enable the embedded chat UI (off by default for headless serve).
         /// Pass --ui to also expose the chat at http://localhost:<ui-port>/.
@@ -369,7 +386,7 @@ async fn main() {
             Some(picker::Picked::Local(path)) => Commands::Run {
                 model: Some(path.to_string_lossy().into_owned()),
                 port: 11434, replace: false, gpu_layers: -1, fit: true,
-                fit_strict: false, ctx_size: 4096,
+                fit_strict: false, cpu_moe: false, ctx_size: 4096,
                 threads: None, batch_size: 1, no_flash_attn: false,
                 n_batch: 2048, cache_type_k: "f16".into(),
                 cache_type_v: "f16".into(), web: false, no_ui: false,
@@ -380,7 +397,7 @@ async fn main() {
             Some(picker::Picked::Catalog(entry)) => Commands::Run {
                 model: Some(entry.id.clone()),
                 port: 11434, replace: false, gpu_layers: -1, fit: true,
-                fit_strict: false, ctx_size: 4096,
+                fit_strict: false, cpu_moe: false, ctx_size: 4096,
                 threads: None, batch_size: 1, no_flash_attn: false,
                 n_batch: 2048, cache_type_k: "f16".into(),
                 cache_type_v: "f16".into(), web: false, no_ui: false,
@@ -421,6 +438,7 @@ async fn main() {
             gpu_layers,
             fit,
             fit_strict,
+            cpu_moe,
             ctx_size,
             threads,
             batch_size,
@@ -483,15 +501,15 @@ async fn main() {
             // Auto-open the browser chat unless the user asked for terminal-only
             // (--cli / --no-chat) or disabled the UI entirely (--no-ui).
             let open_chat = !cli && ui_port_opt.is_some();
-            cmd_run(&store, &model, port, replace, gpu_layers, fit, fit_strict, ctx_size, threads, batch_size, !no_flash_attn, n_batch, ctk, ctv, web, ui_port_opt, open_chat, image).await;
+            cmd_run(&store, &model, port, replace, gpu_layers, fit, fit_strict, cpu_moe, ctx_size, threads, batch_size, !no_flash_attn, n_batch, ctk, ctv, web, ui_port_opt, open_chat, image).await;
         }
         Commands::List => cmd_list(&store),
         Commands::Show { model } => cmd_show(&store, &model),
         Commands::Rm { model, force } => cmd_rm(&store, &model, force),
-        Commands::Serve { port, replace, batch_size: _, ui, ui_port, daemon, pidfile } => {
+        Commands::Serve { port, replace, batch_size: _, cpu_moe, ui, ui_port, daemon, pidfile } => {
             let _ = (daemon, pidfile);
             let ui_port_opt = if ui { Some(ui_port) } else { None };
-            cmd_serve(port, replace, ui_port_opt).await;
+            cmd_serve(port, replace, ui_port_opt, cpu_moe).await;
         }
         Commands::Unload { port } => cmd_unload(port).await,
         Commands::ImportOllama { model, ollama_dir } => cmd_import_ollama(&store, &model, ollama_dir.as_deref()),
@@ -1195,6 +1213,7 @@ async fn cmd_run(
     gpu_layers: i32,
     fit: bool,
     fit_strict: bool,
+    cpu_moe: bool,
     ctx_size: u32,
     threads: Option<u32>,
     batch_size: usize,
@@ -1353,6 +1372,7 @@ async fn cmd_run(
             cache_type_k,
             cache_type_v,
             mmproj_path: mmproj_for_config.clone(),
+            cpu_moe,
         };
 
         // The continuous-batching scheduler is text-only; multimodal models
@@ -1442,6 +1462,9 @@ async fn cmd_run(
         };
         println!("  GPU backend:   {gpu_backend}");
         println!("  GPU layers:    {}", if gpu_layers < 0 { "all".to_string() } else { gpu_layers.to_string() });
+        if cpu_moe {
+            println!("  CPU MoE:       enabled (expert tensors on CPU RAM)");
+        }
         if batch_size > 0 {
             let per_seq = ctx_size / batch_size as u32;
             println!("  Context:       {ctx_size} total ({per_seq} per sequence × {batch_size} slots)");
@@ -1539,6 +1562,7 @@ async fn cmd_run(
             cache_type_k,
             cache_type_v,
             batch_size,
+            cpu_moe,
             web_enabled: web,
             store: api_store,
             ui_port,
@@ -1580,7 +1604,7 @@ async fn cmd_run(
     }
 }
 
-async fn cmd_serve(port: u16, replace: bool, ui_port: Option<u16>) {
+async fn cmd_serve(port: u16, replace: bool, ui_port: Option<u16>, cpu_moe: bool) {
     ensure_port_available(port, replace).await;
     if let Some(p) = ui_port {
         ensure_port_available(p, replace).await;
@@ -1613,6 +1637,7 @@ async fn cmd_serve(port: u16, replace: bool, ui_port: Option<u16>) {
         cache_type_k: inference::KvCacheType::Q8_0,
         cache_type_v: inference::KvCacheType::Q4_0,
         batch_size: 8,
+        cpu_moe,
         web_enabled: false,
         store,
         ui_port,


### PR DESCRIPTION
Adds a --cpu-moe flag (eullm run and eullm serve) that keeps a MoE model's expert tensors (*.ffn_(up|down|gate)_exps) on CPU RAM while attention, embeddings, and the KV cache stay on GPU. Since only a handful of experts fire per token, this reaches VRAM headroom that whole-layer --gpu-layers offload cannot: a 20+ GB MoE model can run at near-GPU speed on a 12 GB card, as long as system RAM holds the expert weights.

The underlying primitive already existed in the vendored llama-cpp-2 binding (LlamaModelParams::add_cpu_moe_override, applying llama.cpp's own --cpu-moe tensor pattern) but was never called from EULLM's own code — InferenceConfig had no field for it and no CLI flag existed. This wires it through: a new InferenceConfig.cpu_moe field, applied at both model load sites (the sequential engine and the continuous-batching scheduler), threaded through AppState/ServeConfig so eullm serve applies it to every model it loads or swaps to, and surfaced in the startup banner when enabled.

Combines with --gpu-layers/--fit (which still size the non-expert tensors) and --ctx-size unchanged. No effect on dense (non-MoE) models.

Bumps engine to 0.6.11.