### PR TITLE
fix(engine): correct the default tracing filter target to eullm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" />
   <img src="https://img.shields.io/badge/EU%20AI%20Act-Designed%20for%20compliance-gold" alt="EU AI Act" />
-  <img src="https://img.shields.io/badge/Engine-v0.6.21-2ea44f" alt="Engine status" />
+  <img src="https://img.shields.io/badge/Engine-v0.6.22-2ea44f" alt="Engine status" />
   <img src="https://img.shields.io/badge/Forge%20%2B%20Hub-Early%20development-orange" alt="Forge/Hub status" />
   <a href="https://github.com/eullm/eullm/actions/workflows/ci.yml"><img src="https://github.com/eullm/eullm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://doi.org/10.5281/zenodo.20412979"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20412979.svg" alt="DOI" /></a>

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.21"
+version = "0.6.22"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -369,7 +369,14 @@ async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "eullm_engine=info".into()),
+                // Module paths are rooted at the [[bin]] name ("eullm" in
+                // Cargo.toml), not the package name ("eullm-engine") - there's
+                // no separate lib.rs, so every tracing::info!/warn! call site
+                // resolves its target under "eullm::...". "eullm_engine=info"
+                // never matched anything, silently disabling all engine
+                // logging (KV-reuse diagnostics, context/scheduler startup
+                // info, etc.) unless RUST_LOG was set explicitly.
+                .unwrap_or_else(|_| "eullm=info".into()),
         )
         .init();
 


### PR DESCRIPTION
Cargo.toml declares [[bin]] name = "eullm" (package name is eullm-engine), and there's no separate lib.rs - every module lives under the binary crate, so tracing::info!/warn! call sites resolve their target as eullm::..., never eullm_engine::.... The default EnvFilter fallback ("eullm_engine=info", used whenever RUST_LOG isn't set) never matched anything, silently disabling all of the engine's own logging by default: KV-cache reuse diagnostics, scheduler/context startup info, everything above println!/eprintln!.

Found while investigating why a real Orion run showed no "reused N from cache" line; reproduced identically on x86 with no ARM/ISA involvement, confirming it as a general, platform-independent bug rather than anything specific to the CIX P1 build profile. Verified fixed: default (unset RUST_LOG) run now prints scheduler/context INFO lines that were previously invisible without manually setting RUST_LOG=eullm=info.