### PR TITLE
fix(engine): strip stray think tags, answer 404 for unknown models, b…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.39"
+version = "0.6.40"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -515,6 +515,19 @@ esterni non si fidano dei valori che leggono.
   della singola richiesta quando `think` è falso. È una decisione lato
   chiamante, non lato `process_piece`, e merita il suo cambio.
 
+  **Punto 2 chiuso in 0.6.40.** `inference::default_filters(think)` costruisce
+  la lista per richiesta: le Harmony sempre, più `<think>` e `</think>` solo
+  quando `think` è falso. Lì il prompt porta già un blocco think chiuso e
+  vuoto, quindi un tag **in uscita** è spurio per costruzione. Con
+  `think: true` i tag sono output legittimo che la UI rende come sezione di
+  ragionamento e non vanno toccati.
+  È una guardia, non un parser: il meccanismo dei filtri lavora su
+  sottostringhe letterali, quindi toglie i tag ma non può eliminare un blocco
+  `<think>…</think>` con contenuto dentro. Sopprimere il ragionamento è
+  compito del prefisso, che è la correzione vera; questa è la seconda linea.
+  Tre test, incluso quello che verifica che i filtri Harmony sopravvivano in
+  entrambe le modalità — la regressione che una riscrittura ingenua causerebbe.
+
 - [x] **H2-E · Estrarre la costruzione della catena di sampling** *(P2)*
   La catena è duplicata in quattro punti (`scheduler.rs:929-966`;
   `inference/mod.rs:781-812, 1000-1031, 1313-1341`) e la divergenza è già iniziata: il
@@ -578,7 +591,7 @@ esterni non si fidano dei valori che leggono.
   `n_ubatch=1024` (riga di log del loader, o `nvidia-smi`) su almeno due modelli e fissare
   il valore sul dato. Da fare insieme a `0.7-E`, che tocca lo stesso sizer.
 
-- [ ] **H2-I · Un modello inesistente deve dare 404, non 500** *(P2)*
+- [x] **H2-I · Un modello inesistente deve dare 404, non 500** *(P2)*
   Emerso testando il binario pubblicato di v0.6.35: una richiesta con
   `{"model":"non-esiste"}` restituisce **500** con `Failed to load model ...`
   (`api/routes.rs:171-180` — l'errore di `swap_model` è mappato su
@@ -589,7 +602,18 @@ esterni non si fidano dei valori che leggono.
   caricamento — VRAM insufficiente, GGUF corrotto — che resta 500. Comporta far
   ritornare a `resolve_model` un errore tipizzato invece di una `String`.
 
-- [ ] **H2-J · Con `think: false` un `</think>` finisce nel testo visibile** *(P2)*
+  **Chiusa.** `ModelError { NotFound, LoadFailed }` in `api/mod.rs`, con
+  `From<String>` che manda tutto ciò che non è esplicitamente una ricerca
+  fallita su `LoadFailed` — così il default è il 500 e il 404 va chiesto,
+  non il contrario. `resolve_model` e `swap_model` lo restituiscono, e
+  `routes.rs` mappa i due casi. Un solo chiamante di `swap_model`, quindi il
+  cambio di firma non si è propagato.
+  Verificato sul binario: `{"model":"non-esiste"}` risponde **404** su
+  `/api/chat` e su `/v1/chat/completions`, un modello vero resta **200**. Lo
+  smoke test aveva questo controllo come `skip` tollerato: ora è
+  un'asserzione dura e il totale passa da 32 a 33 pass.
+
+- [x] **H2-J · Con `think: false` un `</think>` finisce nel testo visibile** *(P2)*
   Emerso dallo smoke test su ARM (Radxa Orion O6, qwen3-0.6b, `think: false`,
   `temperature: 0`): il contenuto ricostruito dallo stream NDJSON è
   `"</think>\n\nCount: one two three"` — il tag di chiusura arriva al client come
@@ -997,10 +1021,21 @@ esterni non si fidano dei valori che leggono.
     è ciò che serve: il difetto 1 era invisibile proprio perché ci fidavamo
     di una feature al posto di un controllo.
 
-  **Nota di metodo, la parte scomoda.** Il 22 luglio ho scritto
-  «eullm-macos-x64 è costruito senza Metal, quindi non tocca mai la GPU» e su
-  quella frase è stata costruita una settimana di indagine nella direzione
-  sbagliata — inclusa la caccia alla cross-compilazione di H2-S, che resta
+  **Nota di metodo, la parte scomoda — e non è quella che sembra.** La
+  diagnosi non è arrivata tardi: è arrivata il **22 luglio**, due giorni dopo
+  il primo report di Peter, ed era giusta. Quel giorno abbiamo rilasciato
+  quella che credevamo fosse la correzione (0.6.31, commit `c891fc8`): **una
+  riga cancellata**, `features: metal`, dalla matrice di build. Peter ha
+  provato e ha risposto «no changes from 0.6.30».
+  **Lì sta l'errore.** Un risultato negativo dopo una correzione ha due
+  spiegazioni — l'ipotesi è sbagliata, oppure la correzione non ha fatto
+  effetto — e ne abbiamo considerata una sola. Abbiamo scartato l'ipotesi
+  giusta e siamo andati a cercare altrove per quattro giorni: baseline AVX2,
+  default dei thread, tipi di KV cache, guardia NaN, cross-compilazione.
+  Quello che avrebbe chiuso tutto è un `grep ggml_metal` sul binario
+  pubblicato. Il 22 luglio ho scritto «eullm-macos-x64 è costruito senza
+  Metal, quindi non tocca mai la GPU» senza mai averlo verificato su un
+  binario — inclusa la caccia alla cross-compilazione di H2-S, che resta
   corretta come igiene ma non era questo. Non avevo mai letto un log di avvio
   di quel binario su una macchina Apple: se l'avessi fatto, `ggml_metal_init`
   era lì dalla prima riga. La lezione non è «Metal è insidioso», è che una

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.39"
+version = "0.6.40"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -129,6 +129,37 @@ pub struct AppState {
     pub launch_model: Option<(String, PathBuf)>,
 }
 
+/// Why a model could not be made ready.
+///
+/// The distinction exists because it is the difference between a 4xx and a
+/// 5xx, and getting it wrong is not cosmetic: a client with automatic retry
+/// treats a 500 as "try again" and will hammer a request that can never
+/// succeed. Asking for a model that does not exist is a client mistake;
+/// failing to load one that does is ours.
+#[derive(Debug)]
+pub enum ModelError {
+    /// No such model, by any accepted spelling. The caller should get a 404.
+    NotFound(String),
+    /// The model exists but could not be loaded: out of VRAM, corrupt GGUF,
+    /// a context that will not allocate. The caller should get a 500.
+    LoadFailed(String),
+}
+
+impl std::fmt::Display for ModelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(m) | Self::LoadFailed(m) => f.write_str(m),
+        }
+    }
+}
+
+impl From<String> for ModelError {
+    /// Everything that is not explicitly a lookup miss is a load failure.
+    fn from(m: String) -> Self {
+        Self::LoadFailed(m)
+    }
+}
+
 impl AppState {
     /// Swap the currently loaded model.  Drops the old engine/scheduler
     /// (in-flight requests on cloned handles still complete) and loads
@@ -145,7 +176,7 @@ impl AppState {
         name: &str,
         override_batch_size: Option<usize>,
         override_ctx_size: Option<u32>,
-    ) -> Result<(), String> {
+    ) -> Result<(), ModelError> {
         // Serialize swaps — if another request is already swapping,
         // wait for it to finish instead of starting a parallel swap.
         let _swap_guard = self.swap_lock.lock().await;
@@ -370,7 +401,7 @@ impl AppState {
     /// The launch path is always accepted regardless: `/api/tags` reports it as
     /// the loaded model's name, clients echo back what they were told, and
     /// refusing our own answer would break `eullm run ./model.gguf`.
-    fn resolve_model(&self, name: &str) -> Result<PathBuf, String> {
+    fn resolve_model(&self, name: &str) -> Result<PathBuf, ModelError> {
         let path = PathBuf::from(name);
 
         // 0. The model this process was launched with, by the name the API
@@ -430,12 +461,12 @@ impl AppState {
             return Ok(p);
         }
 
-        Err(format!(
+        Err(ModelError::NotFound(format!(
             "Model '{name}' not found. Accepted formats:\n  \
              - GGUF file path: /models/model.gguf\n  \
              - Directory with GGUF: /models/mymodel/\n  \
              - Registered name: eullm import-ollama {name}"
-        ))
+        )))
     }
 }
 

--- a/engine/src/api/routes.rs
+++ b/engine/src/api/routes.rs
@@ -174,11 +174,21 @@ async fn ensure_model(
             state
                 .swap_model(name, override_batch_size, override_ctx_size)
                 .await
-                .map_err(|e| {
-                    (
+                .map_err(|e| match e {
+                    // A model that does not exist is a client mistake, and a
+                    // 5xx here is actively harmful: clients with automatic
+                    // retry treat it as transient and hammer a request that
+                    // can never succeed. Ollama answers 404 for this.
+                    crate::api::ModelError::NotFound(msg) => {
+                        (StatusCode::NOT_FOUND, Json(json!({ "error": msg })))
+                    }
+                    // The model exists but would not load: out of VRAM, a
+                    // corrupt GGUF, a context that will not allocate. That is
+                    // ours, and 500 is correct.
+                    crate::api::ModelError::LoadFailed(msg) => (
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({ "error": format!("Failed to load model '{name}': {e}") })),
-                    )
+                        Json(json!({ "error": format!("Failed to load model '{name}': {msg}") })),
+                    ),
                 })?;
         }
     }
@@ -828,10 +838,8 @@ async fn chat(
             // generate() add its own BOS/template on top.
             raw: true,
             stop_sequences: vec!["<end_of_turn>".to_string()],
-            filter_sequences: crate::inference::DEFAULT_HARMONY_FILTERS
-                .iter()
-                .map(|s| (*s).to_string())
-                .collect(),
+            // Gemma has no think toggle, so nothing extra to strip here.
+            filter_sequences: crate::inference::default_filters(true),
             grammar: None,
         };
         if is_streaming(&body) {
@@ -900,10 +908,9 @@ async fn chat(
         seed: sp.seed,
         num_ctx: sp.num_ctx,
         stop_sequences,
-        filter_sequences: crate::inference::DEFAULT_HARMONY_FILTERS
-            .iter()
-            .map(|s| (*s).to_string())
-            .collect(),
+        // think-aware: with think:false a think tag in the OUTPUT is
+        // spurious, since the prompt already carries a closed empty block.
+        filter_sequences: crate::inference::default_filters(think),
         grammar,
         raw: false,
     };
@@ -1125,10 +1132,9 @@ async fn chat_completions(
         seed: sp.seed,
         num_ctx: sp.num_ctx,
         stop_sequences,
-        filter_sequences: crate::inference::DEFAULT_HARMONY_FILTERS
-            .iter()
-            .map(|s| (*s).to_string())
-            .collect(),
+        // think-aware: with think:false a think tag in the OUTPUT is
+        // spurious, since the prompt already carries a closed empty block.
+        filter_sequences: crate::inference::default_filters(think),
         grammar,
         raw: false,
     };

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -658,6 +658,40 @@ pub const DEFAULT_HARMONY_FILTERS: &[&str] = &[
     "<audio|>",
 ];
 
+/// The filter list for one request, given whether the client asked for
+/// thinking.
+///
+/// With `think: false` the prompt already carries a closed, empty think block
+/// (see [`crate::chat_template::ChatTemplate::think_suppression_prefix`]), so
+/// any think tag appearing in the *output* is spurious by construction and is
+/// stripped here.
+///
+/// That case is not hypothetical: until v0.6.39 the injected prefix was one
+/// newline short of what Qwen3's own template emits, which put the prompt off
+/// distribution and made the model reason in the visible channel and close
+/// with the tag. The prefix is fixed, so this is the second line of defence
+/// rather than the fix, and it costs nothing when the model behaves.
+///
+/// With `think: true` the tags are legitimate output the UI renders as a
+/// reasoning section, and must not be touched.
+///
+/// This is a guard, not a parser: the filter mechanism matches literal
+/// substrings, so it removes stray tags but cannot elide a whole
+/// `<think>…</think>` block with content in it. Removing the markers of
+/// reasoning the client did not ask for is an improvement on showing both;
+/// suppressing the reasoning itself is the prefix's job.
+pub fn default_filters(think: bool) -> Vec<String> {
+    let mut out: Vec<String> = DEFAULT_HARMONY_FILTERS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    if !think {
+        out.push("</think>".to_string());
+        out.push("<think>".to_string());
+    }
+    out
+}
+
 /// Request for text generation.
 #[derive(Debug, Clone)]
 pub struct GenerateRequest {
@@ -1944,6 +1978,40 @@ core id\t\t: 0
             "physical cores ({t}) cannot exceed logical ({})",
             logical_core_count()
         );
+    }
+}
+
+#[cfg(test)]
+mod think_filter_tests {
+    use super::*;
+
+    #[test]
+    fn think_true_leaves_the_tags_alone() {
+        let f = default_filters(true);
+        assert!(!f.iter().any(|s| s.contains("think")), "{f:?}");
+        assert_eq!(f.len(), DEFAULT_HARMONY_FILTERS.len());
+    }
+
+    #[test]
+    fn think_false_strips_stray_think_tags() {
+        let f = default_filters(false);
+        assert!(f.iter().any(|s| s == "</think>"));
+        assert!(f.iter().any(|s| s == "<think>"));
+    }
+
+    // The Harmony filters exist independently of thinking and must survive
+    // either way; this is the regression that a naive rewrite would cause.
+    #[test]
+    fn the_harmony_filters_are_present_in_both_modes() {
+        for think in [true, false] {
+            let f = default_filters(think);
+            for expected in DEFAULT_HARMONY_FILTERS {
+                assert!(
+                    f.iter().any(|s| s == expected),
+                    "{expected} missing with think={think}"
+                );
+            }
+        }
     }
 }
 

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -522,11 +522,15 @@ def check_override_validation(rep: Report, api: str) -> None:
         code != 400,
         f"http={code} (a non-400 here means validation let it through)",
     )
-    # Tracked as H2-I: this ought to be 404, not 500.
+    # A model that does not exist is a client mistake. 500 was worse than
+    # merely wrong: clients with automatic retry treat it as transient and
+    # re-send a request that can never succeed. Fixed in 0.6.40 (H2-I), and
+    # this is now a hard assertion rather than a tolerated skip.
     rep.add(
-        "unknown model returns 404",
-        None if code == 500 else (code == 404),
-        f"http={code} — currently 500, should be 404 (backlog H2-I)",
+        "unknown model returns 404, not 500",
+        code == 404,
+        f"http={code}"
+        + ("" if code == 404 else " — a 5xx here invites clients to retry forever"),
     )
 
 


### PR DESCRIPTION
…ump to 0.6.40

H2-J part 2. inference::default_filters(think) builds the filter list per request: the Harmony filters always, plus <think> and </think> only when think is false. In that mode the prompt already carries a closed empty think block, so a tag in the OUTPUT is spurious by construction. With think true the tags are legitimate output the UI renders as a reasoning section and must not be touched. This is a guard rather than a parser: the mechanism matches literal substrings, so it removes stray tags but cannot elide a whole block with content. Suppressing the reasoning itself is the prompt prefix's job, fixed in 0.6.39; this is the second line.

H2-I. A model that does not exist returned 500, which is worse than merely wrong: clients with automatic retry treat a 5xx as transient and re-send a request that can never succeed. ModelError { NotFound, LoadFailed } now carries the distinction, with From<String> routing everything not explicitly a lookup miss to LoadFailed, so 500 stays the default and 404 has to be asked for. Verified on the binary: an unknown model answers 404 on both /api/chat and /v1/chat/completions while a real one still answers 200. The smoke test had this as a tolerated skip and now asserts it.

189 tests, clippy, fmt, --all-targets with and without the multimodal feature, smoke test 34 pass 0 fail against the 0.6.40 binary.