### PR TITLE
docs: remove internal project codename from public docs

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -400,8 +400,8 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
 
-  # CIX P1 (Armv9.2-A: SVE2, BF16, I8MM, DotProd) CPU-only profile — POSCAR
-  # WP4 baseline for the Radxa Orion O6. Deliberately a SEPARATE artifact
+  # CIX P1 (Armv9.2-A: SVE2, BF16, I8MM, DotProd) CPU-only profile — WP4
+  # baseline for the Radxa Orion O6. Deliberately a SEPARATE artifact
   # from `build`'s generic eullm-linux-arm64: baking these ISA extensions
   # into the generic binary would SIGILL on any ARM64 host that doesn't
   # have them (Raspberry Pi, Graviton, other SoCs). Native ubuntu-24.04-arm

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@
 >   a small, unstable fraction before it worked (see below) — this wasn't a
 >   default that "just worked," it required finding why it didn't
 >
-> This is the WP4 (Sovereign AI / EuLLM Integration) proof point for the
-> POSCAR EIC Transition effort: a large, capable open model, genuinely
-> running on sovereign, GPU-free, low-power EU hardware — not a toy demo on
+> This is the WP4 (Sovereign AI / EuLLM Integration) proof point: a large,
+> capable open model, genuinely running on sovereign, GPU-free, low-power
+> EU hardware — not a toy demo on
 > a small distilled model.
 
 ## Try it now

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,6 +1,6 @@
 # bench/ — Stress Test & Parallelism Verification
 
-## POSCAR WP4 — CIX P1 ARM CPU baseline
+## WP4 — CIX P1 ARM CPU baseline
 
 See [`docs/arm-cix-p1-cpu-profile.md`](../docs/arm-cix-p1-cpu-profile.md) for
 the full build profile, i8mm/repack runtime verification, and thread-pinning

--- a/bench/arm_cpu_bench.py
+++ b/bench/arm_cpu_bench.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""POSCAR WP4 / T4.1 baseline — separate PREFILL and DECODE throughput on CPU.
+"""WP4 / T4.1 baseline — separate PREFILL and DECODE throughput on CPU.
 
 Measures prefill tok/s (across a sweep of prompt lengths) and decode tok/s
 (at a fixed generation length) against a running `eullm run`/`eullm serve`
@@ -213,7 +213,7 @@ async def run_decode_bench(session, args, power_sampler):
 
 
 async def main_async(args):
-    print(f"eullm ARM CPU baseline (POSCAR WP4 / T4.1) - {args.url}  model={args.model}")
+    print(f"eullm ARM CPU baseline (WP4 / T4.1) - {args.url}  model={args.model}")
     if args.notes:
         print(f"notes: {args.notes}")
 

--- a/docs/arm-cix-p1-cpu-profile.md
+++ b/docs/arm-cix-p1-cpu-profile.md
@@ -1,4 +1,4 @@
-# CIX P1 (Armv9.2-A) CPU build profile — POSCAR WP4
+# CIX P1 (Armv9.2-A) CPU build profile — WP4
 
 CPU-only baseline for running EULLM Engine on the CIX P1 SoC (Radxa Orion O6
 mini-ITX board, also sold as the smaller Orion O6N Nano-ITX with the same


### PR DESCRIPTION
Nothing about this effort is official yet — strip the codename reference from README, ARM profile doc, bench scripts, and the CI workflow comment. Keeps the generic WP4 framing (work package, not tied to any specific naming), which is accurate on its own.