### PR TITLE
fix(engine): one decode output path instead of three

### DIFF
--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -461,7 +461,7 @@ esterni non si fidano dei valori che leggono.
   produce output plausibile. Contare esplicitamente le sequenze effettivamente aggiunte e
   derivare `logit_idx` da quel conteggio, oppure abortire l'iterazione.
 
-- [ ] **H2-D · Unificare stop sequence e filtri tra i due percorsi di inferenza** *(P1)*
+- [x] **H2-D · Unificare stop sequence e filtri tra i due percorsi di inferenza** *(P1)*
   L'hold-back buffer e i `filter_sequences` esistono solo nello scheduler
   (`process_piece`, `scheduler.rs:1588-1628`). Il percorso sequenziale e quello multimodale
   (`inference/mod.rs:1047-1085, 1357-1387`) confrontano `full_output.ends_with(s)` per
@@ -470,6 +470,50 @@ esterni non si fidano dei valori che leggono.
   filtri esistono per rimuovere restano visibili all'utente in modalità multimodale.
   Estrarre `process_piece` in un helper condiviso e usarlo in tutti e tre i loop di decode.
   Sinergia con H2-E: entrambe le voci sono conseguenze della stessa duplicazione.
+
+  **Chiusa.** `inference/output.rs` contiene ora l'unica implementazione, che è
+  quella dello scheduler spostata **senza modifiche di comportamento** — il
+  codice già collaudato in produzione, non una riscrittura. I tre loop la
+  chiamano: scheduler, motore sequenziale (non streaming e streaming) e
+  multimodale.
+
+  Scrivendo i test è emerso che i difetti erano tre e non uno, e il terzo era
+  peggiore di come l'avevamo descritto:
+  1. **Una stop sequence che non finisce il pezzo veniva ignorata.** Un pezzo
+     `"<|im_end|>\n"` lascia l'output accumulato che finisce con `"\n"`, quindi
+     `ends_with` non vedeva niente e la generazione proseguiva oltre il turno.
+  2. **A cavallo di due token trapelava la prima metà.** I percorsi in streaming
+     ritagliavano il marcatore dal pezzo *corrente*, ma il pezzo precedente coi
+     primi byte era già partito verso il client e non si richiama indietro.
+  3. **Quel ritaglio era un indice di byte su una stringa UTF-8**
+     (`&piece[..piece.len() - s.len()]`): con un carattere multibyte a cavallo
+     del taglio non sbagliava, **andava in panic**. Non c'era nel testo della
+     voce; è saltato fuori scrivendo il test sui multibyte.
+
+  Più il difetto già noto: `filter_sequences` non era applicato fuori dallo
+  scheduler, quindi in multimodale gli artefatti `<|channel|>` andavano
+  all'utente così com'erano.
+
+  Aggiunto anche `flush()`, che rende esplicita una distinzione che prima era
+  implicita e sbagliata negli altri due loop: su **EOG** la coda trattenuta è un
+  delimitatore di turno parziale e si butta; a **budget esaurito** è testo vero
+  e buttarla tronca la risposta. Lo scheduler la emetteva già; gli altri due la
+  perdevano in silenzio.
+
+  Verifica: 9 test nuovi che coprono i tre difetti uno per uno (184 totali),
+  `--all-targets` con e senza `multimodal`, e smoke test sul binario in release
+  su entrambi i percorsi, scheduler e `--batch-size 0`, 32 pass e 0 fail.
+  Nota di metodo: `cargo check` da solo **non compila i test** e mi ha lasciato
+  passare un import rotto nel modulo di test dello scheduler. Va usato
+  `cargo check --all-targets`.
+
+  **Quello che non è dentro**, per non farlo sembrare più completo di quanto è:
+  H2-E (la catena di sampling, ancora duplicata in quattro punti) e il punto 2
+  di H2-J (la guardia sul tag `</think>` orfano). Quest'ultimo ora avrebbe un
+  posto solo dove stare, ma non è un filtro incondizionato: `</think>` è
+  legittimo quando `think: true`, quindi va aggiunto ai `filter_sequences`
+  della singola richiesta quando `think` è falso. È una decisione lato
+  chiamante, non lato `process_piece`, e merita il suo cambio.
 
 - [ ] **H2-E · Estrarre la costruzione della catena di sampling** *(P2)*
   La catena è duplicata in quattro punti (`scheduler.rs:929-966`;

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -8,6 +8,7 @@
 //!   decoded in parallel on a single context. Good for API server / RAG
 //!   workloads with many parallel requests.
 
+pub(crate) mod output;
 pub mod scheduler;
 
 use std::num::NonZeroU32;
@@ -1125,6 +1126,10 @@ impl InferenceEngine {
 
         let mut decoder = encoding_rs::UTF_8.new_decoder();
         let mut output = String::new();
+        // Trailing text that could still grow into a stop or filter sequence.
+        // Dropped on EOG (it is a partial turn delimiter), flushed into
+        // `output` when the token budget ends the loop (it is real text).
+        let mut pending = String::new();
         let mut n_cur = tokens_prompt as i32;
         let mut tokens_generated: u32 = 0;
         let mut batch = LlamaBatch::new(1, 1);
@@ -1159,25 +1164,24 @@ impl InferenceEngine {
                 break;
             }
 
-            // Decode token to text
+            // Decode token to text. Stop sequences and filters go through the
+            // shared hold-back logic in `output`, the same code the scheduler
+            // runs — see that module for the three ways the old per-loop
+            // `output.ends_with(stop)` check was wrong.
             match self.model.token_to_piece(token, &mut decoder, true, None) {
-                Ok(piece) => {
-                    output.push_str(&piece);
-
-                    // Check stop sequences
-                    let should_stop = request.stop_sequences.iter().any(|s| output.ends_with(s));
-                    if should_stop {
-                        // Remove the stop sequence from output
-                        for s in &request.stop_sequences {
-                            if output.ends_with(s) {
-                                let new_len = output.len() - s.len();
-                                output.truncate(new_len);
-                                break;
-                            }
-                        }
+                Ok(piece) => match output::process_piece(
+                    &mut pending,
+                    &request.stop_sequences,
+                    &request.filter_sequences,
+                    &piece,
+                ) {
+                    output::PieceOutcome::Emit(text) => output.push_str(&text),
+                    output::PieceOutcome::Stop(text) => {
+                        output.push_str(&text);
+                        stop_reason = StopReason::Stop;
                         break;
                     }
-                }
+                },
                 Err(_) => break,
             }
 
@@ -1190,6 +1194,12 @@ impl InferenceEngine {
 
             n_cur += 1;
             tokens_generated += 1;
+        }
+
+        // The loop ran out of budget rather than hitting a marker: whatever is
+        // held back is ordinary text, and dropping it would truncate the answer.
+        if matches!(stop_reason, StopReason::Length) {
+            output.push_str(&output::flush(&mut pending));
         }
 
         let duration_ms = start.elapsed().as_millis() as u64;
@@ -1363,6 +1373,9 @@ impl InferenceEngine {
 
         let mut decoder = encoding_rs::UTF_8.new_decoder();
         let mut full_output = String::new();
+        // See the non-streaming path: held-back tail, dropped on EOG, flushed
+        // to the client when the token budget is what ended the loop.
+        let mut pending = String::new();
         let mut n_cur = tokens_prompt as i32;
         let mut tokens_generated: u32 = 0;
         let mut batch = LlamaBatch::new(1, 1);
@@ -1392,42 +1405,37 @@ impl InferenceEngine {
                 break;
             }
 
+            // Streaming cannot retract what it has already sent, so stop and
+            // filter sequences run through the shared hold-back buffer rather
+            // than being cut out of the current piece after the fact. The old
+            // code sliced `&piece[..piece.len() - s.len()]`, which sent the
+            // first half of a marker split across two tokens and panicked
+            // outright when the byte index landed inside a character.
             match self.model.token_to_piece(token, &mut decoder, true, None) {
                 Ok(piece) => {
                     full_output.push_str(&piece);
-
-                    // Check stop sequences
-                    let mut stopped = false;
-                    for s in &request.stop_sequences {
-                        if full_output.ends_with(s) {
-                            // Don't send the stop sequence token
-                            let piece_without_stop = if piece.len() >= s.len() {
-                                &piece[..piece.len() - s.len()]
-                            } else {
-                                ""
-                            };
-                            if !piece_without_stop.is_empty()
-                                && tx
-                                    .blocking_send(StreamEvent::Token(
-                                        piece_without_stop.to_string(),
-                                    ))
-                                    .is_err()
+                    match output::process_piece(
+                        &mut pending,
+                        &request.stop_sequences,
+                        &request.filter_sequences,
+                        &piece,
+                    ) {
+                        output::PieceOutcome::Stop(text) => {
+                            if !text.is_empty()
+                                && tx.blocking_send(StreamEvent::Token(text)).is_err()
                             {
                                 return;
                             }
-                            stopped = true;
+                            stop_reason = StopReason::Stop;
                             break;
                         }
-                    }
-
-                    if stopped {
-                        stop_reason = StopReason::Stop;
-                        break;
-                    }
-
-                    // Send the token piece
-                    if tx.blocking_send(StreamEvent::Token(piece)).is_err() {
-                        return; // receiver dropped
+                        output::PieceOutcome::Emit(text) => {
+                            if !text.is_empty()
+                                && tx.blocking_send(StreamEvent::Token(text)).is_err()
+                            {
+                                return; // receiver dropped
+                            }
+                        }
                     }
                 }
                 Err(_) => break,
@@ -1447,6 +1455,15 @@ impl InferenceEngine {
 
             n_cur += 1;
             tokens_generated += 1;
+        }
+
+        // Budget-exhausted end: the held-back tail is real text the client is
+        // still owed. On EOG or a stop it is a partial marker and is dropped.
+        if matches!(stop_reason, StopReason::Length) {
+            let tail = output::flush(&mut pending);
+            if !tail.is_empty() && tx.blocking_send(StreamEvent::Token(tail)).is_err() {
+                return;
+            }
         }
 
         let duration_ms = start.elapsed().as_millis() as u64;
@@ -1693,6 +1710,9 @@ impl InferenceEngine {
         // ── 7. Decode loop (identical pattern to generate_streaming) ────
         let mut decoder = encoding_rs::UTF_8.new_decoder();
         let mut full_output = String::new();
+        // See the non-streaming path: held-back tail, dropped on EOG, flushed
+        // to the client when the token budget is what ended the loop.
+        let mut pending = String::new();
         let mut n_cur = new_n_past;
         let mut tokens_generated: u32 = 0;
         let mut batch = LlamaBatch::new(1, 1);
@@ -1724,31 +1744,33 @@ impl InferenceEngine {
             match self.model.token_to_piece(token, &mut decoder, true, None) {
                 Ok(piece) => {
                     full_output.push_str(&piece);
-                    let mut stopped = false;
-                    for s in &request.stop_sequences {
-                        if full_output.ends_with(s) {
-                            let trimmed = if piece.len() >= s.len() {
-                                &piece[..piece.len() - s.len()]
-                            } else {
-                                ""
-                            };
-                            if !trimmed.is_empty()
-                                && tx
-                                    .blocking_send(StreamEvent::Token(trimmed.to_string()))
-                                    .is_err()
+                    // Same shared path as the two text loops. This one also
+                    // gains `filter_sequences`, which it never applied at all:
+                    // DEFAULT_HARMONY_FILTERS exists to strip `<|channel|>`
+                    // scaffolding, and on the multimodal path that scaffolding
+                    // was going straight to the user.
+                    match output::process_piece(
+                        &mut pending,
+                        &request.stop_sequences,
+                        &request.filter_sequences,
+                        &piece,
+                    ) {
+                        output::PieceOutcome::Stop(text) => {
+                            if !text.is_empty()
+                                && tx.blocking_send(StreamEvent::Token(text)).is_err()
                             {
                                 return;
                             }
-                            stopped = true;
+                            stop_reason = StopReason::Stop;
                             break;
                         }
-                    }
-                    if stopped {
-                        stop_reason = StopReason::Stop;
-                        break;
-                    }
-                    if tx.blocking_send(StreamEvent::Token(piece)).is_err() {
-                        return;
+                        output::PieceOutcome::Emit(text) => {
+                            if !text.is_empty()
+                                && tx.blocking_send(StreamEvent::Token(text)).is_err()
+                            {
+                                return;
+                            }
+                        }
                     }
                 }
                 Err(_) => break,
@@ -1766,6 +1788,15 @@ impl InferenceEngine {
             }
             n_cur += 1;
             tokens_generated += 1;
+        }
+
+        // Budget-exhausted end: hand over the held-back tail (see the text
+        // streaming path for why EOG and stop cases drop it instead).
+        if matches!(stop_reason, StopReason::Length) {
+            let tail = output::flush(&mut pending);
+            if !tail.is_empty() && tx.blocking_send(StreamEvent::Token(tail)).is_err() {
+                return;
+            }
         }
 
         let duration_ms = start.elapsed().as_millis() as u64;

--- a/engine/src/inference/output.rs
+++ b/engine/src/inference/output.rs
@@ -1,0 +1,250 @@
+//! The single implementation of "what is safe to hand to the client".
+//!
+//! Three decode loops produce text: the scheduler's (continuous batching), the
+//! sequential engine's (`--batch-size 0`), and the multimodal one. Until
+//! v0.6.40 only the scheduler ran the logic in this module; the other two
+//! compared `full_output.ends_with(stop)` once per token, which fails in three
+//! distinct ways:
+//!
+//! 1. **A stop sequence that does not land at the end is missed.** A piece of
+//!    `"<|im_end|>\n"` leaves the accumulated output ending in `"\n"`, so the
+//!    marker is never seen and generation runs on past the turn boundary.
+//! 2. **A stop sequence split across two tokens leaks its first half.** The
+//!    streaming paths cut the marker out of the *current* piece
+//!    (`&piece[..piece.len() - stop.len()]`), but the earlier piece carrying
+//!    the first bytes has already been sent and cannot be recalled.
+//! 3. **That same slice is a byte index into a UTF-8 string**, so when the cut
+//!    lands inside a multi-byte character it panics rather than misbehaves.
+//!
+//! On top of which `filter_sequences` (the `DEFAULT_HARMONY_FILTERS` that exist
+//! to strip `<|channel|>`-style scaffolding) were never applied outside the
+//! scheduler at all, so the multimodal path showed them to the user verbatim.
+//!
+//! The fix is not better checks in three places, it is one place. This module
+//! holds the logic the scheduler had already proven in production; the other
+//! two loops now call it instead of carrying their own version. Anything added
+//! here — a new filter, a new hold-back rule — reaches all three by
+//! construction, which is the property the old arrangement lacked.
+
+/// Outcome of feeding one decoded piece through the stop-sequence filter.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PieceOutcome {
+    /// Safe-to-stream text (may be empty); generation continues.
+    Emit(String),
+    /// A full stop sequence was hit. The contained text is whatever preceded
+    /// the stop marker and should be streamed before finishing.
+    Stop(String),
+}
+
+/// Length (in bytes) of the longest suffix of `buf` that is a *proper* prefix
+/// of any stop sequence. This is the amount of trailing text that must be held
+/// back: it could still grow into a full stop sequence on the next token.
+///
+/// A full match is handled by the caller (via `find`) before this is consulted,
+/// so we never report the entire stop sequence here.
+pub(crate) fn stop_prefix_holdback(buf: &str, stops: &[String]) -> usize {
+    let mut max = 0;
+    for s in stops {
+        if s.is_empty() {
+            continue;
+        }
+        // Try the longest possible overlap first; the suffix of `buf` must be a
+        // prefix of `s` and strictly shorter than `s` (full matches handled elsewhere).
+        let upper = buf.len().min(s.len().saturating_sub(1));
+        let mut k = upper;
+        while k >= 1 {
+            let start = buf.len() - k;
+            if buf.is_char_boundary(start) && s.as_bytes().starts_with(&buf.as_bytes()[start..]) {
+                if k > max {
+                    max = k;
+                }
+                break;
+            }
+            k -= 1;
+        }
+    }
+    max
+}
+
+/// Feed one decoded `piece` into the per-sequence `pending` hold-back buffer and
+/// decide what is safe to stream.
+///
+/// - If appending the piece completes a stop sequence, everything up to the
+///   stop marker is returned as `Stop(..)` and `pending` is cleared.
+/// - Otherwise the longest trailing run that could still become a stop sequence
+///   is retained in `pending`, and the rest is returned as `Emit(..)`.
+///
+/// This makes streaming robust against models that spell a turn delimiter out
+/// as ordinary text and only then emit an EOG token (e.g. Gemma emitting
+/// `<end_of_turn` + EOG): the partial delimiter sits in `pending` and is
+/// discarded when the caller observes EOG, instead of leaking to the client.
+pub(crate) fn process_piece(
+    pending: &mut String,
+    stops: &[String],
+    filters: &[String],
+    piece: &str,
+) -> PieceOutcome {
+    pending.push_str(piece);
+
+    // 1. Stop sequences win: terminate generation at the earliest hit.
+    let mut cut: Option<usize> = None;
+    for s in stops {
+        if let Some(pos) = pending.find(s.as_str()) {
+            cut = Some(cut.map_or(pos, |c| c.min(pos)));
+        }
+    }
+    if let Some(pos) = cut {
+        let out = pending[..pos].to_string();
+        pending.clear();
+        return PieceOutcome::Stop(out);
+    }
+
+    // 2. Filter sequences: silently elide every completed occurrence, then
+    // continue. Unlike stops, these do not terminate the response.
+    for f in filters {
+        if f.is_empty() {
+            continue;
+        }
+        while let Some(pos) = pending.find(f.as_str()) {
+            pending.replace_range(pos..pos + f.len(), "");
+        }
+    }
+
+    // 3. Hold back any trailing run that could still complete EITHER a stop
+    // or a filter sequence. Reuses `stop_prefix_holdback` for both — it just
+    // looks at suffix→prefix overlaps and is agnostic to the list's meaning.
+    let holdback = stop_prefix_holdback(pending, stops).max(stop_prefix_holdback(pending, filters));
+    let emit_upto = pending.len() - holdback;
+    let out = pending[..emit_upto].to_string();
+    pending.drain(..emit_upto);
+    PieceOutcome::Emit(out)
+}
+
+/// Take whatever is still held back, for a generation that ended without a stop
+/// sequence (token budget exhausted, or an EOG token).
+///
+/// The distinction the caller must make: on **EOG** the tail is a partial turn
+/// delimiter the model was in the middle of spelling out, and it is dropped.
+/// On a **budget** end the tail is ordinary text that simply never grew into a
+/// marker, and dropping it would truncate the answer — the scheduler has always
+/// emitted it (`std::mem::take(&mut seq.pending)`), and the other loops now do
+/// the same instead of silently losing those bytes.
+pub(crate) fn flush(pending: &mut String) -> String {
+    std::mem::take(pending)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(stops: &[&str], filters: &[&str], pieces: &[&str]) -> (String, bool) {
+        let stops: Vec<String> = stops.iter().map(|s| s.to_string()).collect();
+        let filters: Vec<String> = filters.iter().map(|s| s.to_string()).collect();
+        let mut pending = String::new();
+        let mut out = String::new();
+        for p in pieces {
+            match process_piece(&mut pending, &stops, &filters, p) {
+                PieceOutcome::Emit(s) => out.push_str(&s),
+                PieceOutcome::Stop(s) => {
+                    out.push_str(&s);
+                    return (out, true);
+                }
+            }
+        }
+        (out, false)
+    }
+
+    // Defect 1 of the old per-loop check: `output.ends_with(stop)` only sees a
+    // marker that finishes the piece. Here the model emits the delimiter and a
+    // newline in one token, and the old code ran straight past the turn end.
+    #[test]
+    fn a_stop_sequence_not_at_the_end_of_a_piece_still_stops() {
+        let (out, stopped) = run(&["<|im_end|>"], &[], &["Rome", "<|im_end|>\nUser: "]);
+        assert!(stopped, "the marker was inside the piece, not at its end");
+        assert_eq!(out, "Rome");
+    }
+
+    // Defect 2: split across two tokens. The old streaming paths had already
+    // sent the first half before noticing.
+    #[test]
+    fn a_stop_sequence_split_across_tokens_never_reaches_the_client() {
+        let (out, stopped) = run(&["<|im_end|>"], &[], &["Rome", "<|im_", "end|>"]);
+        assert!(stopped);
+        assert_eq!(out, "Rome", "no fragment of the marker may be emitted");
+    }
+
+    // Defect 3: the old cut was a byte slice, so a stop landing mid-character
+    // panicked. Multi-byte text either side of the marker must be safe.
+    #[test]
+    fn multibyte_text_around_a_stop_does_not_panic_and_is_not_cut() {
+        let (out, stopped) = run(&["<|im_end|>"], &[], &["Perché", " è così", "<|im_end|>"]);
+        assert!(stopped);
+        assert_eq!(out, "Perché è così");
+    }
+
+    #[test]
+    fn a_multibyte_character_split_across_pieces_survives() {
+        // "è" is 0xC3 0xA8; a decoder can hand the two halves over separately
+        // only as complete pieces, but the hold-back arithmetic must still land
+        // on character boundaries when the marker shares a first byte.
+        let (out, stopped) = run(&["<|im_end|>"], &[], &["è", "à", "ù"]);
+        assert!(!stopped);
+        assert_eq!(out, "èàù");
+    }
+
+    // Filters were absent outside the scheduler, so this scaffolding reached
+    // the user verbatim on the multimodal path.
+    #[test]
+    fn filter_sequences_are_elided_without_stopping() {
+        let (out, stopped) = run(
+            &["<|im_end|>"],
+            &["<|channel|>analysis"],
+            &["Answer: ", "<|channel|>analysis", "42"],
+        );
+        assert!(!stopped);
+        assert_eq!(out, "Answer: 42");
+    }
+
+    #[test]
+    fn a_filter_split_across_tokens_is_still_elided() {
+        let (out, _) = run(
+            &["<|im_end|>"],
+            &["<|channel|>"],
+            &["a", "<|chan", "nel|>", "b"],
+        );
+        assert_eq!(out, "ab");
+    }
+
+    // The hold-back must not swallow text that merely starts like a marker.
+    #[test]
+    fn text_that_only_resembles_a_marker_is_released() {
+        let (out, stopped) = run(&["<|im_end|>"], &[], &["a<|im", "possible"]);
+        assert!(!stopped);
+        assert_eq!(out, "a<|impossible");
+    }
+
+    #[test]
+    fn the_tail_is_recoverable_when_generation_ends_without_a_stop() {
+        let stops = vec!["<end_of_turn>".to_string()];
+        let mut pending = String::new();
+        let mut out = String::new();
+        for p in ["Rome", "<end_of_turn"] {
+            if let PieceOutcome::Emit(s) = process_piece(&mut pending, &stops, &[], p) {
+                out.push_str(&s);
+            }
+        }
+        // Held back because it could still become the marker.
+        assert_eq!(out, "Rome");
+        assert_eq!(pending, "<end_of_turn");
+        // A caller ending on the token budget takes it; one seeing EOG drops it.
+        assert_eq!(flush(&mut pending), "<end_of_turn");
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn an_empty_stop_list_emits_everything_immediately() {
+        let (out, stopped) = run(&[], &[], &["a", "b", "c"]);
+        assert!(!stopped);
+        assert_eq!(out, "abc");
+    }
+}

--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -27,6 +27,7 @@ use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
 use tokio::sync::mpsc;
 
+use super::output::{PieceOutcome, process_piece};
 use super::{GenerateRequest, InferenceConfig, StopReason, StreamEvent, random_seed_fallback};
 
 /// Below this many tokens per slot, a reasoning model routinely runs out of
@@ -1687,99 +1688,6 @@ fn prefill_sequence(
     Ok((n_tokens, tokens.len() as i32, effective_max_tokens))
 }
 
-/// Outcome of feeding one decoded piece through the stop-sequence filter.
-enum PieceOutcome {
-    /// Safe-to-stream text (may be empty); generation continues.
-    Emit(String),
-    /// A full stop sequence was hit. The contained text is whatever preceded
-    /// the stop marker and should be streamed before finishing.
-    Stop(String),
-}
-
-/// Length (in bytes) of the longest suffix of `buf` that is a *proper* prefix
-/// of any stop sequence. This is the amount of trailing text that must be held
-/// back: it could still grow into a full stop sequence on the next token.
-///
-/// A full match is handled by the caller (via `find`) before this is consulted,
-/// so we never report the entire stop sequence here.
-fn stop_prefix_holdback(buf: &str, stops: &[String]) -> usize {
-    let mut max = 0;
-    for s in stops {
-        if s.is_empty() {
-            continue;
-        }
-        // Try the longest possible overlap first; the suffix of `buf` must be a
-        // prefix of `s` and strictly shorter than `s` (full matches handled elsewhere).
-        let upper = buf.len().min(s.len().saturating_sub(1));
-        let mut k = upper;
-        while k >= 1 {
-            let start = buf.len() - k;
-            if buf.is_char_boundary(start) && s.as_bytes().starts_with(&buf.as_bytes()[start..]) {
-                if k > max {
-                    max = k;
-                }
-                break;
-            }
-            k -= 1;
-        }
-    }
-    max
-}
-
-/// Feed one decoded `piece` into the per-sequence `pending` hold-back buffer and
-/// decide what is safe to stream.
-///
-/// - If appending the piece completes a stop sequence, everything up to the
-///   stop marker is returned as `Stop(..)` and `pending` is cleared.
-/// - Otherwise the longest trailing run that could still become a stop sequence
-///   is retained in `pending`, and the rest is returned as `Emit(..)`.
-///
-/// This makes streaming robust against models that spell a turn delimiter out
-/// as ordinary text and only then emit an EOG token (e.g. Gemma emitting
-/// `<end_of_turn` + EOG): the partial delimiter sits in `pending` and is
-/// discarded when the caller observes EOG, instead of leaking to the client.
-fn process_piece(
-    pending: &mut String,
-    stops: &[String],
-    filters: &[String],
-    piece: &str,
-) -> PieceOutcome {
-    pending.push_str(piece);
-
-    // 1. Stop sequences win: terminate generation at the earliest hit.
-    let mut cut: Option<usize> = None;
-    for s in stops {
-        if let Some(pos) = pending.find(s.as_str()) {
-            cut = Some(cut.map_or(pos, |c| c.min(pos)));
-        }
-    }
-    if let Some(pos) = cut {
-        let out = pending[..pos].to_string();
-        pending.clear();
-        return PieceOutcome::Stop(out);
-    }
-
-    // 2. Filter sequences: silently elide every completed occurrence, then
-    // continue. Unlike stops, these do not terminate the response.
-    for f in filters {
-        if f.is_empty() {
-            continue;
-        }
-        while let Some(pos) = pending.find(f.as_str()) {
-            pending.replace_range(pos..pos + f.len(), "");
-        }
-    }
-
-    // 3. Hold back any trailing run that could still complete EITHER a stop
-    // or a filter sequence. Reuses `stop_prefix_holdback` for both — it just
-    // looks at suffix→prefix overlaps and is agnostic to the list's meaning.
-    let holdback = stop_prefix_holdback(pending, stops).max(stop_prefix_holdback(pending, filters));
-    let emit_upto = pending.len() - holdback;
-    let out = pending[..emit_upto].to_string();
-    pending.drain(..emit_upto);
-    PieceOutcome::Emit(out)
-}
-
 /// Bytes per element for a KV cache type (approximate for quantized types).
 /// Thin alias over the shared helper so existing call sites stay unchanged.
 fn cache_type_bytes_per_elem(ct: &super::KvCacheType) -> f64 {
@@ -2053,10 +1961,10 @@ fn warn_if_logits_corrupt(ctx: &LlamaContext, idx: i32, seq_id: i32) {
 
 #[cfg(test)]
 mod tests {
+    use super::super::output::stop_prefix_holdback;
     use super::{
         CachedSlot, PieceOutcome, PromptCheckpoint, SendOutcome, StreamEvent, best_checkpoint,
-        common_prefix_len, pick_slot, process_piece, stop_prefix_holdback, text_prefix_match,
-        try_send_piece,
+        common_prefix_len, pick_slot, process_piece, text_prefix_match, try_send_piece,
     };
     use llama_cpp_2::token::LlamaToken;
     use std::time::{Duration, Instant};


### PR DESCRIPTION
The hold-back buffer and filter_sequences lived only in the scheduler. The sequential and multimodal loops compared full_output.ends_with(stop) once per token, which is wrong in three ways, the third worse than the backlog entry claimed:

1. A stop sequence that does not end the piece was missed entirely. A piece of "<|im_end|>\n" leaves the output ending in a newline, so the marker was never seen and generation ran past the turn boundary.
2. A marker split across two tokens leaked its first half: the streaming loops cut it out of the current piece, but the earlier piece was already sent.
3. That cut was a byte index into a UTF-8 string, so a multi-byte character straddling it panicked rather than misbehaved. This was not in the backlog text; it surfaced while writing the multibyte test.

filter_sequences were also not applied outside the scheduler at all, so DEFAULT_HARMONY_FILTERS did nothing on the multimodal path and the <|channel|> scaffolding reached the user verbatim.

inference/output.rs now holds the single implementation. It is the scheduler's code moved unchanged, not a rewrite, so the path with production mileage is the one everything runs. flush() makes explicit a distinction the other loops had silently wrong: on EOG the held-back tail is a partial delimiter and is dropped, on an exhausted token budget it is real text and dropping it truncates the answer.

Verified with 9 tests covering each defect (184 total), --all-targets with and without the multimodal feature, and the release-binary smoke test on both the scheduler and --batch-size 0 paths, 32 pass 0 fail.

Not included, deliberately: H2-E (the sampler chain, still duplicated in four places) and H2-J's orphan </think> guard, which belongs in the per-request filter list when think is false rather than in process_piece, since the tag is legitimate when think is true.