### PR TITLE
fix(engine): treat a rejected KV-cache rollback as a reuse failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" />
   <img src="https://img.shields.io/badge/EU%20AI%20Act-Designed%20for%20compliance-gold" alt="EU AI Act" />
-  <img src="https://img.shields.io/badge/Engine-v0.6.18-2ea44f" alt="Engine status" />
+  <img src="https://img.shields.io/badge/Engine-v0.6.19-2ea44f" alt="Engine status" />
   <img src="https://img.shields.io/badge/Forge%20%2B%20Hub-Early%20development-orange" alt="Forge/Hub status" />
   <a href="https://github.com/eullm/eullm/actions/workflows/ci.yml"><img src="https://github.com/eullm/eullm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://doi.org/10.5281/zenodo.20412979"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20412979.svg" alt="DOI" /></a>

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.18"
+version = "0.6.19"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -1055,7 +1055,26 @@ fn prefill_sequence(
     // unrelated conversation's KV data attached to this seq_id, silently
     // blended into the new request's generation. Safe in every case:
     // clearing an empty range (a never-used slot) is a no-op.
-    let _ = ctx.clear_kv_cache_seq(Some(seq.seq_id as u32), Some(reuse_len as u32), None);
+    //
+    // The return value matters for reuse_len > 0: llama.cpp's recurrent
+    // memory (Mamba/SSM-style layers, e.g. Qwen3.6's hybrid attention+SSM
+    // architecture) can only roll back a bounded number of tokens
+    // (`n_rs_seq`, 0 by default — we never set it). A partial trim request
+    // beyond that bound returns `false` and leaves the recurrent state
+    // untouched, silently stale relative to the trimmed attention KV cache.
+    // Treat that as a hard failure of this reuse attempt rather than
+    // proceeding on divergent state — the caller retries with reuse_len=0,
+    // which requests a full clear (`p0=0, p1=max`) and always succeeds.
+    let cleared = ctx
+        .clear_kv_cache_seq(Some(seq.seq_id as u32), Some(reuse_len as u32), None)
+        .unwrap_or(false);
+    if reuse_len > 0 && !cleared {
+        return Err(format!(
+            "Seq {}: KV-cache rollback to reuse_len={reuse_len} was rejected (likely a \
+             recurrent/hybrid model architecture); reuse is unsafe here",
+            seq.seq_id,
+        ));
+    }
 
     // Prefill in chunks of n_batch tokens. llama.cpp asserts if a single
     // decode call processes more tokens than n_batch, which causes SIGABRT.


### PR DESCRIPTION
llama.cpp's recurrent memory (Mamba/SSM-style layers, present in hybrid architectures like Qwen3.6's attention+SSM design) only supports a partial rollback within a bounded snapshot window (n_rs_seq, which defaults to 0 and is never configured by this engine). A partial trim request beyond that bound returns false and leaves the recurrent state untouched while the attention KV cache is trimmed correctly, silently diverging the two halves of the model's state on every reused turn.

clear_kv_cache_seq's return value was previously discarded, so this failure was invisible. Now a rejected rollback with reuse_len > 0 returns an error from prefill_sequence, which the existing reused-prefill fallback (added for the prior decode-error crash) already retries with a full fresh prefill (reuse_len=0), a request that always succeeds since it triggers a full clear instead of a partial one.