### PR TITLE
feat: add --n-cpu-moe N for per-layer MoE CPU offload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" />
   <img src="https://img.shields.io/badge/EU%20AI%20Act-Designed%20for%20compliance-gold" alt="EU AI Act" />
-  <img src="https://img.shields.io/badge/Engine-v0.6.11-2ea44f" alt="Engine status" />
+  <img src="https://img.shields.io/badge/Engine-v0.6.12-2ea44f" alt="Engine status" />
   <img src="https://img.shields.io/badge/Forge%20%2B%20Hub-Early%20development-orange" alt="Forge/Hub status" />
   <a href="https://github.com/eullm/eullm/actions/workflows/ci.yml"><img src="https://github.com/eullm/eullm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://doi.org/10.5281/zenodo.20412979"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20412979.svg" alt="DOI" /></a>
@@ -164,7 +164,7 @@ curl -s http://localhost:11434/api/generate \
 EULLM extension, not part of the Ollama API) — call the endpoint directly
 from any language/script that already talks to the API port.
 
-### Run MoE models on a small GPU (`--cpu-moe`, new in v0.6.11)
+### Run MoE models on a small GPU (`--cpu-moe` / `--n-cpu-moe`, new in v0.6.11 / v0.6.12)
 
 MoE models (Qwen3-30B-A3B, Qwen3.6-35B-A3B, …) route each token through only
 a handful of experts, but the expert weights make up most of the file on
@@ -189,7 +189,24 @@ tensors) and `--ctx-size` as usual. No effect on dense (non-MoE) models —
 the tensor pattern simply matches nothing. Available on `eullm run` and
 `eullm serve` (applied to every model the server loads or swaps to).
 
+`--cpu-moe` is all-or-nothing — every expert tensor moves to CPU RAM, which
+can leave VRAM idle if the model would fit with only some layers offloaded.
+`--n-cpu-moe N` (new in v0.6.12) offers finer control: only the first `N`
+transformer layers' expert tensors move to CPU, the rest stay on GPU.
+Mirrors upstream llama.cpp's `--n-cpu-moe` exactly. Mutually exclusive with
+`--cpu-moe`.
+
+```bash
+# Offload only the first 12 layers' experts to CPU RAM, keep the rest on GPU
+eullm run hf.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF:Q4_K_M --n-cpu-moe 12
+```
+
+Picking `N` is currently manual — start low and raise it until the model
+loads without OOM (`--fit` does not yet auto-size `N`).
+
 ## What's ready today, what's coming
+
+**New in v0.6.12** — **`--n-cpu-moe N`**: finer-grained sibling of `--cpu-moe` — offload only the first `N` layers' MoE expert tensors to CPU RAM instead of all of them, so a model that doesn't quite fit under the blanket `--cpu-moe` flag can still use the VRAM it has. See "Run MoE models on a small GPU" above.
 
 **New in v0.6.11** — **`--cpu-moe`**: run MoE models (Qwen3-30B-A3B, Qwen3.6-35B-A3B, …) on a small GPU by keeping expert tensors on CPU RAM while attention, embeddings, and the KV cache stay on GPU — VRAM headroom whole-layer `--gpu-layers` offload can't reach. See "Run MoE models on a small GPU" above.
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -60,6 +60,10 @@ pub struct AppState {
     /// Keep MoE expert tensors on CPU RAM (see `InferenceConfig::cpu_moe`).
     /// Applied to every model this server loads or swaps to.
     pub cpu_moe: bool,
+    /// Keep MoE expert tensors on CPU RAM for only the first N layers (see
+    /// `InferenceConfig::n_cpu_moe`). Applied to every model this server
+    /// loads or swaps to.
+    pub n_cpu_moe: u32,
 
     /// Enable transparent web fetching: URLs in user messages are fetched
     /// and their content is injected into the prompt before inference.
@@ -145,6 +149,7 @@ impl AppState {
             // the text-only fast path (None → no extra VRAM, no init cost).
             mmproj_path: mmproj_path.clone(),
             cpu_moe: self.cpu_moe,
+            n_cpu_moe: self.n_cpu_moe,
         };
 
         // The continuous-batching scheduler is text-only — it does not route
@@ -333,6 +338,7 @@ pub struct ServeConfig {
     pub cache_type_v: crate::inference::KvCacheType,
     pub batch_size: usize,
     pub cpu_moe: bool,
+    pub n_cpu_moe: u32,
     pub web_enabled: bool,
     pub store: ModelStore,
     /// Optional embedded chat UI. When `Some(port)`, a second listener is
@@ -364,6 +370,7 @@ pub async fn serve(cfg: ServeConfig) -> Result<(), Box<dyn std::error::Error>> {
         cache_type_v: cfg.cache_type_v,
         batch_size: cfg.batch_size,
         cpu_moe: cfg.cpu_moe,
+        n_cpu_moe: cfg.n_cpu_moe,
         web_enabled: cfg.web_enabled,
         api_port: cfg.port,
         store: cfg.store,

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -150,6 +150,14 @@ pub struct InferenceConfig {
     /// No effect on dense (non-MoE) models — the tensor pattern simply
     /// matches nothing.
     pub cpu_moe: bool,
+    /// Keep MoE expert tensors on CPU RAM for only the first `n_cpu_moe`
+    /// transformer layers (0 = disabled), leaving the rest on GPU. Finer
+    /// grained than `cpu_moe`: lets a model that doesn't fully fit in VRAM
+    /// offload just enough expert weight to close the gap instead of moving
+    /// every expert tensor to CPU. Equivalent to llama.cpp's `--n-cpu-moe`.
+    /// Mutually exclusive with `cpu_moe` (blanket override wins if both are
+    /// set — checked at the CLI layer).
+    pub n_cpu_moe: u32,
 }
 
 impl Default for InferenceConfig {
@@ -169,6 +177,7 @@ impl Default for InferenceConfig {
             cache_type_v: KvCacheType::F16,
             mmproj_path: None,
             cpu_moe: false,
+            n_cpu_moe: 0,
         }
     }
 }
@@ -418,9 +427,29 @@ impl InferenceEngine {
             LlamaModelParams::default().with_n_gpu_layers(1000)
         };
         let mut model_params = pin!(model_params);
+        // Patterns passed to `add_cpu_buft_override` are stored as raw pointers
+        // (not copied) inside `model_params`, so they must outlive the
+        // `load_from_file` call below — keep them bound in this local.
+        let n_cpu_moe_patterns: Vec<std::ffi::CString> = (0..config.n_cpu_moe)
+            .map(|i| {
+                std::ffi::CString::new(format!(
+                    r"blk\.{i}\.ffn_(up|down|gate|gate_up)_(ch|)exps"
+                ))
+                .expect("pattern has no interior NUL")
+            })
+            .collect();
         if config.cpu_moe {
             tracing::info!("--cpu-moe: keeping MoE expert tensors on CPU RAM");
             model_params.as_mut().add_cpu_moe_override();
+        } else if config.n_cpu_moe > 0 {
+            tracing::info!(
+                "--n-cpu-moe {}: keeping MoE expert tensors on CPU RAM for the first {} layers",
+                config.n_cpu_moe,
+                config.n_cpu_moe
+            );
+            for pattern in &n_cpu_moe_patterns {
+                model_params.as_mut().add_cpu_buft_override(pattern);
+            }
         }
 
         tracing::info!("Loading model: {}", config.model_path.display());

--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -294,9 +294,27 @@ fn run_scheduler_loop(
         LlamaModelParams::default().with_n_gpu_layers(1000)
     };
     let mut model_params = pin!(model_params);
+    // Patterns passed to `add_cpu_buft_override` are stored as raw pointers
+    // (not copied) inside `model_params`, so they must outlive the
+    // `load_from_file` call below — keep them bound in this local.
+    let n_cpu_moe_patterns: Vec<std::ffi::CString> = (0..config.n_cpu_moe)
+        .map(|i| {
+            std::ffi::CString::new(format!(r"blk\.{i}\.ffn_(up|down|gate|gate_up)_(ch|)exps"))
+                .expect("pattern has no interior NUL")
+        })
+        .collect();
     if config.cpu_moe {
         tracing::info!("--cpu-moe: keeping MoE expert tensors on CPU RAM");
         model_params.as_mut().add_cpu_moe_override();
+    } else if config.n_cpu_moe > 0 {
+        tracing::info!(
+            "--n-cpu-moe {}: keeping MoE expert tensors on CPU RAM for the first {} layers",
+            config.n_cpu_moe,
+            config.n_cpu_moe
+        );
+        for pattern in &n_cpu_moe_patterns {
+            model_params.as_mut().add_cpu_buft_override(pattern);
+        }
     }
 
     tracing::info!("Loading model: {}", config.model_path.display());

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -113,6 +113,14 @@ enum Commands {
         #[arg(long)]
         cpu_moe: bool,
 
+        /// For MoE models: keep expert tensors on CPU RAM for only the
+        /// first N transformer layers, leaving the rest on GPU. Finer
+        /// grained than --cpu-moe — use this when the blanket flag leaves
+        /// VRAM idle (all experts to CPU) but the model doesn't fully fit
+        /// with --gpu-layers alone. Mutually exclusive with --cpu-moe.
+        #[arg(long, default_value_t = 0)]
+        n_cpu_moe: u32,
+
         /// Context window size
         #[arg(short, long, default_value_t = 4096)]
         ctx_size: u32,
@@ -226,6 +234,13 @@ enum Commands {
         /// loads or swaps to. See `eullm run --help` for the full rationale.
         #[arg(long)]
         cpu_moe: bool,
+
+        /// For MoE models: keep expert tensors on CPU RAM for only the
+        /// first N transformer layers, leaving the rest on GPU. Applied to
+        /// every model this server loads or swaps to. Mutually exclusive
+        /// with --cpu-moe. See `eullm run --help` for the full rationale.
+        #[arg(long, default_value_t = 0)]
+        n_cpu_moe: u32,
 
         /// Enable the embedded chat UI (off by default for headless serve).
         /// Pass --ui to also expose the chat at http://localhost:<ui-port>/.
@@ -386,7 +401,7 @@ async fn main() {
             Some(picker::Picked::Local(path)) => Commands::Run {
                 model: Some(path.to_string_lossy().into_owned()),
                 port: 11434, replace: false, gpu_layers: -1, fit: true,
-                fit_strict: false, cpu_moe: false, ctx_size: 4096,
+                fit_strict: false, cpu_moe: false, n_cpu_moe: 0, ctx_size: 4096,
                 threads: None, batch_size: 1, no_flash_attn: false,
                 n_batch: 2048, cache_type_k: "f16".into(),
                 cache_type_v: "f16".into(), web: false, no_ui: false,
@@ -397,7 +412,7 @@ async fn main() {
             Some(picker::Picked::Catalog(entry)) => Commands::Run {
                 model: Some(entry.id.clone()),
                 port: 11434, replace: false, gpu_layers: -1, fit: true,
-                fit_strict: false, cpu_moe: false, ctx_size: 4096,
+                fit_strict: false, cpu_moe: false, n_cpu_moe: 0, ctx_size: 4096,
                 threads: None, batch_size: 1, no_flash_attn: false,
                 n_batch: 2048, cache_type_k: "f16".into(),
                 cache_type_v: "f16".into(), web: false, no_ui: false,
@@ -439,6 +454,7 @@ async fn main() {
             fit,
             fit_strict,
             cpu_moe,
+            n_cpu_moe,
             ctx_size,
             threads,
             batch_size,
@@ -497,19 +513,29 @@ async fn main() {
                 ctk = inference::KvCacheType::F16;
                 ctv = inference::KvCacheType::F16;
             }
+            if cpu_moe && n_cpu_moe > 0 {
+                eprintln!("Error: --cpu-moe and --n-cpu-moe are mutually exclusive.");
+                eprintln!("Use --cpu-moe to offload all experts, or --n-cpu-moe N to offload only the first N layers.");
+                std::process::exit(1);
+            }
             let ui_port_opt = if no_ui { None } else { Some(ui_port) };
             // Auto-open the browser chat unless the user asked for terminal-only
             // (--cli / --no-chat) or disabled the UI entirely (--no-ui).
             let open_chat = !cli && ui_port_opt.is_some();
-            cmd_run(&store, &model, port, replace, gpu_layers, fit, fit_strict, cpu_moe, ctx_size, threads, batch_size, !no_flash_attn, n_batch, ctk, ctv, web, ui_port_opt, open_chat, image).await;
+            cmd_run(&store, &model, port, replace, gpu_layers, fit, fit_strict, cpu_moe, n_cpu_moe, ctx_size, threads, batch_size, !no_flash_attn, n_batch, ctk, ctv, web, ui_port_opt, open_chat, image).await;
         }
         Commands::List => cmd_list(&store),
         Commands::Show { model } => cmd_show(&store, &model),
         Commands::Rm { model, force } => cmd_rm(&store, &model, force),
-        Commands::Serve { port, replace, batch_size: _, cpu_moe, ui, ui_port, daemon, pidfile } => {
+        Commands::Serve { port, replace, batch_size: _, cpu_moe, n_cpu_moe, ui, ui_port, daemon, pidfile } => {
             let _ = (daemon, pidfile);
+            if cpu_moe && n_cpu_moe > 0 {
+                eprintln!("Error: --cpu-moe and --n-cpu-moe are mutually exclusive.");
+                eprintln!("Use --cpu-moe to offload all experts, or --n-cpu-moe N to offload only the first N layers.");
+                std::process::exit(1);
+            }
             let ui_port_opt = if ui { Some(ui_port) } else { None };
-            cmd_serve(port, replace, ui_port_opt, cpu_moe).await;
+            cmd_serve(port, replace, ui_port_opt, cpu_moe, n_cpu_moe).await;
         }
         Commands::Unload { port } => cmd_unload(port).await,
         Commands::ImportOllama { model, ollama_dir } => cmd_import_ollama(&store, &model, ollama_dir.as_deref()),
@@ -1214,6 +1240,7 @@ async fn cmd_run(
     fit: bool,
     fit_strict: bool,
     cpu_moe: bool,
+    n_cpu_moe: u32,
     ctx_size: u32,
     threads: Option<u32>,
     batch_size: usize,
@@ -1373,6 +1400,7 @@ async fn cmd_run(
             cache_type_v,
             mmproj_path: mmproj_for_config.clone(),
             cpu_moe,
+            n_cpu_moe,
         };
 
         // The continuous-batching scheduler is text-only; multimodal models
@@ -1464,6 +1492,8 @@ async fn cmd_run(
         println!("  GPU layers:    {}", if gpu_layers < 0 { "all".to_string() } else { gpu_layers.to_string() });
         if cpu_moe {
             println!("  CPU MoE:       enabled (expert tensors on CPU RAM)");
+        } else if n_cpu_moe > 0 {
+            println!("  CPU MoE:       first {n_cpu_moe} layers (expert tensors on CPU RAM)");
         }
         if batch_size > 0 {
             let per_seq = ctx_size / batch_size as u32;
@@ -1563,6 +1593,7 @@ async fn cmd_run(
             cache_type_v,
             batch_size,
             cpu_moe,
+            n_cpu_moe,
             web_enabled: web,
             store: api_store,
             ui_port,
@@ -1604,7 +1635,7 @@ async fn cmd_run(
     }
 }
 
-async fn cmd_serve(port: u16, replace: bool, ui_port: Option<u16>, cpu_moe: bool) {
+async fn cmd_serve(port: u16, replace: bool, ui_port: Option<u16>, cpu_moe: bool, n_cpu_moe: u32) {
     ensure_port_available(port, replace).await;
     if let Some(p) = ui_port {
         ensure_port_available(p, replace).await;
@@ -1638,6 +1669,7 @@ async fn cmd_serve(port: u16, replace: bool, ui_port: Option<u16>, cpu_moe: bool
         cache_type_v: inference::KvCacheType::Q4_0,
         batch_size: 8,
         cpu_moe,
+        n_cpu_moe,
         web_enabled: false,
         store,
         ui_port,

--- a/engine/src/registry/mod.rs
+++ b/engine/src/registry/mod.rs
@@ -339,10 +339,9 @@ pub fn parse_hf_ref(s: &str) -> Option<HfRef> {
         &trimmed[trimmed.len() - stripped.len()..]
     } else if let Some(stripped) = lower.strip_prefix("hf://") {
         &trimmed[trimmed.len() - stripped.len()..]
-    } else if let Some(stripped) = lower.strip_prefix("hf:") {
-        &trimmed[trimmed.len() - stripped.len()..]
     } else {
-        return None;
+        let stripped = lower.strip_prefix("hf:")?;
+        &trimmed[trimmed.len() - stripped.len()..]
     };
 
     // Split off an optional ":<quant>" suffix. The repo itself is `owner/repo`


### PR DESCRIPTION
Mirrors upstream llama.cpp's --n-cpu-moe: pins only the first N transformer layers' expert tensors to CPU RAM via add_cpu_buft_override, leaving the rest on GPU. Finer-grained than the existing blanket --cpu-moe flag, which moves every expert tensor to CPU and can leave VRAM idle on models that would otherwise fit with partial offload.

Wired through both model-load paths (sequential InferenceEngine and the continuous-batching scheduler), eullm run / eullm serve CLI flags, and dynamic model swap under eullm serve. --cpu-moe and --n-cpu-moe are mutually exclusive (checked at the CLI layer).

Also reapplies the parse_hf_ref clippy::question_mark fix that was dropped when feat/cpu-moe merged into main.