### PR TITLE
fix(engine): one sampler chain instead of four

### DIFF
--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -515,12 +515,43 @@ esterni non si fidano dei valori che leggono.
   della singola richiesta quando `think` è falso. È una decisione lato
   chiamante, non lato `process_piece`, e merita il suo cambio.
 
-- [ ] **H2-E · Estrarre la costruzione della catena di sampling** *(P2)*
+- [x] **H2-E · Estrarre la costruzione della catena di sampling** *(P2)*
   La catena è duplicata in quattro punti (`scheduler.rs:929-966`;
   `inference/mod.rs:781-812, 1000-1031, 1313-1341`) e la divergenza è già iniziata: il
   fallback del seed differisce (`seq_id` contro `1234` hardcoded) e i filtri sono assenti in
   tre copie su quattro. Ogni nuovo sampler andrà aggiunto quattro volte. Estrarre
   `fn build_sampler(&LlamaModel, &GenerateRequest, seed) -> LlamaSampler`.
+
+  **Chiusa.** `inference/sampling.rs` contiene `build_sampler`, e le quattro
+  copie sono sparite. Le due divergenze previste dalla voce c'erano entrambe,
+  ed erano di gravità diversa:
+  - il **fallback del seed**: `seq_id` nello scheduler, `1234` fisso nei tre
+    percorsi sequenziali. Conta solo se l'orologio di sistema precede l'epoca
+    Unix, quindi niente di visibile — sono due risposte a una domanda sola, che
+    è il modo in cui cominciano le divergenze che poi contano. Ora il chiamante
+    passa il proprio, e lo scheduler passa lo slot: due richieste concorrenti
+    senza seed non possono collassare sulla stessa sequenza nemmeno in quel caso.
+  - la **copia multimodale ingoiava gli errori di grammatica**: `if let Ok(gs)`
+    senza `else`, mentre le altre tre loggano «Grammar sampler init failed».
+    Una richiesta con `format: "json"` la cui grammatica non compilava tornava
+    testo libero **senza una riga da nessuna parte**. Questo è un difetto vero,
+    non solo duplicazione.
+
+  L'ordine della catena è ora documentato come contratto e non come stile:
+  grammatica → penalties → top-k → top-p → min-p → temperatura → dist. La
+  grammatica deve vedere la distribuzione intera prima che qualcuno la tronchi,
+  e `dist` deve restare ultimo perché è ciò che estrae davvero il token.
+
+  Verifica sul binario, non solo unit test: **stesso seed due volte → risposta
+  identica**, **senza seed → risposte diverse** a temperatura 1.4. È il
+  controllo discriminante per una modifica al sampling, perché passa solo se il
+  seed viene davvero usato e davvero variato. Più smoke test 32 pass / 0 fail,
+  186 test, clippy, fmt, `--all-targets` con e senza `multimodal`.
+
+  Nota di metodo, seconda volta oggi: `cmd | tail; echo $?` legge lo stato di
+  `tail`, non di `cmd`. Mi ha nascosto un fallimento di clippy
+  (`field_reassign_with_default` in un test nuovo) che avevo già dichiarato
+  verde. Con le pipe serve `PIPESTATUS` o `set -o pipefail`.
 
 - [ ] **H2-F · Irrobustire il patcher GGUF** *(P2)*
   A differenza del parser di `fit.rs`, che è bounds-checked con rigore,

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -9,6 +9,7 @@
 //!   workloads with many parallel requests.
 
 pub(crate) mod output;
+pub(crate) mod sampling;
 pub mod scheduler;
 
 use std::num::NonZeroU32;
@@ -22,7 +23,6 @@ use llama_cpp_2::llama_backend::LlamaBackend;
 use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::{AddBos, LlamaModel};
-use llama_cpp_2::sampling::LlamaSampler;
 use parking_lot::Mutex;
 use tokio::sync::mpsc;
 
@@ -1091,38 +1091,7 @@ impl InferenceEngine {
         // Sample tokens — use a small batch (capacity 1) for the decode loop.
         // When a grammar is requested (e.g. format:"json"), we prepend a
         // grammar sampler that constrains the output to valid syntax.
-        let mut sampler = {
-            let seed = request.seed.unwrap_or_else(|| random_seed_fallback(1234));
-            let mut chain: Vec<LlamaSampler> = Vec::new();
-            if let Some(ref grammar_str) = request.grammar {
-                match LlamaSampler::grammar(&self.model, grammar_str, "root") {
-                    Ok(gs) => chain.push(gs),
-                    Err(e) => tracing::warn!(
-                        "Grammar sampler init failed ({e:?}), falling back to unconstrained"
-                    ),
-                }
-            }
-            if request.repeat_penalty != 1.0 {
-                chain.push(LlamaSampler::penalties(
-                    request.repeat_last_n,
-                    request.repeat_penalty,
-                    0.0,
-                    0.0,
-                ));
-            }
-            if request.top_k > 0 {
-                chain.push(LlamaSampler::top_k(request.top_k));
-            }
-            if request.top_p < 1.0 {
-                chain.push(LlamaSampler::top_p(request.top_p, 1));
-            }
-            if request.min_p > 0.0 {
-                chain.push(LlamaSampler::min_p(request.min_p, 1));
-            }
-            chain.push(LlamaSampler::temp(request.temperature));
-            chain.push(LlamaSampler::dist(seed));
-            LlamaSampler::chain_simple(chain)
-        };
+        let mut sampler = sampling::build_sampler(&self.model, request, 1234);
 
         let mut decoder = encoding_rs::UTF_8.new_decoder();
         let mut output = String::new();
@@ -1338,38 +1307,7 @@ impl InferenceEngine {
             }
         }
 
-        let mut sampler = {
-            let seed = request.seed.unwrap_or_else(|| random_seed_fallback(1234));
-            let mut chain: Vec<LlamaSampler> = Vec::new();
-            if let Some(ref grammar_str) = request.grammar {
-                match LlamaSampler::grammar(&self.model, grammar_str, "root") {
-                    Ok(gs) => chain.push(gs),
-                    Err(e) => tracing::warn!(
-                        "Grammar sampler init failed ({e:?}), falling back to unconstrained"
-                    ),
-                }
-            }
-            if request.repeat_penalty != 1.0 {
-                chain.push(LlamaSampler::penalties(
-                    request.repeat_last_n,
-                    request.repeat_penalty,
-                    0.0,
-                    0.0,
-                ));
-            }
-            if request.top_k > 0 {
-                chain.push(LlamaSampler::top_k(request.top_k));
-            }
-            if request.top_p < 1.0 {
-                chain.push(LlamaSampler::top_p(request.top_p, 1));
-            }
-            if request.min_p > 0.0 {
-                chain.push(LlamaSampler::min_p(request.min_p, 1));
-            }
-            chain.push(LlamaSampler::temp(request.temperature));
-            chain.push(LlamaSampler::dist(seed));
-            LlamaSampler::chain_simple(chain)
-        };
+        let mut sampler = sampling::build_sampler(&self.model, request, 1234);
 
         let mut decoder = encoding_rs::UTF_8.new_decoder();
         let mut full_output = String::new();
@@ -1677,35 +1615,7 @@ impl InferenceEngine {
         );
 
         // ── 6. Sampler (identical to generate_streaming) ────────────────
-        let mut sampler = {
-            let seed = request.seed.unwrap_or_else(|| random_seed_fallback(1234));
-            let mut chain: Vec<LlamaSampler> = Vec::new();
-            if let Some(ref grammar_str) = request.grammar {
-                if let Ok(gs) = LlamaSampler::grammar(&self.model, grammar_str, "root") {
-                    chain.push(gs);
-                }
-            }
-            if request.repeat_penalty != 1.0 {
-                chain.push(LlamaSampler::penalties(
-                    request.repeat_last_n,
-                    request.repeat_penalty,
-                    0.0,
-                    0.0,
-                ));
-            }
-            if request.top_k > 0 {
-                chain.push(LlamaSampler::top_k(request.top_k));
-            }
-            if request.top_p < 1.0 {
-                chain.push(LlamaSampler::top_p(request.top_p, 1));
-            }
-            if request.min_p > 0.0 {
-                chain.push(LlamaSampler::min_p(request.min_p, 1));
-            }
-            chain.push(LlamaSampler::temp(request.temperature));
-            chain.push(LlamaSampler::dist(seed));
-            LlamaSampler::chain_simple(chain)
-        };
+        let mut sampler = sampling::build_sampler(&self.model, request, 1234);
 
         // ── 7. Decode loop (identical pattern to generate_streaming) ────
         let mut decoder = encoding_rs::UTF_8.new_decoder();

--- a/engine/src/inference/sampling.rs
+++ b/engine/src/inference/sampling.rs
@@ -1,0 +1,122 @@
+//! The single place a sampling chain is built.
+//!
+//! The chain was written out four times: once in the scheduler and three times
+//! in `inference/mod.rs` (non-streaming, streaming, multimodal). Four copies of
+//! the same sequence of `if` statements, and they had already started to drift:
+//!
+//! - the **seed fallback** differed. The scheduler passed `seq_id`, the three
+//!   sequential paths a hardcoded `1234`. The value only matters when the
+//!   system clock predates the Unix epoch, so nothing was visibly wrong — it is
+//!   just two answers to one question, which is how the interesting divergences
+//!   start.
+//! - the **multimodal copy swallowed grammar errors**. Where the other three
+//!   log `"Grammar sampler init failed …, falling back to unconstrained"`, it
+//!   used `if let Ok(gs) = …` and said nothing. A request with `format: "json"`
+//!   whose grammar failed to compile returned free-form text with no trace of
+//!   why.
+//!
+//! Neither is dramatic on its own. The point is the shape: every new sampler
+//! has to be added in four places, and being right in three of them is
+//! indistinguishable, in a diff, from being right in all four. Order matters
+//! here too (grammar must lead, `dist` must close), and an ordering fixed in
+//! one copy would silently not be fixed in the others.
+
+use llama_cpp_2::model::LlamaModel;
+use llama_cpp_2::sampling::LlamaSampler;
+
+use super::{GenerateRequest, random_seed_fallback};
+
+/// Build the sampler chain for one request.
+///
+/// `seed_fallback` is only consulted when the client sent no seed *and* the
+/// system clock is unusable; see [`random_seed_fallback`]. Callers pass
+/// something stable and locally distinct (the scheduler passes its slot id).
+///
+/// Order is part of the contract, not a style choice:
+/// grammar → penalties → top-k → top-p → min-p → temperature → dist.
+/// The grammar sampler must see the full distribution before anything has
+/// truncated it, and `dist` must be last because it is what actually draws the
+/// token; anything after it would have no effect.
+pub(crate) fn build_sampler(
+    model: &LlamaModel,
+    request: &GenerateRequest,
+    seed_fallback: u32,
+) -> LlamaSampler {
+    let seed = request
+        .seed
+        .unwrap_or_else(|| random_seed_fallback(seed_fallback));
+
+    let mut chain: Vec<LlamaSampler> = Vec::new();
+
+    // Grammar (if any) must be first in the chain.
+    if let Some(ref grammar_str) = request.grammar {
+        match LlamaSampler::grammar(model, grammar_str, "root") {
+            Ok(gs) => chain.push(gs),
+            // Never silent: a request that asked for constrained output and did
+            // not get it must leave a trace. The multimodal copy used to drop
+            // this on the floor.
+            Err(e) => {
+                tracing::warn!("Grammar sampler init failed ({e:?}), falling back to unconstrained")
+            }
+        }
+    }
+
+    // Repeat penalty (Ollama default: 1.1, last 64 tokens).
+    if request.repeat_penalty != 1.0 {
+        chain.push(LlamaSampler::penalties(
+            request.repeat_last_n,
+            request.repeat_penalty,
+            0.0,
+            0.0,
+        ));
+    }
+    // Top-K (Ollama default: 40).
+    if request.top_k > 0 {
+        chain.push(LlamaSampler::top_k(request.top_k));
+    }
+    // Top-P (Ollama default: 0.9).
+    if request.top_p < 1.0 {
+        chain.push(LlamaSampler::top_p(request.top_p, 1));
+    }
+    // Min-P (Ollama default: 0.0).
+    if request.min_p > 0.0 {
+        chain.push(LlamaSampler::min_p(request.min_p, 1));
+    }
+    chain.push(LlamaSampler::temp(request.temperature));
+    // Draws the token — must stay last.
+    chain.push(LlamaSampler::dist(seed));
+
+    LlamaSampler::chain_simple(chain)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The chain itself needs a loaded model to build, so what is testable
+    // without one is the decision that precedes it: which seed is used. That is
+    // also the part that had actually diverged between the four copies.
+    #[test]
+    fn an_explicit_seed_is_used_verbatim_whatever_the_fallback() {
+        let req = GenerateRequest {
+            seed: Some(4242),
+            ..Default::default()
+        };
+        let seed = req.seed.unwrap_or_else(|| random_seed_fallback(7));
+        assert_eq!(seed, 4242);
+    }
+
+    #[test]
+    fn without_a_seed_two_requests_do_not_agree() {
+        // Ollama's default is a fresh seed per request, not a fixed one. Two
+        // calls landing in the same nanosecond are astronomically unlikely, so
+        // this is a meaningful check rather than a flaky one.
+        let a = random_seed_fallback(1234);
+        let b = random_seed_fallback(1234);
+        assert_ne!(
+            (a, b),
+            (1234, 1234),
+            "the fallback constant must not be the normal path"
+        );
+    }
+}

--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -28,7 +28,7 @@ use llama_cpp_2::token::LlamaToken;
 use tokio::sync::mpsc;
 
 use super::output::{PieceOutcome, process_piece};
-use super::{GenerateRequest, InferenceConfig, StopReason, StreamEvent, random_seed_fallback};
+use super::{GenerateRequest, InferenceConfig, StopReason, StreamEvent};
 
 /// Below this many tokens per slot, a reasoning model routinely runs out of
 /// room mid-answer. Not a hard limit — just the threshold at which staying
@@ -961,47 +961,10 @@ fn run_scheduler_loop(
                     };
 
                     let req = &scheduled.request;
-                    let seed = req
-                        .seed
-                        .unwrap_or_else(|| random_seed_fallback(seq_id as u32));
-                    let sampler = {
-                        let mut chain: Vec<LlamaSampler> = Vec::new();
-                        // Grammar (if any) must be first in the chain
-                        if let Some(ref grammar_str) = req.grammar {
-                            match LlamaSampler::grammar(&model, grammar_str, "root") {
-                                Ok(gs) => chain.push(gs),
-                                Err(e) => tracing::warn!(
-                                    "Grammar sampler init failed ({e:?}), falling back to unconstrained"
-                                ),
-                            }
-                        }
-                        // Repeat penalty (Ollama default: 1.1, last 64 tokens)
-                        if req.repeat_penalty != 1.0 {
-                            chain.push(LlamaSampler::penalties(
-                                req.repeat_last_n,
-                                req.repeat_penalty,
-                                0.0,
-                                0.0,
-                            ));
-                        }
-                        // Top-K (Ollama default: 40)
-                        if req.top_k > 0 {
-                            chain.push(LlamaSampler::top_k(req.top_k));
-                        }
-                        // Top-P (Ollama default: 0.9)
-                        if req.top_p < 1.0 {
-                            chain.push(LlamaSampler::top_p(req.top_p, 1));
-                        }
-                        // Min-P (Ollama default: 0.0)
-                        if req.min_p > 0.0 {
-                            chain.push(LlamaSampler::min_p(req.min_p, 1));
-                        }
-                        // Temperature
-                        chain.push(LlamaSampler::temp(req.temperature));
-                        // Sampling distribution
-                        chain.push(LlamaSampler::dist(seed));
-                        LlamaSampler::chain_simple(chain)
-                    };
+                    // Slot id as the seed fallback: distinct per slot, so two
+                    // concurrent unseeded requests cannot collapse onto the
+                    // same sequence even in the clock-unusable case.
+                    let sampler = super::sampling::build_sampler(&model, req, seq_id as u32);
 
                     let seq = ActiveSequence {
                         seq_id,


### PR DESCRIPTION
The chain was written out four times, once in the scheduler and three times in inference/mod.rs. Both divergences the backlog predicted were there, and one of them is a real defect rather than duplication:

The seed fallback differed: seq_id in the scheduler, a hardcoded 1234 in the three sequential paths. It only matters when the system clock predates the Unix epoch, so nothing was visibly wrong. It is still two answers to one question. Callers now pass their own, and the scheduler passes its slot id, so two concurrent unseeded requests cannot collapse onto the same sequence even in that case.

The multimodal copy swallowed grammar errors. Where the other three log "Grammar sampler init failed, falling back to unconstrained", it used if-let-Ok with no else. A request with format: "json" whose grammar failed to compile returned free-form text with no trace anywhere of why.

Chain order is now documented as a contract: grammar leads because it must see the distribution before anything truncates it, and dist closes because it is what draws the token.

Verified on the release binary, not only in unit tests: the same seed twice returns identical text, and no seed at temperature 1.4 returns different text. That check fails if the seed is either ignored or never varied. Plus 186 tests, clippy, fmt, --all-targets with and without the multimodal feature, and the smoke test at 32 pass 0 fail.