### PR TITLE
docs: soften absolute compliance/positioning claims, document mirror …

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,12 +504,12 @@ The **EU AI Act** (Regulation 2024/1689) takes effect August 2, 2026. High-risk 
 European SMEs need AI models that:
 
 - **Run locally** on their own hardware or EU servers
-- **Comply** with GDPR and the AI Act out of the box
+- **Make GDPR and AI Act audit-trail requirements easier to satisfy**
 - **Speak their language** and understand their domain
 - **Carry their brand** — not "Powered by Qwen" or "Built with Llama"
 - **Cost nothing** in ongoing API fees
 
-EULLM is the missing infrastructure.
+EULLM aims to close that gap.
 
 ## The solution
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,6 +199,12 @@ All code is Apache 2.0. Only models with fully permissive licenses are supported
 
 Meta Llama is excluded due to branding requirements.
 
+## Dependency provenance: mirrors, not forks
+
+EULLM Engine depends on two upstream projects — [`ggml-org/llama.cpp`](https://github.com/ggml-org/llama.cpp) and [`utilityai/llama-cpp-rs`](https://github.com/utilityai/llama-cpp-rs) — and neither is forked. A scheduled job (`.github/workflows/mirror-sync.yml`, daily at 03:17 UTC) mirrors both upstream repos verbatim, including all tags, into `eullm/llama.cpp` and `eullm/llama-cpp-rs`. The Engine's git submodule and Cargo path dependency point at those EU-hosted mirrors, not at upstream directly, and every release is built against a tag on the mirror.
+
+The reason is durability, not divergence: tags pushed to the mirror are immutable, so even if upstream history is rewritten or a repo disappears, every version EULLM has ever depended on stays pinnable. We track upstream, we don't diverge from it — any patch we need goes through upstream's own contribution process first.
+
 ## Infrastructure
 
 All EULLM infrastructure runs on EU servers:


### PR DESCRIPTION
…policy

- Reword the GDPR/AI Act bullet in "The problem" so it doesn't imply the binary alone makes a deployment compliant.
- Soften "EULLM is the missing infrastructure" to avoid reading as "nobody else can do this."
- Document that llama.cpp and llama-cpp-rs are mirrored daily into eullm-owned repos rather than forked, and why releases pin against the mirror instead of upstream directly.