### PR TITLE
fix(engine): stop misreading a full event channel as a disconnected c…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" />
   <img src="https://img.shields.io/badge/EU%20AI%20Act-Designed%20for%20compliance-gold" alt="EU AI Act" />
-  <img src="https://img.shields.io/badge/Engine-v0.6.19-2ea44f" alt="Engine status" />
+  <img src="https://img.shields.io/badge/Engine-v0.6.20-2ea44f" alt="Engine status" />
   <img src="https://img.shields.io/badge/Forge%20%2B%20Hub-Early%20development-orange" alt="Forge/Hub status" />
   <a href="https://github.com/eullm/eullm/actions/workflows/ci.yml"><img src="https://github.com/eullm/eullm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://doi.org/10.5281/zenodo.20412979"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20412979.svg" alt="DOI" /></a>

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.19"
+version = "0.6.20"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -754,11 +754,42 @@ fn run_scheduler_loop(
                                                         last_used: std::time::Instant::now(),
                                                     });
                                                 } else {
-                                                    if !out.is_empty() {
-                                                        let _ = seq.tx.try_send(StreamEvent::Token(out));
+                                                    // Check for a dropped receiver even when `out`
+                                                    // is empty (piece fully absorbed into the stop/
+                                                    // filter holdback buffer) — a disconnect must not
+                                                    // depend on there being bytes to send. A `Full`
+                                                    // channel (slow-consuming client, not a dropped
+                                                    // one) must NOT be treated the same way: the
+                                                    // token is best-effort dropped, but the sequence
+                                                    // and its cache stay alive.
+                                                    let disconnected = if out.is_empty() {
+                                                        seq.tx.is_closed()
+                                                    } else {
+                                                        match seq.tx.try_send(StreamEvent::Token(out)) {
+                                                            Ok(()) => false,
+                                                            Err(mpsc::error::TrySendError::Full(_)) => {
+                                                                tracing::warn!(
+                                                                    "Seq {}: event channel full, dropping a token (client consuming too slowly)",
+                                                                    seq.seq_id,
+                                                                );
+                                                                false
+                                                            }
+                                                            Err(mpsc::error::TrySendError::Closed(_)) => true,
+                                                        }
+                                                    };
+                                                    if disconnected {
+                                                        // Cache state is not confirmed-safe (mid
+                                                        // first-token piece): full wipe.
+                                                        let _ = ctx.clear_kv_cache_seq(Some(seq.seq_id as u32), None, None);
+                                                        idle_slots.push(CachedSlot {
+                                                            seq_id: seq.seq_id,
+                                                            tokens: Vec::new(),
+                                                            last_used: std::time::Instant::now(),
+                                                        });
+                                                    } else {
+                                                        seq.last_token = Some(token);
+                                                        active.push(seq);
                                                     }
-                                                    seq.last_token = Some(token);
-                                                    active.push(seq);
                                                 }
                                             }
                                         }
@@ -921,9 +952,28 @@ fn run_scheduler_loop(
                             continue;
                         }
                         PieceOutcome::Emit(out) => {
-                            if !out.is_empty()
-                                && seq.tx.try_send(StreamEvent::Token(out)).is_err()
-                            {
+                            // Checked regardless of whether `out` is empty (piece fully
+                            // absorbed into the stop/filter holdback buffer) — a disconnect
+                            // must not depend on there being bytes to send. A `Full` channel
+                            // (slow-consuming client, not a dropped one) must NOT be treated
+                            // as a disconnect: the token is best-effort dropped, but the
+                            // sequence and its cache stay alive.
+                            let disconnected = if out.is_empty() {
+                                seq.tx.is_closed()
+                            } else {
+                                match seq.tx.try_send(StreamEvent::Token(out)) {
+                                    Ok(()) => false,
+                                    Err(mpsc::error::TrySendError::Full(_)) => {
+                                        tracing::warn!(
+                                            "Seq {}: event channel full, dropping a token (client consuming too slowly)",
+                                            seq.seq_id,
+                                        );
+                                        false
+                                    }
+                                    Err(mpsc::error::TrySendError::Closed(_)) => true,
+                                }
+                            };
+                            if disconnected {
                                 // Receiver dropped — client disconnected.
                                 // Cache state is not confirmed-safe: full wipe.
                                 to_remove.push(i);


### PR DESCRIPTION
…lient

seq.tx.try_send(...).is_err() collapsed tokio's TrySendError::Full and TrySendError::Closed into the same branch. Under concurrent load a client that is merely slow to drain its stream (backed-up SSE/NDJSON writer, runtime busy with other sequences) fills the 256-slot channel and gets treated exactly like a dropped receiver: the scheduler aborts a live generation and wipes its KV cache. Now only a Closed channel triggers the disconnect path; Full drops the current token (logged) and leaves the sequence and its cache alive.

Also close two detection gaps around the same disconnect check: it was never evaluated when the decoded piece was fully absorbed into the stop/ filter-sequence holdback buffer (out.is_empty() short-circuited the try_send), and it was skipped entirely for the very first token sampled right after prefill. Both left an abandoned sequence occupying an active scheduler slot and burning decode compute well past the point a client actually disconnected.