### PR TITLE
chore(engine): bump version to 0.6.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.31"
+version = "0.6.32"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"


### PR DESCRIPTION
Catches up Cargo.toml with the already-tagged EuLLM-v0.6.32 release (tagged before this bump landed, so that release's binaries report 0.6.31 internally — known, accepted discrepancy, not re-tagging to avoid a second full release build). Next version is 0.6.33.