### PR TITLE
test: make the --fit check able to discriminate the KV sizing fix

### DIFF
--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -81,6 +81,31 @@ tutti attesi e già tracciati: H2-I, H1-A (`user_id` sempre `null` perché non
 esiste ancora un'identità di richiesta) e l'assenza di GPU su un binario CPU.
 Un difetto nuovo è emerso da questo run e non era visibile su x86: H2-J.
 
+**E su Linux CUDA** (Ryzen 9 5950X, RTX 5070 Ti 16 GB, driver 595.84, binario
+`eullm-linux-x64-cuda-12.8`): 22 PASS, 0 FAIL, 2 SKIP — gli unici due sono H2-I
+e H1-A, cioè voci aperte e non regressioni. Il banner conferma il build Blackwell
+(`CUDA : ARCHS = 860,890,1200 | USE_GRAPHS = 1 | BLACKWELL_NATIVE_FP4 = 1`) e su
+GPU le 8 richieste concorrenti chiudono in 0,2 s contro 1,5 s su ARM, tutte
+corrette. Questo è anche l'unico dei tre run in cui il ramo di backpressure di
+H2-B è stato plausibilmente raggiunto (500 byte trasferiti integralmente a un
+client lento, contro i 12 eventi del run ARM che non arrivano alla capacità di
+256 del canale).
+
+**Quello che il controllo `--fit` non ha ancora dimostrato.** `--fit` con
+qwen3-4b ha risposto `model (2.33 GiB) fits fully in 14.65 GiB free VRAM`, e il
+modello ha poi servito una richiesta: il percorso funziona, ma **non discrimina
+H2-A**. L'errore di stima era per token e per layer, quindi diventa
+decision-changing solo quando la KV cache domina il budget, non quando i pesi
+sono il 16% della scheda: a `--ctx-size 32768` sia l'aritmetica corretta sia
+quella che sottostimava concludono "fits fully". Con 14,65 GiB liberi, `usable`
+≈ 13,6 GiB e 36 layer a `head_dim` 128, le due stime divergono in decisione
+sopra ~82k token di contesto, dove la corretta impone un offload parziale e la
+vecchia dichiarava un fit pieno che poi moriva in allocazione. Per questo
+`tools/smoke_test.py` ha ora `--fit-ctx` e dichiara esplicitamente nel report
+quando un "fits fully" non è una conferma. Il controllo va rifatto con
+`--fit-ctx 98304`; finché non è fatto, H2-A resta verificata solo dai test
+unitari, non su hardware.
+
 **Correzione a H0-B fatta prima della release.** Il controllo all'avvio era
 troppo aggressivo: rifiutava di partire ogni volta che la directory di audit non
 era scrivibile, quindi una home in sola lettura diventava un'interruzione di
@@ -353,8 +378,10 @@ esterni non si fidano dei valori che leggono.
   Emerso dallo smoke test su ARM (Radxa Orion O6, qwen3-0.6b, `think: false`,
   `temperature: 0`): il contenuto ricostruito dallo stream NDJSON è
   `"</think>\n\nCount: one two three"` — il tag di chiusura arriva al client come
-  testo dell'assistente. Lo stesso binario su x86 ha invece prodotto prosa di
-  reasoning: in entrambi i casi la soppressione non ha fatto quello che dichiara.
+  testo dell'assistente. **Riprodotto byte per byte su x86 con backend CUDA**
+  (RTX 5070 Ti, stesso modello, stesso prompt): identico. Quindi non dipende
+  dall'architettura né dal backend, ed è deterministico a `temperature: 0` —
+  che esclude una spiegazione basata sul sampling e punta al prompt.
   Due cause candidate, indipendenti, entrambe da verificare prima di toccare il
   codice:
   1. Il prefisso iniettato è `"<think>\n</think>\n\n"` (`chat_template.rs:89-94`),
@@ -371,9 +398,8 @@ esterni non si fidano dei valori che leggono.
      blocco `<think>…</think>` — o un tag di chiusura orfano — dal contenuto
      visibile. `process_piece` ha già il buffer di hold-back per le stop sequence
      (`inference/scheduler.rs`): è il posto dove filtrare, non a valle nel client.
-  Verificare con `--model qwen3-0.6b --no-inference` disattivato e
-  `temperature: 0` su entrambe le architetture: a temperatura zero il sintomo è
-  deterministico, quindi un before/after è misurabile senza ambiguità.
+  Il sintomo è già riproducibile con `tools/smoke_test.py` su qualunque box: a
+  temperatura zero un before/after è misurabile senza ambiguità.
 
 ---
 

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -30,6 +30,11 @@ Usage
     # under-size the KV cache and die out of VRAM)
     python3 tools/smoke_test.py --binary ./eullm --pull --fit-model qwen3-4b
 
+    # ...but a small model on a large card fits under *any* arithmetic, so that
+    # only proves the path runs. To make the check discriminating, raise the
+    # context until the KV cache — not the weights — is what fills the card:
+    python3 tools/smoke_test.py --binary ./eullm --fit-model qwen3-4b --fit-ctx 98304
+
     # Quick pass, no inference (config/validation checks only, seconds)
     python3 tools/smoke_test.py --binary ./eullm --no-inference
 
@@ -736,7 +741,9 @@ def check_backpressure(rep: Report, api: str, model: str) -> None:
     )
 
 
-def check_fit(rep: Report, binary: Path, model: str, env: dict, log_dir: Path) -> None:
+def check_fit(
+    rep: Report, binary: Path, model: str, env: dict, log_dir: Path, ctx: int
+) -> None:
     """`--fit` must size the offload without dying out of VRAM.
 
     CUDA-only by construction: on any other build VRAM cannot be probed, so the
@@ -745,11 +752,21 @@ def check_fit(rep: Report, binary: Path, model: str, env: dict, log_dir: Path) -
     under-estimates it on architectures that declare attention.key_length
     explicitly (qwen3-4b: 80 assumed vs 128 real), so --fit offloaded more layers
     than fit and the load died — the exact failure --fit exists to prevent.
+
+    Note on what a pass proves. When the weights alone are a small fraction of
+    free VRAM, both the correct and the under-estimating arithmetic conclude
+    "fits fully", so the check only proves the path runs — it does not
+    discriminate the fix. The under-estimate is a *per-token, per-layer* error,
+    so it only becomes decision-changing once the KV cache dominates the budget.
+    Raise ``--fit-ctx`` until the decision stops being "offloading all layers":
+    the first context that reports a partial offload is the one where the two
+    arithmetics disagree, and under the old one that same context would have
+    claimed a full fit and then died allocating it.
     """
     port = free_port()
     log = log_dir / "engine-fit.log"
     args = [
-        "run", model, "--fit", "--ctx-size", "32768",
+        "run", model, "--fit", "--ctx-size", str(ctx),
         "--port", str(port), "--no-ui", "--cli",
     ]
     with Engine(binary, args, env, log) as eng:
@@ -769,7 +786,22 @@ def check_fit(rep: Report, binary: Path, model: str, env: dict, log_dir: Path) -
         if "could not size the model" in decision:
             rep.add(f"--fit sizes {model}", None, decision + " (expected off CUDA)")
         else:
-            rep.add(f"--fit sizes {model}", True, decision)
+            # "offloading all layers" is the outcome both the correct and the old
+            # under-estimating arithmetic reach when the weights are small
+            # relative to the card — say so, rather than letting it read as
+            # confirmation of the fix.
+            full = "fits fully" in decision
+            rep.add(
+                f"--fit sizes {model}",
+                True,
+                decision + (
+                    f" — a full fit at ctx {ctx} is reached by the under-estimating "
+                    "arithmetic too, so this does not discriminate H2-A; raise "
+                    "--fit-ctx until a partial offload is reported" if full else
+                    f" — partial offload at ctx {ctx}: this is the regime where the "
+                    "KV sizing decides, and the old arithmetic claimed a full fit here"
+                ),
+            )
         code, body = post(
             f"http://127.0.0.1:{port}/api/chat",
             {
@@ -802,6 +834,10 @@ def main(argv: list[str] | None = None) -> int:
                     help="run `eullm pull <model>` first if it is not on disk")
     ap.add_argument("--fit-model", default=None, metavar="ID",
                     help="additionally exercise --fit with this model (CUDA boxes: try qwen3-4b)")
+    ap.add_argument("--fit-ctx", type=int, default=32768, metavar="N",
+                    help="context size for the --fit check (default 32768). Raise it "
+                         "until --fit reports a partial offload instead of all layers: "
+                         "that is the regime where the KV sizing actually decides")
     ap.add_argument("--no-inference", action="store_true",
                     help="config/validation checks only — no model needed")
     ap.add_argument("--concurrency", type=int, default=8, help="parallel requests (default 8)")
@@ -948,7 +984,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.pull:
             subprocess.run([str(binary), "pull", args.fit_model],
                            env={**os.environ, **env}, capture_output=True, timeout=7200)
-        check_fit(rep, binary, args.fit_model, env, work)
+        check_fit(rep, binary, args.fit_model, env, work, args.fit_ctx)
 
     return finish(rep, args, work, keep=args.keep_workdir)
 


### PR DESCRIPTION
The CUDA run reported "model (2.33 GiB) fits fully in 14.65 GiB free VRAM" and passed, which proves the path runs but proves nothing about the KV sizing fix: the old arithmetic under-estimated the cache per token per layer, so at a 32k context on a 16 GB card both the correct and the under-estimating arithmetic reach the same "offload everything" decision. The check only becomes discriminating once the cache, not the weights, is what fills the card.

The context used by the check is now --fit-ctx (default unchanged at 32768), and the reported detail states in which regime the run landed — a full fit is labelled as not discriminating rather than left to read as confirmation.

Also records the Linux CUDA run in the backlog (22 pass, 0 fail, the two skips being open items rather than regressions) and notes that H2-J reproduces byte for byte on x86 CUDA. Identical output on a different architecture and backend at temperature zero rules out a sampling explanation and points at the prompt.