### PR TITLE
fix(engine): honor /no_think in the CLI REPL via template suppression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" />
   <img src="https://img.shields.io/badge/EU%20AI%20Act-Designed%20for%20compliance-gold" alt="EU AI Act" />
-  <img src="https://img.shields.io/badge/Engine-v0.6.17-2ea44f" alt="Engine status" />
+  <img src="https://img.shields.io/badge/Engine-v0.6.18-2ea44f" alt="Engine status" />
   <img src="https://img.shields.io/badge/Forge%20%2B%20Hub-Early%20development-orange" alt="Forge/Hub status" />
   <a href="https://github.com/eullm/eullm/actions/workflows/ci.yml"><img src="https://github.com/eullm/eullm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://doi.org/10.5281/zenodo.20412979"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20412979.svg" alt="DOI" /></a>
@@ -239,7 +239,7 @@ every model the server loads or swaps to).
 
 ## What's ready today, what's coming
 
-**New in v0.6.17** — **KV-cache prefix reuse**: multi-turn conversations (both the `--cli` REPL and `/api/generate`, which both resend the full growing history as the prompt on every call) no longer re-prefill the entire conversation from scratch on every turn. The scheduler now matches each incoming prompt against its idle sequence slots by longest common token-id prefix (mirroring upstream llama.cpp server's slot model) and only decodes the unreused suffix, keeping the rest resident in the KV cache. No new parameter, no client changes — purely content-addressed, works transparently on both surfaces since they share the same scheduler path.
+**New in v0.6.18** — **KV-cache prefix reuse**: multi-turn conversations (both the `--cli` REPL and `/api/generate`, which both resend the full growing history as the prompt on every call) no longer re-prefill the entire conversation from scratch on every turn. The scheduler now matches each incoming prompt against its idle sequence slots by longest common token-id prefix (mirroring upstream llama.cpp server's slot model) and only decodes the unreused suffix, keeping the rest resident in the KV cache. No new parameter, no client changes — purely content-addressed, works transparently on both surfaces since they share the same scheduler path.
 
 **New in v0.6.13** — **`--n-cpu-moe N`**: finer-grained sibling of `--cpu-moe` — offload only the first `N` transformer layers' MoE expert tensors to CPU RAM instead of all of them, so a model whose VRAM sits idle under the blanket `--cpu-moe` flag can push more experts back onto the GPU and recover throughput. Direct port of upstream llama.cpp's `--n-cpu-moe` (same per-layer tensor pattern). Mutually exclusive with `--cpu-moe`. See "Run MoE models on a small GPU" above.
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.17"
+version = "0.6.18"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -2156,10 +2156,18 @@ async fn interactive_chat(
     let mut temperature: f32 = 0.8;
     let mut max_reply_tokens: u32 = 2048;
     // Sticky reasoning toggle. ON by default (reasoning models need it). When
-    // OFF we append the ` /no_think` soft-switch to each user turn — the
-    // mechanism the models actually honour (an injected empty <think></think>
-    // breaks reasoning models like DeepSeek-R1).
+    // OFF we append the ` /no_think` soft-switch to each user turn AND, for
+    // every model except the DeepSeek-R1 family, also force an empty
+    // `<think></think>` block in the template — the mechanism the API's
+    // `"think": false` param already uses. R1-style models are always-
+    // reasoning and never learned to see a pre-closed empty think block as
+    // anything but malformed input, so they keep relying on the soft-switch
+    // text alone.
     let mut think_mode = true;
+    let is_r1_family = {
+        let lower = model_name.to_lowercase();
+        lower.contains("deepseek-r1") || lower.contains("deepseek_r1")
+    };
 
     let mut history: Vec<ChatMessage> = vec![ChatMessage {
         role: "system",
@@ -2272,6 +2280,12 @@ async fn interactive_chat(
         let user_content = if think_mode { input.clone() } else { format!("{input} /no_think") };
         history.push(ChatMessage { role: "user", content: user_content });
 
+        // Whether to let build_prompt open the assistant turn normally
+        // (true) or force the empty `<think></think>` suppression (false).
+        // Only suppress via the template when reasoning is actually off AND
+        // the model isn't DeepSeek-R1-family (see think_mode's doc comment).
+        let think_arg = think_mode || is_r1_family;
+
         // Build prompt using the model-appropriate chat template.
         // If web browsing is enabled, fetch URLs and inject content into a
         // TEMPORARY message list — web content is NOT stored in history so it
@@ -2307,18 +2321,18 @@ async fn interactive_chat(
                     tmp.push(&web_msg);
                     tmp.push(history.last().unwrap());
                     let pairs: Vec<(&str, &str)> = tmp.iter().map(|m| (m.role, m.content.as_str())).collect();
-                    template.build_prompt(&pairs, true)
+                    template.build_prompt(&pairs, think_arg)
                 } else {
                     let pairs: Vec<(&str, &str)> = history.iter().map(|m| (m.role, m.content.as_str())).collect();
-                    template.build_prompt(&pairs, true)
+                    template.build_prompt(&pairs, think_arg)
                 }
             } else {
                 let pairs: Vec<(&str, &str)> = history.iter().map(|m| (m.role, m.content.as_str())).collect();
-                template.build_prompt(&pairs, true)
+                template.build_prompt(&pairs, think_arg)
             }
         } else {
             let pairs: Vec<(&str, &str)> = history.iter().map(|m| (m.role, m.content.as_str())).collect();
-            template.build_prompt(&pairs, true)
+            template.build_prompt(&pairs, think_arg)
         };
 
         // Rough token estimate: ~4 chars per token. Leave room for the response.


### PR DESCRIPTION
The REPL's /no_think only ever appended a " /no_think" soft-switch to the user's message text; it never passed think=false to build_prompt, so the template-level empty <think></think> suppression that the "think": false API parameter already uses (format_chat_prompt in routes.rs) was never applied here. Some models don't honor the inline soft-switch reliably on its own (observed on Qwen3.6-35B-A3B, which kept opening a <think> block immediately despite /no_think).

Add real DeepSeek-R1-family detection (previously only described in a comment, never implemented) and use it to decide which suppression to apply: for R1-family models, keep today's behavior unchanged (soft-switch text only — forcing an empty think block breaks models trained to always open with <think>). For every other ChatML model, also force the template-level suppression, matching what the API path already does reliably.