### PR TITLE
fix(engine): fall back to full reprefill when a reused prefill fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" />
   <img src="https://img.shields.io/badge/EU%20AI%20Act-Designed%20for%20compliance-gold" alt="EU AI Act" />
-  <img src="https://img.shields.io/badge/Engine-v0.6.15-2ea44f" alt="Engine status" />
+  <img src="https://img.shields.io/badge/Engine-v0.6.16-2ea44f" alt="Engine status" />
   <img src="https://img.shields.io/badge/Forge%20%2B%20Hub-Early%20development-orange" alt="Forge/Hub status" />
   <a href="https://github.com/eullm/eullm/actions/workflows/ci.yml"><img src="https://github.com/eullm/eullm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://doi.org/10.5281/zenodo.20412979"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20412979.svg" alt="DOI" /></a>
@@ -239,7 +239,7 @@ every model the server loads or swaps to).
 
 ## What's ready today, what's coming
 
-**New in v0.6.15** — **KV-cache prefix reuse**: multi-turn conversations (both the `--cli` REPL and `/api/generate`, which both resend the full growing history as the prompt on every call) no longer re-prefill the entire conversation from scratch on every turn. The scheduler now matches each incoming prompt against its idle sequence slots by longest common token-id prefix (mirroring upstream llama.cpp server's slot model) and only decodes the unreused suffix, keeping the rest resident in the KV cache. No new parameter, no client changes — purely content-addressed, works transparently on both surfaces since they share the same scheduler path.
+**New in v0.6.16** — **KV-cache prefix reuse**: multi-turn conversations (both the `--cli` REPL and `/api/generate`, which both resend the full growing history as the prompt on every call) no longer re-prefill the entire conversation from scratch on every turn. The scheduler now matches each incoming prompt against its idle sequence slots by longest common token-id prefix (mirroring upstream llama.cpp server's slot model) and only decodes the unreused suffix, keeping the rest resident in the KV cache. No new parameter, no client changes — purely content-addressed, works transparently on both surfaces since they share the same scheduler path.
 
 **New in v0.6.13** — **`--n-cpu-moe N`**: finer-grained sibling of `--cpu-moe` — offload only the first `N` transformer layers' MoE expert tensors to CPU RAM instead of all of them, so a model whose VRAM sits idle under the blanket `--cpu-moe` flag can push more experts back onto the GPU and recover throughput. Direct port of upstream llama.cpp's `--n-cpu-moe` (same per-layer tensor pattern). Mutually exclusive with `--cpu-moe`. See "Run MoE models on a small GPU" above.
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.15"
+version = "0.6.16"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -667,7 +667,35 @@ fn run_scheduler_loop(
                     };
 
                     // Prefill the unreused suffix of the prompt into the context.
-                    match prefill_sequence(&mut ctx, &config, &scheduled.request, &seq, per_seq_ctx, &tokens, reuse_len) {
+                    //
+                    // If a reused (partial) prefill fails, retry once with a
+                    // full fresh prefill (reuse_len=0) before giving up. This
+                    // keeps prefix reuse strictly fallback-safe: whatever the
+                    // underlying cause (llama.cpp's llama_decode returns -1
+                    // for several distinct reasons that this binding's error
+                    // type collapses into one message, so the exact cause
+                    // isn't always visible here), the worst case is paying
+                    // for the old, proven full-reprefill behavior — never a
+                    // hard failure of the user's request.
+                    let mut effective_reuse_len = reuse_len;
+                    let mut prefill_result = prefill_sequence(
+                        &mut ctx, &config, &scheduled.request, &seq, per_seq_ctx, &tokens, effective_reuse_len,
+                    );
+                    if let Err(ref e) = prefill_result {
+                        if effective_reuse_len > 0 {
+                            tracing::warn!(
+                                "Seq {}: reused prefill failed ({e}), retrying with a full fresh prefill",
+                                seq.seq_id,
+                            );
+                            let _ = ctx.clear_kv_cache_seq(Some(seq.seq_id as u32), None, None);
+                            effective_reuse_len = 0;
+                            prefill_result = prefill_sequence(
+                                &mut ctx, &config, &scheduled.request, &seq, per_seq_ctx, &tokens, effective_reuse_len,
+                            );
+                        }
+                    }
+
+                    match prefill_result {
                         Ok((n_tokens, n_past, effective_max)) => {
                             let mut seq = seq;
                             seq.tokens_prompt = n_tokens;


### PR DESCRIPTION
A real conversation hit "Prefill failed: Prompt decode failed at chunk N..M: Decode Error -1: n_tokens == 0" on the third turn of a long multi-turn session, aborting the whole request instead of degrading gracefully.

Root cause investigation: the vendored llama-cpp-2 binding maps EVERY llama_decode() return code of -1 to a single generic "n_tokens == 0" message (context.rs DecodeError::from(NonZeroI32)), but the pinned llama.cpp source returns -1 for at least three distinct reasons (empty batch, batch validation failure in llama_batch_allocr::init, more than one output token per sequence for backend sampling) — the message shown is therefore not reliable evidence of which one fired, and llama.cpp's own internal error logging (which would disambiguate) is suppressed by void_logs() after context creation. SWA/iSWA cache semantics were ruled out (QWEN3MOE does not set hparams.n_swa, so it uses the plain flat KV cache, not the composite iSWA path) as a contributing factor, but the exact C-side trigger remains unconfirmed pending a build that can surface the underlying log line.

Pending a confirmed root cause, make prefix reuse strictly fallback- safe at the point it can fail: if a prefill that reuses part of a slot's cached history fails, wipe that slot's KV cache and retry once with a full fresh prefill (reuse_len=0) before surfacing an error to the caller. Worst case is now paying for the old, already-proven full-reprefill behavior instead of aborting the request.