### PR TITLE
fix: repair the multimodal build, and make CI compile the feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,20 @@ jobs:
         # RUSTC_WORKSPACE_WRAPPER would run clippy on their build scripts and
         # `-D warnings` would fail on upstream's pedantic/missing-docs findings.
         run: cargo clippy --no-deps -- -D warnings -A dead-code -A unused-imports
+      - name: Check the multimodal feature compiles
+        working-directory: engine
+        # The release CUDA jobs build with `--features "cuda,multimodal"`, and
+        # code behind `#[cfg(feature = "multimodal")]` is invisible to every
+        # step above. A refactor that changed a shared type therefore compiled
+        # clean here, went green on main, and then broke all three CUDA jobs at
+        # tag time — three long builds and a pulled release, for an error a
+        # `cargo check` would have caught in a minute.
+        #
+        # `check`, not `build`: type errors are the failure mode this guards,
+        # and the C++/CUDA side is not what changes underneath us. `cuda` is
+        # deliberately not checked here — it needs the CUDA toolkit, which is a
+        # multi-minute install on every push, and it shares this same Rust code.
+        run: cargo check --features multimodal
 
   # ── Hub ──────────────────────────────────────────────────────────────
   hub:

--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -755,7 +755,7 @@ perché ognuna di queste era un sospetto plausibile:
 garantisce ciò che dichiara; le dipendenze sono controllate per costruzione e non per
 diligenza manuale.
 
-- [ ] **H3-A · La CI deve compilare le feature che può compilare a costo basso** *(P1)*
+- [x] **H3-A · La CI deve compilare le feature che può compilare a costo basso** *(P1)*
   *Riformulata dopo aver misurato i costi reali: la CI gira solo su `push: [main]`,
   in ~7 minuti, su runner standard di un repo pubblico — quindi gratuiti. Il
   vincolo non sono i minuti ma il wall-clock, e le feature GPU richiedono il
@@ -771,6 +771,22 @@ diligenza manuale.
   imparato quanto costa scoprire un problema durante una release. Aggiungere un job
   `cargo check --features <x>` per ciascuna feature (economico: nessun link finale) e
   `cargo test --features multimodal` dove i test non richiedono GPU.
+
+  **Chiusa dal modo peggiore: rompendo una release.** Il refactor di `StopReason`
+  ha toccato `GenerateResult` e `StreamEvent::Done`, tipi usati anche da codice
+  dietro `#[cfg(feature = "multimodal")]`. Quel codice è invisibile a
+  `cargo build`, `cargo test` e `cargo clippy` senza la feature: tutto verde in
+  locale, tutto verde sulla CI di main, e poi **tre job CUDA falliti al tag**,
+  perché i build di release usano `--features "cuda,multimodal"`. Tre build
+  lunghi e una release da rifare per un errore che `cargo check` trovava in un
+  minuto.
+  Aggiunto `cargo check --features multimodal` al job engine. `check` e non
+  `build` perché il fallimento da prevenire è di tipi, non di link; e `cuda`
+  resta fuori di proposito — richiede il toolkit CUDA, minuti di installazione a
+  ogni push, e condivide lo stesso codice Rust che questo step già copre.
+  Nota per chi ci tornerà: `cargo clippy --features multimodal` segnala oggi due
+  lint preesistenti in `inference/mod.rs:867` e `:1578`, in codice mai passato
+  sotto lint. Vanno sistemati prima di poter alzare anche clippy alla feature.
 
 - [ ] **H3-B · Il mirror non deve poter sovrascrivere i tag** *(P1)*
   `mirror-sync.yml:9-11` dichiara che i tag sono immutabili e che ogni versione da cui si è

--- a/engine/src/api/routes.rs
+++ b/engine/src/api/routes.rs
@@ -844,13 +844,18 @@ async fn chat(
             ));
         }
         let rx = multimodal_to_channel(engine, mm_request, media);
-        let (text, tokens_generated, tokens_prompt, duration_ms) =
-            collect_stream(rx).await.map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({ "error": e })),
-                )
-            })?;
+        let Collected {
+            text,
+            tokens_generated,
+            tokens_prompt,
+            duration_ms,
+            stop_reason,
+        } = collect_stream(rx).await.map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e })),
+            )
+        })?;
         let mut audit = AuditEntry::new(model.clone(), "chat".to_string());
         audit.input_tokens = tokens_prompt;
         audit.output_tokens = tokens_generated;
@@ -862,7 +867,7 @@ async fn chat(
             "created_at": chrono::Utc::now().to_rfc3339(),
             "message": { "role": "assistant", "content": text },
             "done": true,
-            "done_reason": reason,
+            "done_reason": stop_reason.as_api_str(),
             "total_duration": duration_ms * 1_000_000,
             "load_duration": 0,
             "prompt_eval_count": tokens_prompt,

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -3255,6 +3255,8 @@ async fn run_multimodal_oneshot(engine: Arc<InferenceEngine>, image_path: PathBu
                 tokens_generated,
                 tokens_prompt,
                 duration_ms,
+                // The one-shot multimodal probe prints no stop reason.
+                stop_reason: _,
             } => {
                 let _ = writeln!(stdout);
                 let _ = writeln!(


### PR DESCRIPTION
The StopReason refactor changed GenerateResult and StreamEvent::Done, which are also used by code behind #[cfg(feature = "multimodal")]. That code is invisible to cargo build, cargo test and cargo clippy without the feature, so everything was green locally and on main, and then all three CUDA jobs failed at tag time — the release builds use --features "cuda,multimodal". Three long builds and a pulled release for three type errors that cargo check finds in a minute.

Fixes the three sites: the multimodal non-streaming path destructures Collected, its response body uses the real stop reason instead of a name that only exists inside format_done_event, and the one-shot probe's Done arm matches the new field. Verified with cargo check --features multimodal, which now also runs in CI on the engine job.

check rather than build, because the failure this guards is in the types and not the C++ link step. cuda stays out on purpose: it needs the CUDA toolkit, which is minutes of install on every push, and it shares the same Rust code this step already covers.

Closes the open backlog item asking for exactly this, in the least pleasant way available — by breaking a release first.