### PR TITLE
docs: fix ARM hardware wording in README callout for accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ---
 
-> ### 🇪🇺 Proven: a 35B-parameter model, fully local, on European ARM hardware, no GPU
+> ### 🇪🇺 Proven: a 35B-parameter model, fully local, on EU-available ARM hardware, no GPU
 >
 > A 35B-parameter hybrid MoE model (`qwen3.6-35b-a3b`, ~3B active params/token)
 > running entirely on CPU on a **Radxa Orion O6 (CIX P1 SoC, Armv9.2-A,


### PR DESCRIPTION
Heading said "European ARM hardware" while the body correctly said "EU-available hardware" — the board (Radxa Orion O6/CIX P1) is designed and made in China, not Europe. Sovereignty claim rests on software/data control, not hardware manufacturing origin.