### PR TITLE
fix(engine): satisfy clippy::collapsible_if in the reuse fallback retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" />
   <img src="https://img.shields.io/badge/EU%20AI%20Act-Designed%20for%20compliance-gold" alt="EU AI Act" />
-  <img src="https://img.shields.io/badge/Engine-v0.6.16-2ea44f" alt="Engine status" />
+  <img src="https://img.shields.io/badge/Engine-v0.6.17-2ea44f" alt="Engine status" />
   <img src="https://img.shields.io/badge/Forge%20%2B%20Hub-Early%20development-orange" alt="Forge/Hub status" />
   <a href="https://github.com/eullm/eullm/actions/workflows/ci.yml"><img src="https://github.com/eullm/eullm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://doi.org/10.5281/zenodo.20412979"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20412979.svg" alt="DOI" /></a>
@@ -239,7 +239,7 @@ every model the server loads or swaps to).
 
 ## What's ready today, what's coming
 
-**New in v0.6.16** — **KV-cache prefix reuse**: multi-turn conversations (both the `--cli` REPL and `/api/generate`, which both resend the full growing history as the prompt on every call) no longer re-prefill the entire conversation from scratch on every turn. The scheduler now matches each incoming prompt against its idle sequence slots by longest common token-id prefix (mirroring upstream llama.cpp server's slot model) and only decodes the unreused suffix, keeping the rest resident in the KV cache. No new parameter, no client changes — purely content-addressed, works transparently on both surfaces since they share the same scheduler path.
+**New in v0.6.17** — **KV-cache prefix reuse**: multi-turn conversations (both the `--cli` REPL and `/api/generate`, which both resend the full growing history as the prompt on every call) no longer re-prefill the entire conversation from scratch on every turn. The scheduler now matches each incoming prompt against its idle sequence slots by longest common token-id prefix (mirroring upstream llama.cpp server's slot model) and only decodes the unreused suffix, keeping the rest resident in the KV cache. No new parameter, no client changes — purely content-addressed, works transparently on both surfaces since they share the same scheduler path.
 
 **New in v0.6.13** — **`--n-cpu-moe N`**: finer-grained sibling of `--cpu-moe` — offload only the first `N` transformer layers' MoE expert tensors to CPU RAM instead of all of them, so a model whose VRAM sits idle under the blanket `--cpu-moe` flag can push more experts back onto the GPU and recover throughput. Direct port of upstream llama.cpp's `--n-cpu-moe` (same per-layer tensor pattern). Mutually exclusive with `--cpu-moe`. See "Run MoE models on a small GPU" above.
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.16"
+version = "0.6.17"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -681,18 +681,18 @@ fn run_scheduler_loop(
                     let mut prefill_result = prefill_sequence(
                         &mut ctx, &config, &scheduled.request, &seq, per_seq_ctx, &tokens, effective_reuse_len,
                     );
-                    if let Err(ref e) = prefill_result {
-                        if effective_reuse_len > 0 {
-                            tracing::warn!(
-                                "Seq {}: reused prefill failed ({e}), retrying with a full fresh prefill",
-                                seq.seq_id,
-                            );
-                            let _ = ctx.clear_kv_cache_seq(Some(seq.seq_id as u32), None, None);
-                            effective_reuse_len = 0;
-                            prefill_result = prefill_sequence(
-                                &mut ctx, &config, &scheduled.request, &seq, per_seq_ctx, &tokens, effective_reuse_len,
-                            );
-                        }
+                    if let Err(ref e) = prefill_result
+                        && effective_reuse_len > 0
+                    {
+                        tracing::warn!(
+                            "Seq {}: reused prefill failed ({e}), retrying with a full fresh prefill",
+                            seq.seq_id,
+                        );
+                        let _ = ctx.clear_kv_cache_seq(Some(seq.seq_id as u32), None, None);
+                        effective_reuse_len = 0;
+                        prefill_result = prefill_sequence(
+                            &mut ctx, &config, &scheduled.request, &seq, per_seq_ctx, &tokens, effective_reuse_len,
+                        );
                     }
 
                     match prefill_result {


### PR DESCRIPTION
CI (run 29184603736) failed on main after the prefill-reuse-fallback merge: clippy::collapsible_if under -D warnings on the nested if let Err(...) { if condition { ... } } added for the retry. Collapse into a single let-chain condition, exactly as clippy's own suggested diff proposes. No behavior change.