### PR TITLE
feat(engine): CIX P1 (Armv9.2-A) CPU build profile for POSCAR WP4

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - "engine-v*"
       - "EuLLM-v*"
+  # Manual dispatch runs ONLY build-arm-cix-p1 (see its `if:` below) - lets
+  # that job be iterated on and re-run from the Actions tab without a real
+  # tag, without paying for the rest of the release matrix (Windows CUDA
+  # alone is a ~50 min cold build), and without ever creating a GitHub
+  # Release (the `release` job only runs on an actual tag push).
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -43,6 +49,9 @@ env:
 
 jobs:
   build:
+    # Manual dispatch is for testing build-arm-cix-p1 in isolation - skip
+    # the rest of the matrix there.
+    if: ${{ github.event_name == 'push' }}
     strategy:
       fail-fast: false
       matrix:
@@ -155,6 +164,7 @@ jobs:
           path: ${{ matrix.artifact }}
 
   build-cuda:
+    if: ${{ github.event_name == 'push' }}
     strategy:
       matrix:
         include:
@@ -282,6 +292,7 @@ jobs:
   # Targets ARM hosts with a discrete NVIDIA GPU (Ampere Altra / Grace + RTX,
   # ARM dev kits, etc.). Compiling CUDA needs only nvcc, not a GPU on the runner.
   build-cuda-arm64:
+    if: ${{ github.event_name == 'push' }}
     strategy:
       matrix:
         include:
@@ -471,6 +482,7 @@ jobs:
           path: ${{ matrix.artifact }}
 
   build-windows:
+    if: ${{ github.event_name == 'push' }}
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v5
@@ -544,6 +556,7 @@ jobs:
           path: eullm-windows-x64.exe
 
   build-windows-cuda:
+    if: ${{ github.event_name == 'push' }}
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v5
@@ -719,7 +732,10 @@ jobs:
       - build-windows-cuda
     # Run as long as at least one upstream job built something. We never
     # want a single failing build to nuke a release after CI on the others.
-    if: ${{ !cancelled() }}
+    # Also never run on a manual workflow_dispatch (that's only for testing
+    # build-arm-cix-p1 in isolation, and there's no real tag to attach a
+    # release to on that trigger).
+    if: ${{ !cancelled() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -389,6 +389,87 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
 
+  # CIX P1 (Armv9.2-A: SVE2, BF16, I8MM, DotProd) CPU-only profile — POSCAR
+  # WP4 baseline for the Radxa Orion O6. Deliberately a SEPARATE artifact
+  # from `build`'s generic eullm-linux-arm64: baking these ISA extensions
+  # into the generic binary would SIGILL on any ARM64 host that doesn't
+  # have them (Raspberry Pi, Graviton, other SoCs). Native ubuntu-24.04-arm
+  # runner rather than cross-compiling from x86_64: its default gcc is
+  # already GCC 13 (Ubuntu 22.04's gcc-aarch64-linux-gnu cross package is
+  # 11.2.0, too old to parse -march=armv9.2-a at all), so no toolchain
+  # upgrade step is needed here the way a cross-compile job would.
+  # See docs/arm-cix-p1-cpu-profile.md for the full profile writeup.
+  build-arm-cix-p1:
+    strategy:
+      matrix:
+        include:
+          - artifact: eullm-linux-arm64-cix-p1
+
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # llama.cpp submodule under engine/vendor/llama-cpp-rs/llama-cpp-sys-2/
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: aarch64-cix-p1
+
+      - name: Install sccache
+        shell: bash
+        run: |
+          SCCACHE_VER=0.8.0
+          TMPSC=$(mktemp -d)
+          curl -sSfL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-aarch64-unknown-linux-musl.tar.gz" \
+            -o "${TMPSC}/sccache.tar.gz"
+          tar -xzf "${TMPSC}/sccache.tar.gz" -C "${TMPSC}"
+          find "${TMPSC}" -maxdepth 2 -name sccache -type f -exec mv {} /usr/local/bin/ \;
+          chmod +x /usr/local/bin/sccache
+          rm -rf "${TMPSC}"
+          # Same S3 reachability probe as every other build job: a backend
+          # outage degrades to a cache-less build, never a failed one.
+          if curl -sSf -m 10 "${SCCACHE_ENDPOINT}/minio/health/live" >/dev/null 2>&1; then
+            echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+            echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+            echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+            echo "sccache: S3 backend reachable — caching enabled."
+          else
+            echo "::warning::sccache S3 backend (${SCCACHE_ENDPOINT}) unreachable — building WITHOUT cache (slower, but the build will not fail)."
+          fi
+          sccache --version
+          sccache --start-server || true
+
+      - name: Install build dependencies
+        run: sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake build-essential pkg-config libssl-dev
+
+      - name: Build engine (CIX P1 profile)
+        run: cargo build --release -p eullm-engine
+        env:
+          # Read by engine/vendor/llama-cpp-rs/llama-cpp-sys-2/build.rs; falls
+          # back to the generic armv8-a baseline everywhere this isn't set.
+          LLAMA_GGML_CPU_ARM_ARCH: armv9.2-a+sve2+bf16+i8mm+dotprod
+
+      - name: sccache stats (visibility into S3 hit/miss)
+        if: always()
+        shell: bash
+        run: sccache --show-stats || true
+
+      - name: Package binary
+        run: |
+          cp target/release/eullm ${{ matrix.artifact }}
+          strip --strip-all ${{ matrix.artifact }} 2>/dev/null || strip -x ${{ matrix.artifact }} 2>/dev/null || true
+          chmod +x ${{ matrix.artifact }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
   build-windows:
     runs-on: windows-2022
     steps:
@@ -633,6 +714,7 @@ jobs:
       - build
       - build-cuda
       - build-cuda-arm64
+      - build-arm-cix-p1
       - build-windows
       - build-windows-cuda
     # Run as long as at least one upstream job built something. We never
@@ -677,6 +759,7 @@ jobs:
             artifacts/eullm-linux-x64-cuda-12.8/eullm-linux-x64-cuda-12.8
             artifacts/eullm-linux-arm64/eullm-linux-arm64
             artifacts/eullm-linux-arm64-cuda-12.8/eullm-linux-arm64-cuda-12.8
+            artifacts/eullm-linux-arm64-cix-p1/eullm-linux-arm64-cix-p1
             artifacts/eullm-macos-x64/eullm-macos-x64
             artifacts/eullm-macos-arm64/eullm-macos-arm64
             artifacts/eullm-windows-x64/eullm-windows-x64.exe

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,5 +1,14 @@
 # bench/ — Stress Test & Parallelism Verification
 
+## POSCAR WP4 — CIX P1 ARM CPU baseline
+
+See [`docs/arm-cix-p1-cpu-profile.md`](../docs/arm-cix-p1-cpu-profile.md) for
+the full build profile, i8mm/repack runtime verification, and thread-pinning
+recipe for the Radxa Orion O6 (CIX P1). `detect_arm_big_cores.sh` finds the
+big Cortex-A720 cores on the actual board (core numbering isn't stable
+across firmware, so this can't be a hardcoded range); `arm_cpu_bench.py` is
+the T4.1 prefill/decode baseline harness.
+
 Real stress test that **proves** whether an inference server processes requests in parallel or just queues them sequentially.
 
 ## `reuse_validation.py` — roadmap 0.7-A real-hardware checklist

--- a/bench/arm_cpu_bench.py
+++ b/bench/arm_cpu_bench.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""POSCAR WP4 / T4.1 baseline — separate PREFILL and DECODE throughput on CPU.
+
+Measures prefill tok/s (across a sweep of prompt lengths) and decode tok/s
+(at a fixed generation length) against a running `eullm run`/`eullm serve`
+instance, with no GPU involved. Meant to be re-run on the same board over
+time as a regression baseline (T4.1), not a one-off number.
+
+Why client-side timing, not server-reported duration: the server's own
+per-request stats (`total_duration`/`eval_duration` in the Ollama-compatible
+response) still lump prefill and decode into one timer — the fix for that
+(separate prefill/decode histograms via `/metrics`) is tracked as roadmap
+item 0.7-B and not implemented yet. Until then, TTFT (time to first token)
+is the standard proxy for prefill wall time, and (last_token - first_token)
+for decode wall time — the same technique bench/stress_test.py already uses
+for its per-request `generation_ms`. On localhost (the expected setup: this
+script and the server on the same board) network overhead in TTFT is
+negligible, so the split is accurate enough for a CPU baseline.
+
+This script does NOT set CPU affinity or thread count itself — pin the
+server process (taskset / OMP env vars) and pass --threads to `eullm run`
+BEFORE starting it, then use --notes here to record what you used, so the
+JSON output is self-documenting. See docs/arm-cix-p1-cpu-profile.md for the
+recommended pinning recipe for this SoC.
+
+Requires: pip install aiohttp
+
+Usage:
+    python bench/arm_cpu_bench.py --url http://localhost:11434 --model qwen3-8b \\
+        --notes "8 big A720 cores, taskset 4-11, --threads 8" \\
+        --json t4.1-baseline-2026-07-16.json
+"""
+
+import argparse
+import asyncio
+import json
+import statistics
+import sys
+import time
+
+try:
+    import aiohttp
+except ImportError:
+    print("This script requires aiohttp: pip install aiohttp", file=sys.stderr)
+    sys.exit(1)
+
+# Repeated filler text used to build prompts of increasing (approximate)
+# length. The actual tokenized length used for tok/s is always the server's
+# own `prompt_eval_count` from the response, never assumed from word count.
+FILLER_SENTENCE = (
+    "The European approach to sovereign artificial intelligence emphasizes "
+    "local control over data, compute, and model weights, running entirely "
+    "on infrastructure within national or union borders. "
+)
+
+DEFAULT_PREFILL_WORD_TARGETS = [128, 512, 2048, 4096]
+DEFAULT_DECODE_TOKENS = 128
+DEFAULT_DECODE_PROMPT = "Write a short paragraph about renewable energy in Europe."
+
+
+def build_prompt(word_target):
+    words_per_sentence = len(FILLER_SENTENCE.split())
+    repeats = max(1, word_target // words_per_sentence)
+    return (FILLER_SENTENCE * repeats).strip()
+
+
+class PowerSampler:
+    """Periodically reads a sysfs power file during a benchmark window.
+
+    Documented hook: if your board exposes power telemetry (INA2xx under
+    /sys/class/hwmon/*, a vendor PMIC sysfs node, etc.) point --power-sysfs-path
+    at the raw value file and set --power-scale-to-watts to convert it (default
+    1e-6, i.e. assumes the file reports microwatts like the standard hwmon
+    `powerX_input` convention). If no such node is documented for your board,
+    leave it unset — the report will say so explicitly instead of guessing.
+    """
+
+    def __init__(self, sysfs_path, scale_to_watts, interval=0.2):
+        self.sysfs_path = sysfs_path
+        self.scale_to_watts = scale_to_watts
+        self.interval = interval
+        self.samples = []
+        self._task = None
+        self._stop = False
+
+    def available(self):
+        if not self.sysfs_path:
+            return False
+        try:
+            with open(self.sysfs_path) as f:
+                f.read()
+            return True
+        except OSError:
+            return False
+
+    async def _run(self):
+        while not self._stop:
+            try:
+                with open(self.sysfs_path) as f:
+                    raw = float(f.read().strip())
+                self.samples.append(raw * self.scale_to_watts)
+            except (OSError, ValueError):
+                pass
+            await asyncio.sleep(self.interval)
+
+    def start(self):
+        if self.available():
+            self._task = asyncio.ensure_future(self._run())
+
+    async def stop(self):
+        self._stop = True
+        if self._task:
+            await self._task
+
+    def average_watts(self):
+        return statistics.mean(self.samples) if self.samples else None
+
+
+async def stream_generate(session, base_url, model, prompt, max_tokens, timeout):
+    """POST /api/generate (stream:true) and return (ttft_s, total_s, prompt_tokens, gen_tokens)."""
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "stream": True,
+        "max_tokens": max_tokens,
+        "options": {"num_predict": max_tokens},
+    }
+    start = time.monotonic()
+    ttft = None
+    last_token_time = None
+    prompt_tokens = None
+    gen_tokens = None
+
+    async with session.post(
+        f"{base_url}/api/generate", json=payload,
+        timeout=aiohttp.ClientTimeout(total=timeout),
+    ) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"HTTP {resp.status}: {await resp.text()}")
+        async for raw_line in resp.content:
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("done"):
+                prompt_tokens = event.get("prompt_eval_count")
+                gen_tokens = event.get("eval_count")
+                if last_token_time is None:
+                    last_token_time = time.monotonic()
+                break
+            if event.get("response"):
+                now = time.monotonic()
+                if ttft is None:
+                    ttft = now - start
+                last_token_time = now
+
+    total = time.monotonic() - start
+    return ttft, total, prompt_tokens, gen_tokens, last_token_time - start if last_token_time else total
+
+
+async def run_prefill_sweep(session, args):
+    print(f"\n[prefill] sweeping prompt lengths: {args.prefill_word_targets}")
+    results = []
+    for word_target in args.prefill_word_targets:
+        prompt = build_prompt(word_target)
+        # max_tokens=1: isolate prefill as much as possible. The one token
+        # produced is unavoidable (llama.cpp always samples one token from
+        # the prefill logits — see engine/src/inference/scheduler.rs), but a
+        # single decode step is negligible next to prefilling thousands of
+        # tokens on CPU.
+        ttft, total, prompt_tokens, gen_tokens, _ = await stream_generate(
+            session, args.url, args.model, prompt, max_tokens=1, timeout=args.timeout,
+        )
+        if ttft is None or not prompt_tokens:
+            print(f"  ~{word_target} words: FAILED to get a timed response")
+            continue
+        tok_s = prompt_tokens / ttft
+        print(f"  {prompt_tokens:5d} prompt tokens: TTFT={ttft*1000:8.1f}ms  prefill={tok_s:7.1f} tok/s")
+        results.append({"prompt_tokens": prompt_tokens, "ttft_s": ttft, "prefill_tok_s": tok_s})
+    return results
+
+
+async def run_decode_bench(session, args, power_sampler):
+    print(f"\n[decode] {args.decode_tokens} tokens, {args.decode_repeats} repeat(s)")
+    runs = []
+    for i in range(args.decode_repeats):
+        if power_sampler:
+            power_sampler.start()
+        ttft, total, prompt_tokens, gen_tokens, last_token_s = await stream_generate(
+            session, args.url, args.model, args.decode_prompt,
+            max_tokens=args.decode_tokens, timeout=args.timeout,
+        )
+        if power_sampler:
+            await power_sampler.stop()
+
+        if ttft is None or not gen_tokens or gen_tokens < 2:
+            print(f"  repeat {i}: FAILED or too few tokens to measure decode rate")
+            continue
+        decode_s = last_token_s - ttft
+        decode_tok_s = (gen_tokens - 1) / decode_s if decode_s > 0 else 0.0
+        print(f"  repeat {i}: TTFT={ttft*1000:7.1f}ms  decode={decode_tok_s:7.1f} tok/s over {gen_tokens} tokens")
+        runs.append({
+            "prompt_tokens": prompt_tokens,
+            "gen_tokens": gen_tokens,
+            "ttft_s": ttft,
+            "decode_s": decode_s,
+            "decode_tok_s": decode_tok_s,
+        })
+    return runs
+
+
+async def main_async(args):
+    print(f"eullm ARM CPU baseline (POSCAR WP4 / T4.1) - {args.url}  model={args.model}")
+    if args.notes:
+        print(f"notes: {args.notes}")
+
+    power_sampler = None
+    if args.power_sysfs_path:
+        power_sampler = PowerSampler(args.power_sysfs_path, args.power_scale_to_watts)
+        if not power_sampler.available():
+            print(f"\n[power] WARNING: cannot read {args.power_sysfs_path} - power will not be reported")
+            power_sampler = None
+    else:
+        print("\n[power] no --power-sysfs-path given - power/perf-per-watt will not be reported "
+              "(see docs/arm-cix-p1-cpu-profile.md for how to find and wire one in for your board)")
+
+    async with aiohttp.ClientSession() as session:
+        prefill_results = await run_prefill_sweep(session, args)
+        decode_results = await run_decode_bench(session, args, power_sampler)
+
+    avg_decode_tok_s = statistics.mean(r["decode_tok_s"] for r in decode_results) if decode_results else None
+    avg_watts = power_sampler.average_watts() if power_sampler else None
+
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    for r in prefill_results:
+        print(f"  prefill  {r['prompt_tokens']:5d} tok  {r['prefill_tok_s']:7.1f} tok/s")
+    if avg_decode_tok_s is not None:
+        print(f"  decode   avg over {len(decode_results)} run(s): {avg_decode_tok_s:7.1f} tok/s")
+    if avg_watts is not None:
+        print(f"  power    avg during decode: {avg_watts:.2f} W")
+        if avg_decode_tok_s:
+            print(f"  perf/W   {avg_decode_tok_s / avg_watts:.2f} tok/s per W")
+    print("=" * 60)
+
+    if args.json:
+        payload = {
+            "url": args.url,
+            "model": args.model,
+            "notes": args.notes,
+            "prefill": prefill_results,
+            "decode": decode_results,
+            "decode_tok_s_avg": avg_decode_tok_s,
+            "power_watts_avg": avg_watts,
+        }
+        with open(args.json, "w") as f:
+            json.dump(payload, f, indent=2)
+        print(f"\nWrote {args.json}")
+
+    return 0 if (prefill_results and decode_results) else 1
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--url", default="http://localhost:11434")
+    p.add_argument("--model", required=True)
+    p.add_argument("--notes", default="", help="free-text run metadata (threads/pinning used, board state) saved into --json")
+    p.add_argument("--prefill-word-targets", type=int, nargs="+", default=DEFAULT_PREFILL_WORD_TARGETS,
+                   help="approximate prompt sizes (in words) to sweep; actual tokenized size is measured and reported")
+    p.add_argument("--decode-tokens", type=int, default=DEFAULT_DECODE_TOKENS)
+    p.add_argument("--decode-prompt", default=DEFAULT_DECODE_PROMPT)
+    p.add_argument("--decode-repeats", type=int, default=3)
+    p.add_argument("--power-sysfs-path", default=None, help="sysfs file to sample during decode, e.g. /sys/class/hwmon/hwmon0/power1_input")
+    p.add_argument("--power-scale-to-watts", type=float, default=1e-6, help="multiply the raw sysfs value by this to get Watts (default assumes microwatts)")
+    p.add_argument("--timeout", type=float, default=300)
+    p.add_argument("--json", default=None, help="write machine-readable results here for baseline tracking over time")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    sys.exit(asyncio.run(main_async(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/detect_arm_big_cores.sh
+++ b/bench/detect_arm_big_cores.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Detect which logical CPUs are Cortex-A720 ("big"/"medium") vs Cortex-A520
+# ("little") on an Armv9.2-A tri-cluster SoC (written for the CIX P1 /
+# Radxa Orion O6, but the MIDR-based method is generic to any big.MEDIUM.LITTLE
+# Cortex-A720/A520 design).
+#
+# Why detection instead of a hardcoded core range: on this board, core
+# numbering is firmware-dependent and non-contiguous by tier. A SystemReady
+# UEFI firmware exposes only 8 cores (big+medium A720, little A520 disabled
+# outright); Radxa's own BSP firmware exposes all 12 across 5 cpufreq
+# policies. A real capture on one firmware showed cpu0 = big, cpu1-4 =
+# little, cpu5-8 = medium, cpu9-11 = big — i.e. NOT a contiguous block per
+# tier. Never assume a fixed range; always detect on the actual board.
+#
+# Method: read MIDR_EL1 per core (bits [15:4] = primary part number) —
+# Cortex-A720 = 0xd81, Cortex-A520 = 0xd80 (confirmed against the Linux
+# kernel's arch/arm64/include/asm/cputype.h and independently against
+# pytorch/cpuinfo's src/arm/uarch.c). Cortex-A720 cores are then split into
+# "big" vs "medium" tiers by cpufreq's cpuinfo_max_freq, since both tiers
+# share the same MIDR part number and only differ in clock ceiling.
+set -euo pipefail
+
+A720_PART="0xd81"
+A520_PART="0xd80"
+
+declare -a a720_cores=()
+declare -a a520_cores=()
+declare -a unknown_cores=()
+
+for cpu_path in /sys/devices/system/cpu/cpu[0-9]*; do
+    [ -d "$cpu_path" ] || continue
+    n=$(basename "$cpu_path" | sed 's/cpu//')
+    midr_file="$cpu_path/regs/identification/midr_el1"
+    if [ ! -r "$midr_file" ]; then
+        echo "cpu$n: cannot read $midr_file (need root, or kernel too old to expose it)" >&2
+        continue
+    fi
+    midr=$(cat "$midr_file")
+    part_hex=$(printf '0x%03x' "$(( (midr >> 4) & 0xFFF ))")
+    case "$part_hex" in
+        "$A720_PART") a720_cores+=("$n") ;;
+        "$A520_PART") a520_cores+=("$n") ;;
+        *) unknown_cores+=("$n ($part_hex)") ;;
+    esac
+done
+
+if [ "${#a520_cores[@]}" -gt 0 ]; then
+    mapfile -t a520_cores < <(printf '%s\n' "${a520_cores[@]}" | sort -n)
+fi
+echo "Cortex-A520 (little): ${a520_cores[*]:-none detected}"
+
+if [ "${#unknown_cores[@]}" -gt 0 ]; then
+    echo "Unrecognized MIDR part number on: ${unknown_cores[*]} (not A720/A520 - different SoC/silicon rev?)" >&2
+fi
+
+if [ "${#a720_cores[@]}" -eq 0 ]; then
+    echo "No Cortex-A720 cores detected - check that this is actually running on the target board." >&2
+    exit 1
+fi
+
+# Split A720 cores into big/medium by max frequency. If every A720 core
+# reports the same cpuinfo_max_freq (some firmware/BIOS configs may not
+# expose the distinction), everything falls into "big" as a safe fallback.
+declare -A freq_of
+for n in "${a720_cores[@]}"; do
+    f="/sys/devices/system/cpu/cpu$n/cpufreq/cpuinfo_max_freq"
+    freq_of[$n]=$( [ -r "$f" ] && cat "$f" || echo 0 )
+done
+
+max_freq=0
+for n in "${a720_cores[@]}"; do
+    [ "${freq_of[$n]}" -gt "$max_freq" ] && max_freq=${freq_of[$n]}
+done
+
+big=() medium=()
+for n in "${a720_cores[@]}"; do
+    if [ "${freq_of[$n]}" -eq "$max_freq" ]; then
+        big+=("$n")
+    else
+        medium+=("$n")
+    fi
+done
+
+# `cpu[0-9]*` globs (and thus every array above) come out in shell
+# lexicographic order (cpu10/cpu11 before cpu2) on 10+ core boards like this
+# one - sort numerically so the reported core lists read sanely.
+if [ "${#big[@]}" -gt 0 ]; then
+    mapfile -t big < <(printf '%s\n' "${big[@]}" | sort -n)
+fi
+if [ "${#medium[@]}" -gt 0 ]; then
+    mapfile -t medium < <(printf '%s\n' "${medium[@]}" | sort -n)
+fi
+
+echo "Cortex-A720 big    (max ~$((max_freq / 1000)) MHz): ${big[*]}"
+echo "Cortex-A720 medium: ${medium[*]:-none distinguished (same max freq as big - treated as big above)}"
+
+big_csv=$(IFS=,; echo "${big[*]}")
+echo ""
+echo "Recommended pinning for this run:"
+echo "  taskset -c $big_csv eullm run <model> --no-ui --threads ${#big[@]} < /dev/null > server.log 2>&1 &"

--- a/docs/arm-cix-p1-cpu-profile.md
+++ b/docs/arm-cix-p1-cpu-profile.md
@@ -1,0 +1,253 @@
+# CIX P1 (Armv9.2-A) CPU build profile — POSCAR WP4
+
+CPU-only baseline for running EULLM Engine on the CIX P1 SoC (Radxa Orion O6
+mini-ITX board, also sold as the smaller Orion O6N Nano-ITX with the same
+SoC) — no GPU, no NPU. This covers WP4's build profile, runtime verification,
+thread pinning, and the T4.1 benchmark baseline. NPU offload is explicitly
+out of scope here; see the roadmap for where that would land separately.
+
+## 1. Hardware summary
+
+CIX P1 (silkscreened CD8180, CD8160 on early boards — functionally
+identical) is a 12-core Armv9.2-A tri-cluster SoC:
+
+| Tier | Cores | Max clock |
+|---|---|---|
+| Cortex-A720 "big" | 4 | ~2.6-2.8 GHz (see caveat below) |
+| Cortex-A720 "medium" | 4 | ~2.4 GHz |
+| Cortex-A520 "little" | 4 | ~1.8 GHz |
+
+12 MB shared L3, single DSU. ISA extensions relevant to this profile: SVE2,
+BF16, I8MM, DotProd.
+
+**Caveats (flagging what's confirmed vs. not):**
+- Early CIX P1 silicon targeted 2.8 GHz on the big cores; later production
+  parts appear capped at 2.6 GHz. Don't hardcode a specific number — read
+  `cpuinfo_max_freq` on the actual unit (the detection script below does
+  this).
+- I have not read CIX's own datasheet/TRM directly, only secondary coverage
+  confirming one exists (published Dec 2025). If you need authoritative
+  numbers beyond what's here, pull it from CIX's developer portal.
+- Sources: [CNX Software board announcement](https://www.cnx-software.com/2024/12/18/radxa-orion-o6-mini-itx-motherboard-is-powered-by-cix-p1-12-core-armv9-soc-with-a-30-tops-ai-accelerator/), [Radxa product page](https://radxa.com/products/orion/o6/), [SBCwiki CD8180/P1](https://sbcwiki.com/docs/soc-manufacturers/cix/cd8180-p1/), [CNX Software review](https://www.cnx-software.com/2025/01/29/radxa-orion-o6-review-unboxing-debian-12-installation-and-first-benchmarks/).
+
+## 2. Build profile
+
+### Toolchain requirement — read this before building
+
+`armv9.2-a` as a `-march` value needs **GCC 13+ or Clang 14+**. GCC's own
+release notes confirm armv9.1-a/9.2-a/9.3-a landed in GCC 13 (GCC 12 only
+has plain `armv9-a`); Clang added it in 14.0.0. **Ubuntu 22.04's default
+`gcc-aarch64-linux-gnu` package is 11.2.0 and cannot parse this flag at
+all** — it predates even `armv9-a` (GCC 12). If you're cross-compiling from
+an Ubuntu 22.04 host (as `release-engine.yml`'s generic `aarch64-unknown-linux-gnu`
+job does today, with no `-march` override), install a newer cross-toolchain
+first: the `ubuntu-toolchain-r/test` PPA, the Arm GNU Toolchain from
+developer.arm.com, or build from a newer host (Ubuntu 24.04's default is
+new enough — verified empirically in this profile's own testing: GCC
+13.3.0 from a 24.04-based cross-toolchain accepted the flag and produced a
+working cross-compiled binary end to end).
+
+Note the `+sve2+bf16+i8mm+dotprod` suffixes are technically redundant on a
+new-enough compiler — GCC's own AArch64-Options table shows `armv9.1-a`
+already implies `+sve+sve2+bf16+i8mm`, and dotprod is inherited further
+back from `armv8.4-a`. They're kept explicit here anyway: harmless, and it
+makes the intent self-documenting instead of relying on an implication
+chain the reader has to look up.
+
+### How the flag is wired
+
+`engine/vendor/llama-cpp-rs/llama-cpp-sys-2/build.rs` already had a
+cross-compile branch for generic `aarch64-unknown-linux-gnu` that hardcoded
+`GGML_CPU_ARM_ARCH=armv8-a` (the lowest common denominator — correct for a
+generic ARM64 release binary, but it never gave the CIX P1 its actual ISA
+extensions). It now reads a `LLAMA_GGML_CPU_ARM_ARCH` env var and falls back
+to the same `armv8-a` default when unset, so every existing build (CI's
+generic arm64 job included) is unaffected unless it opts in.
+
+`GGML_CPU_ARM_ARCH` itself is upstream `ggml`'s own CMake option
+(`ggml/CMakeLists.txt`) — this profile does not patch the vendored
+`llama.cpp` submodule at all, only how our own build script drives an
+option it already exposes.
+
+### Cross-compiling for the CIX P1
+
+```bash
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+export LLAMA_GGML_CPU_ARM_ARCH="armv9.2-a+sve2+bf16+i8mm+dotprod"
+cargo build --release --target aarch64-unknown-linux-gnu -p eullm-engine
+```
+
+Verified in this profile's own testing: the resulting `CMakeCache.txt` shows
+`GGML_CPU_ARM_ARCH:STRING=armv9.2-a+sve2+bf16+i8mm+dotprod` and
+`GGML_NATIVE:BOOL=OFF`, and the actual `ggml-cpu` target's `flags.make`
+carries `-march=armv9.2-a+sve2+bf16+i8mm+dotprod -fopenmp` through to the
+real compile command — not just the CMake cache variable.
+
+### Building natively, on the Orion itself
+
+If you build directly on the board instead of cross-compiling, set
+`GGML_NATIVE`'s automatic detection aside and use the same override — native
+`-mcpu=native` probing runs on the actual CPU so it can work, but pinning the
+exact profile explicitly is more reproducible for a WP4 baseline than
+relying on what the compiler's `-mcpu=native` probe happens to detect:
+
+```bash
+LLAMA_GGML_CPU_ARM_ARCH="armv9.2-a+sve2+bf16+i8mm+dotprod" cargo build --release -p eullm-engine
+```
+
+## 3. Verify the ISA path is actually active at runtime
+
+Start the engine and look at the `system_info:` line it prints at startup
+(`common_params_get_system_info` in llama.cpp, called from `cmd_run`). It
+lists every compiled-in feature the CPU backend detected as present, e.g.:
+
+```
+system_info: n_threads = 8 / 12 | CPU : NEON = 1 | ARM_FMA = 1 | FP16_VA = 1 | MATMUL_INT8 = 1 | SVE = 1 | SVE_CNT = 16 | DOTPROD = 1 | LLAMAFILE = 1 |
+```
+
+`MATMUL_INT8 = 1` is i8mm, `SVE = 1` (+ `SVE_CNT`, the vector length in
+bytes) confirms SVE2, `DOTPROD = 1` confirms dotprod. If any of these are
+missing, the `-march` override either wasn't picked up (check
+`LLAMA_GGML_CPU_ARM_ARCH` was actually exported before the build, and that
+`CMakeCache.txt` in the build directory shows it) or the toolchain silently
+fell back to a lower baseline (check the compiler actually recognized the
+flag — the GCC 13+/Clang 14+ requirement above).
+
+## 4. Confirm Q4_0 quantization triggers the i8mm repack path
+
+Q4_0 tensors get repacked at model-load time into an interleaved layout
+matched to whatever the CPU backend detected (`ggml/src/ggml-cpu/repack.cpp`,
+`get_tensor_traits`): SVE 8x8 if `SVE_CNT` happens to equal 32 bytes, else
+i8mm-backed `q4_0_4x8` if i8mm is present (this is the CIX P1's expected
+path — a 256-bit SVE vector length isn't confirmed for this core, and even
+if present the codepath still needs the exact 32-byte match), else
+dotprod-only `q4_0_4x4`, else the plain unpacked path.
+
+This repack step logs at `GGML_LOG_DEBUG` — and EULLM does not suppress
+logs until *after* the inference context is created (`scheduler.rs` calls
+`backend.void_logs()` only once the context is up, specifically so
+model-load diagnostics like this stay visible). No special verbosity flag
+is needed: just check the model-load output.
+
+```bash
+eullm run <model> --no-ui --threads 4 < /dev/null 2>&1 | grep -i "repack tensor"
+# or, if you started it backgrounded into server.log:
+grep -i "repack tensor" server.log
+```
+
+Expect lines like:
+
+```
+ggml_backend_cpu_x86_repack_buffer_type_get_extra_bufts?: repack tensor blk.0.attn_q.weight with q4_0_4x8
+```
+
+(exact function-name prefix depends on the call site — the load-bearing
+part is `with q4_0_4x8`, confirming the i8mm/smmla kernel was selected, vs
+`q4_0_4x4` for dotprod-only or `q4_0_8x8` for the SVE path). Only Q4_0
+tensors with `ne[1] % 4 == 0` are eligible — true for essentially every
+real weight matrix, but worth knowing if a specific tensor is missing from
+the log.
+
+## 5. Thread pinning — big cores only
+
+**Do not hardcode a core range.** Core numbering on this board is
+firmware-dependent and non-contiguous by tier: a SystemReady UEFI firmware
+exposes only 8 cores (big+medium A720; the 4 little A520 cores are disabled
+outright), while Radxa's own BSP firmware exposes all 12 across 5 cpufreq
+policies. A real capture on one firmware showed `cpu0` = big, `cpu1-4` =
+little, `cpu5-8` = medium, `cpu9-11` = big — the 4 big cores are
+non-contiguous even within one boot. Always detect on the actual unit.
+
+`bench/detect_arm_big_cores.sh` does this: it reads each online core's
+`MIDR_EL1` (Cortex-A720 = part `0xd81`, Cortex-A520 = part `0xd80`,
+cross-checked against the Linux kernel's `cputype.h` and independently
+against `pytorch/cpuinfo`), then splits the A720 cores into big/medium by
+`cpuinfo_max_freq` (both tiers share the same MIDR part number). Run it on
+the Orion itself:
+
+```bash
+sudo bash bench/detect_arm_big_cores.sh
+```
+
+It prints a ready-to-use `taskset` command. Combine with `--threads` set to
+the detected big-core count so the scheduler doesn't also spin up worker
+threads for cores it isn't pinned to:
+
+```bash
+taskset -c <big-core-list> eullm run <model> --no-ui --threads <big-core-count> < /dev/null > server.log 2>&1 &
+```
+
+`taskset` pins the whole process (and everything it spawns) regardless of
+whether the build uses OpenMP or ggml's own thread pool, so it's the
+recommended default. This build is OpenMP-enabled by default
+(`llama-cpp-2`'s `openmp` feature, `-fopenmp` visible in the build's own
+`flags.make` — see § 2), so `OMP_PROC_BIND=close` /
+`OMP_PLACES="{<big-core-list>}"` work as a complementary/alternative
+mechanism if you'd rather not wrap the whole process in `taskset`.
+
+Native low-level pinning via ggml's own `ggml_threadpool_params` cpumask
+(what upstream's `--cpu-mask`/`--cpu-range` CLI flags use) is not wired
+through our Rust bindings at all today — only a plain thread *count*
+(`--threads`) is. Wiring that through would mean new `wrapper_common.cpp` +
+Rust binding surface, which is a real option later if `taskset` proves
+insufficient, but wasn't pursued here as a first cut, since it touches
+inference-pipeline plumbing on a change this profile can't verify itself
+(no ARM hardware in the build/dev environment used to write it).
+
+## 6. Power estimation
+
+**Not confirmed on this board.** I checked Radxa's official hardware-info
+docs, the product brief, multiple independent reviews, and the community
+forum, and found no documented onboard INA-family hwmon sensor, vendor power
+CLI tool, or PMIC telemetry exposed to Linux for the Orion O6. All power
+figures in published reviews (idle ~11-15 W, load ~24-55+ W depending on
+workload) appear to be external wall/USB meter readings, not board-reported
+values.
+
+`bench/arm_cpu_bench.py --power-sysfs-path <path>` is the documented hook:
+if you find a real hwmon node on your actual unit — check
+`ls /sys/class/hwmon/*/name` on the board itself, since this wasn't
+confirmed remotely — point the flag at it (plus
+`--power-scale-to-watts` if it's not in microwatts) and the benchmark
+will sample it during the decode run and report average watts and
+tok/s-per-watt. Until then, treat power/perf-per-watt as requiring an
+external USB power meter around the board.
+
+## 7. T4.1 baseline benchmark
+
+`bench/arm_cpu_bench.py` measures prefill and decode tok/s separately
+(client-side TTFT/generation-time split — the server doesn't yet report
+these as separate durations; see roadmap item 0.7-B), sweeping prompt
+length for prefill and repeating a fixed generation for decode:
+
+```bash
+pip install aiohttp
+python bench/arm_cpu_bench.py \
+    --url http://localhost:11434 --model <model> \
+    --notes "4 big A720 cores, taskset 0,9,10,11, --threads 4" \
+    --json t4.1-baseline-$(date +%Y%m%d).json
+```
+
+Re-run with the same flags after any build/config change and diff the JSON
+to track regressions or gains against this baseline. `--notes` exists
+specifically so the pinning/thread config used for a given run travels with
+its numbers instead of being tribal knowledge.
+
+## Known open items
+
+- Exact big-core clock ceiling (2.6 vs 2.8 GHz) varies by silicon revision —
+  read it on the actual unit, don't assume.
+- Power telemetry is unconfirmed; treat as absent until verified with
+  `ls /sys/class/hwmon/*/name` on real hardware.
+- Native ggml threadpool cpumask pinning (beyond `taskset`) isn't exposed
+  through our Rust bindings; see § 5.
+- None of this document's runtime claims (system_info output, repack log
+  lines, actual tok/s) have been executed on real CIX P1 hardware — this
+  environment has no ARM device. The build itself was verified end to end
+  by cross-compiling in this environment (GCC 13.3.0 cross-toolchain,
+  confirmed via the resulting `CMakeCache.txt` and `flags.make`); the
+  runtime behavior described in §§ 3-4 follows directly from reading the
+  vendored `ggml`/`llama.cpp` source, not from an actual run. Please
+  confirm on the Orion and report back if anything here doesn't match.

--- a/docs/arm-cix-p1-cpu-profile.md
+++ b/docs/arm-cix-p1-cpu-profile.md
@@ -69,6 +69,19 @@ generic arm64 job included) is unaffected unless it opts in.
 `llama.cpp` submodule at all, only how our own build script drives an
 option it already exposes.
 
+### Prebuilt binary from CI
+
+Every tagged release now also builds `eullm-linux-arm64-cix-p1` (job
+`build-arm-cix-p1` in `release-engine.yml`), on GitHub's native
+`ubuntu-24.04-arm` runners — its default `gcc` is already 13.x, so no
+toolchain upgrade step is needed there the way a cross-compile job would.
+Grab it from the [latest release](https://github.com/eullm/eullm/releases/latest)
+instead of building it yourself if a tagged version is recent enough.
+**This is a separate artifact from the generic `eullm-linux-arm64`
+binary on purpose** — it will SIGILL on any ARM64 host that lacks these
+exact ISA extensions (Raspberry Pi, Graviton, etc.), so it's not listed in
+the README's general platform table.
+
 ### Cross-compiling for the CIX P1
 
 ```bash

--- a/docs/arm-cix-p1-cpu-profile.md
+++ b/docs/arm-cix-p1-cpu-profile.md
@@ -82,6 +82,12 @@ binary on purpose** — it will SIGILL on any ARM64 host that lacks these
 exact ISA extensions (Raspberry Pi, Graviton, etc.), so it's not listed in
 the README's general platform table.
 
+To iterate on the job itself without cutting a real tag (and without
+paying for the other 5 platform builds, or creating a GitHub Release):
+Actions tab → *Release Engine* → *Run workflow* (`workflow_dispatch`) on
+this branch. That trigger runs `build-arm-cix-p1` only — every other job,
+and the release step itself, are skipped on manual dispatch.
+
 ### Cross-compiling for the CIX P1
 
 ```bash

--- a/engine/vendor/llama-cpp-rs/llama-cpp-sys-2/build.rs
+++ b/engine/vendor/llama-cpp-rs/llama-cpp-sys-2/build.rs
@@ -814,8 +814,16 @@ fn main() {
         // If the target-cpu is not specified as native, we take off the native ARM64 support.
         // It is useful in docker environments where the native feature is not enabled.
         config.define("GGML_NATIVE", "OFF");
-        config.define("GGML_CPU_ARM_ARCH", "armv8-a");
+        // Cross-compiling can't rely on GGML_NATIVE's `-mcpu=native` probe (that
+        // probes the BUILD host, not the TARGET device), so the baseline defaults
+        // to the lowest common aarch64 denominator. Override for a known target
+        // device's exact core (e.g. `armv9.2-a+sve2+bf16+i8mm` for a CIX P1 board)
+        // via this env var so its optional ISA extensions actually get used
+        // instead of silently falling back to plain armv8-a codegen.
+        let arm_arch = env::var("LLAMA_GGML_CPU_ARM_ARCH").unwrap_or_else(|_| "armv8-a".to_string());
+        config.define("GGML_CPU_ARM_ARCH", &arm_arch);
     }
+    println!("cargo:rerun-if-env-changed=LLAMA_GGML_CPU_ARM_ARCH");
 
     if cfg!(feature = "vulkan") {
         config.define("GGML_VULKAN", "ON");


### PR DESCRIPTION
## Summary

CPU-only baseline for running the engine on the CIX P1 SoC (Radxa Orion O6), per POSCAR WP4. No NPU work here — CPU only, as scoped.

- **Build profile**: `engine/vendor/llama-cpp-rs/llama-cpp-sys-2/build.rs` gained an opt-in `LLAMA_GGML_CPU_ARM_ARCH` env var, read by the existing aarch64 cross-compile branch that previously hardcoded `GGML_CPU_ARM_ARCH=armv8-a` unconditionally. Default behavior (every existing build, including CI's generic arm64 job) is unchanged unless this is set. `GGML_CPU_ARM_ARCH` is upstream `ggml`'s own CMake option — nothing in the pinned `llama.cpp` submodule is touched.
- **Toolchain requirement (important)**: `-march=armv9.2-a+...` needs **GCC 13+ or Clang 14+**. Ubuntu 22.04's default `gcc-aarch64-linux-gnu` is 11.2.0 and cannot parse it at all — documented prominently in the new doc.
- **Verified end to end** in this environment: cross-compiled `eullm-engine` for `aarch64-unknown-linux-gnu` with a GCC 13 cross-toolchain; confirmed via the resulting `CMakeCache.txt` and `ggml-cpu`'s `flags.make` that the exact `-march` string reaches the real compile command, not just the CMake cache variable.
- **`docs/arm-cix-p1-cpu-profile.md`**: build profile, how to confirm i8mm/SVE2/dotprod are active via the `system_info` line, how to confirm Q4_0 repacks to the i8mm-backed `q4_0_4x8` kernel (via the existing `GGML_LOG_DEBUG` repack line — visible without extra flags since `void_logs()` only runs after context creation), thread-pinning guidance, and the documented gap around board power telemetry.
- **`bench/detect_arm_big_cores.sh`**: MIDR_EL1-based detection of Cortex-A720 vs Cortex-A520 cores (and big vs medium A720 tiers by max frequency). Core numbering on this board is firmware-dependent and non-contiguous by tier (confirmed via research), so this deliberately does not hardcode a core range.
- **`bench/arm_cpu_bench.py`**: T4.1 baseline harness measuring prefill and decode tok/s separately (client-side TTFT/generation-time split, since the server doesn't separate these yet — roadmap item 0.7-B), with an optional `--power-sysfs-path` hook.

## What's documented but not implemented

Native ggml threadpool cpumask pinning (upstream's `--cpu-mask`/`--cpu-range`) is not wired through our Rust bindings — only thread *count* (`--threads`) is. `taskset` + OpenMP env vars are documented as the recommended pinning mechanism instead. Wiring the native cpumask through would need new `wrapper_common.cpp` + Rust binding surface — a real option later, not attempted here since it touches inference-pipeline plumbing this change can't verify without ARM hardware.

## Test plan

- [x] `cargo build`, `cargo clippy --no-deps -- -D warnings`, `cargo test` all pass on the native (x86_64) build — this change doesn't touch engine logic, only the vendored sys-crate's build script.
- [x] Cross-compiled for `aarch64-unknown-linux-gnu` with a GCC 13 cross-toolchain; confirmed the `-march` flag reaches the real build via `CMakeCache.txt` and `flags.make`.
- [x] `bench/detect_arm_big_cores.sh` and `bench/arm_cpu_bench.py` syntax-checked and smoke-tested against simulated/mock inputs (no real ARM hardware or model available in this environment).
- [ ] **Needs a real run on the Orion**: `system_info` showing `MATMUL_INT8`/`SVE`/`DOTPROD`, the `repack tensor ... q4_0_4x8` log line, `detect_arm_big_cores.sh` against the real board, and a first `arm_cpu_bench.py` T4.1 baseline number.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MNmp9cqoW2qXPk5C6LYVxy)_