### PR TITLE
test: fail clearly on a wrong-architecture binary, and record two fin…

### DIFF
--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -29,7 +29,7 @@ esistenti non sono ripetute qui: sono elencate nella tabella dei rimandi in fond
 ## Stato
 
 **Chiuse (v0.6.35):** tutte le H0, più H1-B, H1-D, H1-G, H2-A, H2-B, H2-C,
-H2-G, H3-D, H3-K, H3-L, H3-M e D-01 — 18 voci su 34.
+H2-G, H3-D, H3-K, H3-L, H3-M e D-01 — 18 voci su 36.
 
 Engine 114 test, Hub 3, Forge 136 — tutti verdi; clippy pulito con
 `-D warnings`; ruff pulito su `eullm_forge/`. I nuovi test coprono: limiti
@@ -69,6 +69,17 @@ hanno risposto ognuna alla propria domanda** (2→20 … 9→90), che è l'invar
 di H2-C sotto concorrenza reale. Il pull ha esercitato anche il download a range
 paralleli e la verifica SHA-256 contro il digest del catalogo. Due scostamenti trovati e registrati: H2-I (404 invece di 500) e H3-N (banner
 assente su `serve`), il secondo emerso scrivendo l'harness.
+
+**La stessa verifica su ARM64** (Radxa Orion O6, Ubuntu 6.14 aarch64, binario
+CIX-P1 CPU-only, `sha256 05611181…`): 19 PASS, 0 FAIL, 3 SKIP. Contano tre cose.
+Le otto richieste concorrenti hanno risposto ognuna alla propria domanda anche
+qui, quindi l'invariante di H2-C non dipendeva da un dettaglio di x86. Il banner
+conferma che il build CPU sfrutta l'ISA del CIX-P1
+(`NEON | ARM_FMA | FP16_VA | MATMUL_INT8 | SVE | DOTPROD | SVE_CNT = 16 | OPENMP | REPACK`),
+cioè che la porta ARM non sta girando in modalità scalare. E i tre SKIP sono
+tutti attesi e già tracciati: H2-I, H1-A (`user_id` sempre `null` perché non
+esiste ancora un'identità di richiesta) e l'assenza di GPU su un binario CPU.
+Un difetto nuovo è emerso da questo run e non era visibile su x86: H2-J.
 
 **Correzione a H0-B fatta prima della release.** Il controllo all'avvio era
 troppo aggressivo: rifiutava di partire ogni volta che la directory di audit non
@@ -337,6 +348,32 @@ esterni non si fidano dei valori che leggono.
   mai riuscire. Distinguere "non trovato" (404) da un fallimento reale di
   caricamento — VRAM insufficiente, GGUF corrotto — che resta 500. Comporta far
   ritornare a `resolve_model` un errore tipizzato invece di una `String`.
+
+- [ ] **H2-J · Con `think: false` un `</think>` finisce nel testo visibile** *(P2)*
+  Emerso dallo smoke test su ARM (Radxa Orion O6, qwen3-0.6b, `think: false`,
+  `temperature: 0`): il contenuto ricostruito dallo stream NDJSON è
+  `"</think>\n\nCount: one two three"` — il tag di chiusura arriva al client come
+  testo dell'assistente. Lo stesso binario su x86 ha invece prodotto prosa di
+  reasoning: in entrambi i casi la soppressione non ha fatto quello che dichiara.
+  Due cause candidate, indipendenti, entrambe da verificare prima di toccare il
+  codice:
+  1. Il prefisso iniettato è `"<think>\n</think>\n\n"` (`chat_template.rs:89-94`),
+     mentre il template ufficiale di Qwen3 per `enable_thinking=false` emette
+     `<think>\n\n</think>\n\n` — una riga vuota fra i due tag. Una sequenza fuori
+     distribuzione di un solo newline è sufficiente a far riemettere al modello il
+     tag di chiusura. Il fix è di un carattere, ma tocca due test che asseriscono
+     la stringa attuale (`chat_template.rs:247` e `:264`) e — attenzione — anche
+     la ricostruzione della history in `main.rs:2927`, che deve restare
+     byte-identica al prefisso iniettato, altrimenti si rompe il riuso del prefix
+     KV (è il motivo per cui `think_suppression_prefix()` esiste come funzione
+     unica invece di due letterali).
+  2. Indipendentemente dalla causa, l'engine non ha nessuna guardia che tolga un
+     blocco `<think>…</think>` — o un tag di chiusura orfano — dal contenuto
+     visibile. `process_piece` ha già il buffer di hold-back per le stop sequence
+     (`inference/scheduler.rs`): è il posto dove filtrare, non a valle nel client.
+  Verificare con `--model qwen3-0.6b --no-inference` disattivato e
+  `temperature: 0` su entrambe le architetture: a temperatura zero il sintomo è
+  deterministico, quindi un before/after è misurabile senza ambiguità.
 
 ---
 

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -228,6 +228,49 @@ class Engine:
 # ── environment description ─────────────────────────────────────────────────
 
 
+# ELF e_machine → nome leggibile. Serve per dire "hai scaricato l'asset
+# sbagliato" invece di lasciare che execve fallisca con "Exec format error",
+# che è vero ma non dice cosa fare.
+_ELF_MACHINES = {0x03: "x86", 0x3E: "x86_64", 0x28: "arm", 0xB7: "aarch64",
+                 0xF3: "riscv64", 0x15: "ppc64"}
+# Come `platform.machine()` nomina le stesse architetture.
+_UNAME_ALIASES = {"x86_64": {"x86_64", "amd64"}, "aarch64": {"aarch64", "arm64"},
+                  "arm": {"armv7l", "armv6l", "arm"}, "x86": {"i386", "i686"}}
+
+
+def binary_arch(binary: Path) -> str | None:
+    """Architecture an ELF binary targets, or None if not an ELF."""
+    try:
+        with open(binary, "rb") as f:
+            head = f.read(20)
+    except OSError:
+        return None
+    if len(head) < 20 or head[:4] != b"\x7fELF":
+        return None
+    little = head[5] == 1
+    e_machine = int.from_bytes(head[18:20], "little" if little else "big")
+    return _ELF_MACHINES.get(e_machine, f"unknown(0x{e_machine:02x})")
+
+
+def check_arch_match(rep: Report, binary: Path) -> bool:
+    """False when the binary cannot possibly run here."""
+    arch = binary_arch(binary)
+    host = platform.machine()
+    if arch is None:
+        rep.add("binary is an ELF executable", None,
+                "not an ELF file — skipping the architecture check "
+                "(fine on macOS, where binaries are Mach-O)")
+        return True
+    ok = host in _UNAME_ALIASES.get(arch, {arch})
+    rep.add(
+        "binary architecture matches this host",
+        ok,
+        f"binary is {arch}, host is {host}" + ("" if ok else
+        " — you downloaded the wrong release asset for this machine"),
+    )
+    return ok
+
+
 def describe_env(binary: Path) -> dict:
     env = {
         "uname": " ".join(platform.uname()),
@@ -809,7 +852,19 @@ def main(argv: list[str] | None = None) -> int:
         if v:
             print(f"  {k}: {v}")
 
+    smi = rep.env.get("nvidia_smi", "")
+    if smi and ("version mismatch" in smi.lower() or "couldn't communicate" in smi.lower()):
+        rep.add(
+            "nvidia-smi usable",
+            None,
+            smi.splitlines()[0][:110] + " — a CUDA build will not find a GPU until "
+            "this is resolved (usually a reboot after a driver update)",
+        )
+
     print("\n── binary ──")
+    if not check_arch_match(rep, binary):
+        print("\nthe binary cannot execute on this host; stopping here.")
+        return finish(rep, args, work, keep=args.keep_workdir)
     version_out = check_binary(rep, binary, args.expect_version)
     rep.env["version_output"] = version_out
 
@@ -819,13 +874,17 @@ def main(argv: list[str] | None = None) -> int:
         on_disk = is_path or any((models_dir / model).glob("*.gguf"))
         if not on_disk and args.pull:
             print(f"\n── pulling {model} into {models_dir} ──")
-            r = subprocess.run(
-                [str(binary), "pull", model],
-                env={**os.environ, **env}, capture_output=True, text=True, timeout=7200,
-            )
-            tail = (r.stdout or r.stderr).strip().splitlines()
-            rep.add(f"pull {model}", r.returncode == 0, tail[-1][:120] if tail else "")
-            on_disk = r.returncode == 0
+            try:
+                r = subprocess.run(
+                    [str(binary), "pull", model],
+                    env={**os.environ, **env}, capture_output=True, text=True, timeout=7200,
+                )
+                tail = (r.stdout or r.stderr).strip().splitlines()
+                rep.add(f"pull {model}", r.returncode == 0, tail[-1][:120] if tail else "")
+                on_disk = r.returncode == 0
+            except (OSError, subprocess.SubprocessError) as e:
+                rep.add(f"pull {model}", False, f"could not run the binary: {e}")
+                on_disk = False
         elif not on_disk:
             rep.add(
                 f"model {model} available",


### PR DESCRIPTION
…dings

The first cross-architecture runs of the smoke test exposed two defects in the harness itself. On the x86 box the downloaded asset turned out to be eullm-linux-arm64-cuda-12.8, so the pull subprocess raised an uncaught OSError (Exec format error) and the run died with a traceback instead of a report. The harness now reads the ELF e_machine field before doing anything else, says which architecture the binary targets and which one the host is, and stops with a report rather than a stack trace. A non-ELF binary is a skip, not a failure, so the check stays correct on macOS.

An nvidia-smi that reports a driver/library version mismatch is now surfaced as an informational line, because a CUDA build cannot find a GPU in that state and the resulting SKIPs are otherwise indistinguishable from "no GPU here".

Two findings recorded in the backlog. The ARM64 run (Radxa Orion O6, CPU-only build) was fully green — 19 pass, 0 fail, 3 expected skips — and confirms that the concurrency invariant is not an x86 accident and that the CPU build uses the CIX-P1 ISA rather than falling back to scalar code. It also surfaced H2-J: with think set to false the closing </think> tag reached the client as assistant text, while the same request on x86 produced reasoning prose. Both candidate causes are written down, including the constraint that the injected prefix and the history reconstruction must stay byte-identical or prefix KV reuse breaks.