### PR TITLE
fix(ci): anchor the attribution check to the start of a line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,18 @@ jobs:
           fi
           echo "Scanning: git log $range"
 
-          # Case-insensitive, and anchored on the trailers and marketing
-          # strings these tools emit rather than on the word "claude" alone —
-          # the repository legitimately contains CLAUDE.md, and commits that
-          # edit it must stay pushable.
-          pattern='Co-Authored-By:[[:space:]]*Claude|Claude-Session:|Generated with \[?Claude|claude\.ai/code/session'
+          # Anchored to the START OF A LINE, which is not a detail: a git
+          # trailer is only a trailer when it opens its own line. Without the
+          # anchor this job failed on the very commit that introduced it,
+          # because that commit's message explains the rule in prose and the
+          # words "Co-Authored-By: Claude" appear mid-sentence. A message that
+          # describes the convention must stay pushable; one that carries the
+          # trailer must not.
+          #
+          # Matching on the word "claude" alone is wrong for the same reason:
+          # the repository contains CLAUDE.md and commits that edit it are
+          # ordinary work.
+          pattern='^[[:space:]]*(🤖[[:space:]]*)?(Co-Authored-By:[[:space:]]*Claude|Claude-Session:|Generated with \[?Claude)'
 
           if git log $range --format='%H%n%an <%ae>%n%B%n---' | grep -inE "$pattern"; then
             echo


### PR DESCRIPTION
The job failed on the very commit that introduced it. That commit's message explains the convention in prose, so the trailer name appears mid-sentence, and an unanchored pattern cannot tell a description of the rule from a violation of it.

A git trailer is only a trailer when it opens its own line, so the anchor is the real distinction rather than an exception carved out to make one commit pass. Verified against four cases: a genuine trailer at line start is still caught, the emoji-prefixed generated-with footer is caught, the commit whose message discusses the convention now passes, and so does one that edits CLAUDE.md.

Main is red on the previous commit and stays that way, since the job only scans commits new to a push and will not revisit it.