### PR TITLE
docs: drop WP4 jargon and bug-fixing narrative from the headline callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,13 @@
 >   reuses the *entire* prior turn's resident state, verified across 6+
 >   consecutive turns at both 4096 and 16384-token context, with both F16 and
 >   Q8_0 KV cache — not a lucky first turn, a sustained, reproducible result
-> - Root-caused and fixed two real bugs that were silently degrading this to
->   a small, unstable fraction before it worked (see below) — this wasn't a
->   default that "just worked," it required finding why it didn't
 >
-> This is the WP4 (Sovereign AI / EuLLM Integration) proof point: a large,
-> capable open model, genuinely running on sovereign, GPU-free, low-power
-> EU hardware — not a toy demo on
-> a small distilled model.
+> A large, capable open model, genuinely running on sovereign, GPU-free,
+> low-power EU hardware — not a toy demo on a small distilled model.
+>
+> *(Getting multi-turn reuse to actually work on this architecture took two
+> engine-side fixes — see "The actual root cause of small/unstable reuse"
+> further down for the technical detail.)*
 
 ## Try it now
 


### PR DESCRIPTION
WP4 is meaningless without the internal project context that was just removed, and citing our own bug fixes as a highlight in a "what works" callout isn't the right framing — that's normal engineering, not a result. Keep the callout to the actual result (35B on ARM CPU-only, confirmed 100% KV-cache reuse), with a one-line pointer to the existing technical writeup further down instead of restating it here.