### PR TITLE
fix(ci): actually build eullm-macos-x64 CPU-only

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -65,7 +65,6 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-15
             artifact: eullm-macos-x64
-            features: metal
           - target: aarch64-apple-darwin
             os: macos-15
             artifact: eullm-macos-arm64


### PR DESCRIPTION
The release notes template already documented eullm-macos-x64 as "CPU only" (macOS Intel), but the build matrix still passed --features metal for x86_64-apple-darwin, so the published binary kept the broken Metal path. Metal on Intel-Mac GPUs (Intel UHD 630, AMD discrete) produces garbage output or hangs — reported on issue #140 (Mac mini 2018, MacBook Pro 2018) — which this build config change was supposed to fix but never applied to the matrix.

Drop features: metal from that one matrix entry; the build step already handles an empty features list (plain CPU build), and eullm-macos-arm64 keeps Metal unaffected.