### PR TITLE
fix(engine): stop diverging from Ollama's max_tokens and seed defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" />
   <img src="https://img.shields.io/badge/EU%20AI%20Act-Designed%20for%20compliance-gold" alt="EU AI Act" />
-  <img src="https://img.shields.io/badge/Engine-v0.6.26-2ea44f" alt="Engine status" />
+  <img src="https://img.shields.io/badge/Engine-v0.6.27-2ea44f" alt="Engine status" />
   <img src="https://img.shields.io/badge/Forge%20%2B%20Hub-Early%20development-orange" alt="Forge/Hub status" />
   <a href="https://github.com/eullm/eullm/actions/workflows/ci.yml"><img src="https://github.com/eullm/eullm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://doi.org/10.5281/zenodo.20412979"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20412979.svg" alt="DOI" /></a>
@@ -448,7 +448,50 @@ quantization where every non-shared tensor type is on the accelerated
 list above over a smaller file that isn't** — file size and ARM decode
 speed are not the same axis.
 
+### `max_tokens`/`num_predict` and `seed`: two defaults that silently diverged from Ollama
+
+A community report on a text-based tool-calling client (Cline, via the
+Ollama-compatible `/api/chat`) described the client reliably freezing on
+long agentic conversations. Reproduced on real hardware with a scripted
+conversation that mimics Cline's own text-based MCP tool-call convention
+(eullm has no native `tools`/function-calling API, so any such client falls
+back to plain text for it):
+
+- With no `max_tokens`/`num_predict` in the request, eullm defaulted to
+  **512** — a fixed cap that doesn't exist in Ollama itself, whose real
+  default is unbounded (`-1`: generate until context is full or a stop
+  condition). A reasoning model can spend hundreds of tokens still inside
+  `<think>` before producing anything else; on real hardware this
+  reproduced exactly as described — generation cut off mid-`<think>`, with
+  no closing tag, leaving a text-based tool-calling client holding a block
+  that will never close in that message. Fixed: the default is now
+  unbounded, clamped only by whatever context budget the request actually
+  has left (the existing per-request clamp in `prefill_sequence` already
+  did this correctly — it just never got an unbounded value to clamp).
+- Separately, when no `seed` is given, eullm defaulted to a fixed value
+  (the KV-cache slot id on the scheduler path, a hardcoded `1234` on the
+  sequential-fallback path) instead of Ollama's real behavior of a fresh
+  seed per request. Harmless for the freeze itself, but silently made every
+  unseeded request through a given slot deterministic — surprising for an
+  API that advertises Ollama compatibility. Fixed: both paths now derive an
+  unseeded request's seed from wall-clock entropy.
+
+**What this fix does *not* do:** remove the token cap and a long reasoning
+turn stops being *corrupted*, but on CPU-only ARM hardware it doesn't stop
+being *slow*. Reproduced on the same hardware as the 35B CPU result above:
+a single turn that needed 3,270 tokens of genuine (non-looping — checked
+for repeated n-gram windows, found none) reasoning took **337 seconds** at
+the model's normal ~10 tok/s decode rate. That's long enough to look
+identical to a freeze from the outside, with nothing actually wrong
+server-side. There is no code fix for this — it's the real cost of running
+a large reasoning model without a GPU. If a client's tool-routing turns
+don't need deep reasoning, disabling thinking for those turns (`"think":
+false` on the API, where the client exposes it) is the actual mitigation,
+not a bigger token budget.
+
 ## What's ready today, what's coming
+
+**New in v0.6.27** — Fixed two sampling defaults that silently diverged from Ollama's real behavior when a client doesn't set them explicitly: `max_tokens`/`num_predict` defaulted to a fixed 512 instead of Ollama's real unbounded-until-context-or-stop (`-1`) default, and `seed` defaulted to a fixed per-slot value instead of a fresh one per request. The `max_tokens` gap was confirmed on real hardware to truncate a reasoning model's response mid-`<think>` or mid-tool-call on long agentic conversations, corrupting the response for any client (e.g. Cline) that expects well-formed output — see the max_tokens/seed note below for the reproduction and the latency trade-off it does *not* fix on its own.
 
 **New in v0.6.26** — Fixed `eullm run --cli`'s `/no_think` sticky toggle silently corrupting KV-cache reuse: the injected think-suppression text was never re-added when reconstructing a suppressed turn for later history, so every `/no_think` turn permanently diverged from what was truly resident. Confirmed on real hardware to be the dominant cause of small/unstable reuse in practice — see "`/no_think`" above.
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.26"
+version = "0.6.27"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/api/routes.rs
+++ b/engine/src/api/routes.rs
@@ -131,10 +131,15 @@ fn parse_generate_params(body: &Value) -> SamplingParams {
         body.get(key).or_else(|| options.and_then(|o| o.get(key)))
     };
 
+    // Ollama's real default is unbounded (-1: generate until context is
+    // full or a stop condition), not a small fixed cap — confirmed against
+    // Ollama's own docs/source, see ollama/ollama#7691. Leaving this
+    // unbounded here is safe because prefill_sequence() always clamps it to
+    // the remaining context budget regardless of what's requested.
     let max_tokens = get("max_tokens")
         .or_else(|| get("num_predict"))
         .and_then(|v| v.as_u64())
-        .unwrap_or(512) as u32;
+        .unwrap_or(u32::MAX as u64) as u32;
     // Defaults match Ollama: temperature=0.8, top_k=40, top_p=0.9, repeat_penalty=1.1
     let temperature = get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.8) as f32;
     let top_k = get("top_k").and_then(|v| v.as_i64()).unwrap_or(40) as i32;
@@ -1216,4 +1221,29 @@ fn model_names_match(loaded: &str, normalized_request: &str) -> bool {
         .and_then(|s| s.to_str())
         .unwrap_or(normalized_request);
     loaded_stem == request_stem
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A reasoning model doing free-text tool-calling can burn through
+    // hundreds of tokens of <think> before producing anything else — a
+    // small fixed cap here (the old default was 512) truncates mid-block
+    // and leaves a text-based tool-calling client (e.g. Cline) holding an
+    // unclosed tag. Confirmed on real hardware: see the v0.6.27 changelog.
+    #[test]
+    fn max_tokens_defaults_to_unbounded_not_a_small_fixed_cap() {
+        let sp = parse_generate_params(&json!({}));
+        assert_eq!(sp.max_tokens, u32::MAX);
+    }
+
+    #[test]
+    fn max_tokens_still_honors_an_explicit_client_value() {
+        let sp = parse_generate_params(&json!({ "max_tokens": 128 }));
+        assert_eq!(sp.max_tokens, 128);
+
+        let sp = parse_generate_params(&json!({ "options": { "num_predict": 256 } }));
+        assert_eq!(sp.max_tokens, 256);
+    }
 }

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -112,6 +112,21 @@ pub(crate) fn build_ctx_params_with_cache(
     params
 }
 
+/// Sampling seed to use when the client doesn't specify one.
+///
+/// Ollama's real default is a fresh, effectively random seed per request
+/// (-1), not a fixed value — confirmed against Ollama's own docs/source
+/// (see ollama/ollama#7691). Wall-clock nanoseconds give enough variety for
+/// sampling without pulling in a `rand` dependency for this. `fallback` is
+/// only used in the practically-impossible case the system clock predates
+/// the Unix epoch.
+pub(crate) fn random_seed_fallback(fallback: u32) -> u32 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(fallback)
+}
+
 pub use scheduler::{BatchScheduler, ModelReadyInfo, SchedulerConfig, SchedulerHandle};
 
 /// Configuration for the inference engine.
@@ -689,7 +704,7 @@ impl InferenceEngine {
         // When a grammar is requested (e.g. format:"json"), we prepend a
         // grammar sampler that constrains the output to valid syntax.
         let mut sampler = {
-            let seed = request.seed.unwrap_or(1234);
+            let seed = request.seed.unwrap_or_else(|| random_seed_fallback(1234));
             let mut chain: Vec<LlamaSampler> = Vec::new();
             if let Some(ref grammar_str) = request.grammar {
                 match LlamaSampler::grammar(&self.model, grammar_str, "root") {
@@ -887,7 +902,7 @@ impl InferenceEngine {
         }
 
         let mut sampler = {
-            let seed = request.seed.unwrap_or(1234);
+            let seed = request.seed.unwrap_or_else(|| random_seed_fallback(1234));
             let mut chain: Vec<LlamaSampler> = Vec::new();
             if let Some(ref grammar_str) = request.grammar {
                 match LlamaSampler::grammar(&self.model, grammar_str, "root") {
@@ -1186,7 +1201,7 @@ impl InferenceEngine {
 
         // ── 6. Sampler (identical to generate_streaming) ────────────────
         let mut sampler = {
-            let seed = request.seed.unwrap_or(1234);
+            let seed = request.seed.unwrap_or_else(|| random_seed_fallback(1234));
             let mut chain: Vec<LlamaSampler> = Vec::new();
             if let Some(ref grammar_str) = request.grammar {
                 if let Ok(gs) = LlamaSampler::grammar(&self.model, grammar_str, "root") {
@@ -1269,4 +1284,21 @@ fn num_cpus() -> u32 {
     std::thread::available_parallelism()
         .map(|n| n.get() as u32)
         .unwrap_or(4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The old default (a fixed seq_id, or a hardcoded 1234 on the
+    // sequential-fallback path) made every unseeded request through a given
+    // slot fully deterministic, unlike Ollama's real -1-seed (random)
+    // behavior. Two calls in the same nanosecond are astronomically
+    // unlikely, so this is a meaningful check, not a flaky one.
+    #[test]
+    fn random_seed_fallback_is_not_a_fixed_value() {
+        let a = random_seed_fallback(1234);
+        let b = random_seed_fallback(1234);
+        assert_ne!(a, b, "seed fallback must not collapse to the `fallback` argument");
+    }
 }

--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -27,7 +27,7 @@ use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
 use tokio::sync::mpsc;
 
-use super::{GenerateRequest, InferenceConfig, StreamEvent};
+use super::{random_seed_fallback, GenerateRequest, InferenceConfig, StreamEvent};
 
 /// Configuration for the batch scheduler.
 #[derive(Debug, Clone)]
@@ -861,7 +861,7 @@ fn run_scheduler_loop(
                     };
 
                     let req = &scheduled.request;
-                    let seed = req.seed.unwrap_or(seq_id as u32);
+                    let seed = req.seed.unwrap_or_else(|| random_seed_fallback(seq_id as u32));
                     let sampler = {
                         let mut chain: Vec<LlamaSampler> = Vec::new();
                         // Grammar (if any) must be first in the chain


### PR DESCRIPTION
max_tokens/num_predict defaulted to a fixed 512 instead of Ollama's real unbounded (-1) behavior. Reproduced on real hardware: a reasoning model doing text-based tool-calling (Cline, via /api/chat) can run past 512 tokens while still inside <think>, truncating the response mid-block and leaving a text-based tool-calling client holding an unclosed tag. The default is now unbounded, clamped only by the existing per-request context budget check in prefill_sequence.

seed defaulted to a fixed value when unspecified (the KV-cache slot id on the scheduler path, a hardcoded 1234 on the sequential-fallback path) instead of a fresh seed per request. Verified this has no relationship to KV-cache prefix reuse, which matches on token/text content only. Both paths now derive an unseeded request's seed from wall-clock entropy via a shared helper.

Also documents that raising the token budget alone does not fix the underlying freeze risk on CPU-only ARM: a genuine, non-looping reasoning turn can legitimately take several minutes at this hardware's decode speed, which looks identical to a freeze from a client's perspective.

Bump to v0.6.27.