### PR TITLE
fix(engine): a damaged manifest no longer hides every model

### DIFF
--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -1078,6 +1078,43 @@ esterni non si fidano dei valori che leggono.
   compila e nient'altro. Il difetto era invisibile a 191 test e visibile alla
   prima richiesta vera.
 
+- [x] **H2-V · Un `manifest.json` danneggiato nascondeva tutti i modelli** *(P1)*
+  Segnalato dal campo, non da una revisione: `eullm list` rispondeva
+  `Error listing models: expected ',' or '}' at line 24 column 3` e basta.
+  Nessun elenco, e nessuna indicazione di quale directory fosse il problema.
+
+  Due difetti che si alimentano a vicenda, ed è importante vederli entrambi
+  perché correggerne uno solo lascia il sistema fragile:
+
+  1. **Scrittura non atomica** (`store.rs`): `fs::write` tronca il file e poi
+     scrive. Un processo che muore in mezzo — crash, `kill`, disco pieno —
+     lascia un percorso valido con dentro contenuto invalido. È così che il
+     manifest si rompe.
+  2. **Lettura intollerante**: `list()` faceva `serde_json::from_str(&data)?`,
+     e quel `?` propaga. **Un** manifest rotto rendeva invisibili **tutti** gli
+     altri modelli. Le due funzioni sorelle nello stesso file
+     (`store.rs:186` e `:221`) erano già tolleranti: la sola severa era quella
+     che l'utente lancia davvero.
+
+  Chiuso su entrambi i fronti. La scrittura passa da `write_atomically`, che
+  scrive su un file temporaneo **nella stessa directory** — un rename fra
+  filesystem non è atomico e ricadrebbe in una copia, cioè proprio il modo di
+  guasto da evitare — e poi rinomina. `std::fs::rename` sostituisce la
+  destinazione esistente sia su Unix sia su Windows, quindi il lettore vede o
+  il vecchio manifest o il nuovo, mai un prefisso di uno dei due. La lettura
+  salta il manifest illeggibile con un warning che **nomina il file** e dice
+  cosa fare.
+
+  Verificato riproducendo il sintomo su un archivio con un manifest troncato:
+  il binario pubblicato stampa solo l'errore del parser, quello corretto elenca
+  il modello sano e nomina quello rotto. Quattro test, inclusi i due che
+  coprono l'atomicità.
+
+  Nota sul fixture: la prima versione del test passava per il motivo sbagliato,
+  perché il manifest "sano" che avevo scritto era incompleto e veniva scartato
+  anche lui — l'elenco risultava vuoto e l'asserzione lo prendeva per un
+  successo. Un test che non distingue i due casi non verifica niente.
+
 ### Verificato e **non** indotto da noi
 
 Elencato perché l'assenza di un difetto va registrata quanto la presenza, e

--- a/engine/src/models/store.rs
+++ b/engine/src/models/store.rs
@@ -72,6 +72,28 @@ pub struct ModelStore {
     root: PathBuf,
 }
 
+/// Write a file so a reader never sees it half-written.
+///
+/// `fs::write` truncates first and writes after, so a process that dies in
+/// between leaves a valid path holding invalid content. For `manifest.json`
+/// that turns into a parse error on the next `eullm list`, and the model looks
+/// as though it were never pulled. Seen in the field.
+///
+/// Writing to a sibling temporary file and renaming makes the swap atomic on
+/// every platform we ship: `std::fs::rename` replaces an existing destination
+/// on Unix and on Windows alike. The reader therefore observes either the old
+/// manifest or the new one, never a prefix of either.
+///
+/// The temporary file sits in the destination's own directory on purpose. A
+/// rename across filesystems is not atomic and would fall back to a copy,
+/// which is the failure mode this exists to avoid.
+fn write_atomically(path: &Path, contents: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, contents)?;
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
 impl ModelStore {
     /// Create a store at the default location (`~/.eullm/models/`), or at
     /// `$EULLM_MODELS_DIR` when set.
@@ -127,7 +149,7 @@ impl ModelStore {
 
         let manifest_path = model_dir.join("manifest.json");
         let json = serde_json::to_string_pretty(&manifest)?;
-        fs::write(&manifest_path, json)?;
+        write_atomically(&manifest_path, &json)?;
 
         Ok(model_dir)
     }
@@ -168,7 +190,7 @@ impl ModelStore {
 
         let manifest_path = model_dir.join("manifest.json");
         let json = serde_json::to_string_pretty(&manifest)?;
-        fs::write(&manifest_path, json)?;
+        write_atomically(&manifest_path, &json)?;
 
         Ok(model_dir)
     }
@@ -256,8 +278,34 @@ impl ModelStore {
             if entry.file_type()?.is_dir() {
                 let manifest_path = entry.path().join("manifest.json");
                 if manifest_path.exists() {
-                    let data = fs::read_to_string(&manifest_path)?;
-                    let mut manifest: ModelManifest = serde_json::from_str(&data)?;
+                    // One damaged manifest must not hide every other model.
+                    // This used to propagate with `?`, so a single truncated
+                    // file made `eullm list` print a bare parser position and
+                    // nothing else: no list, and no clue which directory was
+                    // at fault. Reported from the field as
+                    // "expected ',' or '}' at line 24 column 3".
+                    //
+                    // Note the two sibling readers below already tolerate this
+                    // (`if let Ok(manifest) = ...`); the listing was the strict
+                    // one, and it is the one people actually run.
+                    let data = match fs::read_to_string(&manifest_path) {
+                        Ok(d) => d,
+                        Err(e) => {
+                            tracing::warn!("skipping {}: {e}", manifest_path.display());
+                            continue;
+                        }
+                    };
+                    let mut manifest: ModelManifest = match serde_json::from_str(&data) {
+                        Ok(m) => m,
+                        Err(e) => {
+                            tracing::warn!(
+                                "skipping {}: {e}. Delete that directory and pull the model \
+                                 again to repair it.",
+                                manifest_path.display()
+                            );
+                            continue;
+                        }
+                    };
                     // Backfill the addressable id from the directory name for
                     // manifests written before the `id` field existed.
                     if manifest.id.is_empty()
@@ -458,5 +506,98 @@ mod safe_filename_tests {
             );
             assert_eq!(joined.parent(), Some(base));
         }
+    }
+}
+
+#[cfg(test)]
+mod manifest_robustness_tests {
+    use super::*;
+    use uuid::Uuid;
+
+    // Every non-defaulted field of ModelManifest. A fixture missing one is
+    // rejected exactly like a truncated file, which would make the test below
+    // pass for the wrong reason.
+    const GOOD: &str = r#"{
+        "id": "good", "name": "Good", "description": "d", "languages": ["en"],
+        "base": "b", "vram_gb": 2, "size_bytes": 1, "license": "Apache-2.0",
+        "digest": "sha256:0", "pulled_at": "2026-07-27T00:00:00Z",
+        "status": "ready", "gguf_file": "g.gguf"
+    }"#;
+    // The shape reported from the field: a write that stopped partway.
+    const TRUNCATED: &str = "{\n  \"id\": \"broken\",\n  \"name\": \"Bro";
+
+    struct Scratch(PathBuf);
+    impl Scratch {
+        fn new() -> Self {
+            let d = std::env::temp_dir().join(format!("eullm-store-{}", Uuid::new_v4()));
+            fs::create_dir_all(&d).expect("mkdir");
+            Self(d)
+        }
+        fn model(&self, name: &str, manifest: &str) {
+            let d = self.0.join(name);
+            fs::create_dir_all(&d).expect("mkdir");
+            fs::write(d.join("manifest.json"), manifest).expect("write");
+        }
+        fn store(&self) -> ModelStore {
+            ModelStore {
+                root: self.0.clone(),
+            }
+        }
+    }
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn one_damaged_manifest_does_not_hide_the_others() {
+        let s = Scratch::new();
+        s.model("good", GOOD);
+        s.model("broken", TRUNCATED);
+        let listed = s
+            .store()
+            .list()
+            .expect("listing must survive a bad manifest");
+        let ids: Vec<&str> = listed.iter().map(|m| m.id.as_str()).collect();
+        assert!(ids.contains(&"good"), "the healthy model vanished: {ids:?}");
+        assert!(
+            !ids.contains(&"broken"),
+            "the damaged one must be skipped: {ids:?}"
+        );
+    }
+
+    #[test]
+    fn a_directory_without_a_manifest_is_ignored() {
+        let s = Scratch::new();
+        s.model("good", GOOD);
+        fs::create_dir_all(s.0.join("empty")).expect("mkdir");
+        assert_eq!(s.store().list().expect("list").len(), 1);
+    }
+
+    // The other half of the defect. If the write is not atomic, an interrupted
+    // one produces exactly the truncated file the test above has to tolerate.
+    #[test]
+    fn an_atomic_write_leaves_no_temporary_behind() {
+        let s = Scratch::new();
+        let target = s.0.join("manifest.json");
+        write_atomically(&target, GOOD).expect("write");
+        assert_eq!(fs::read_to_string(&target).expect("read"), GOOD);
+        let leftovers: Vec<String> = fs::read_dir(&s.0)
+            .expect("readdir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.ends_with(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temporary left behind: {leftovers:?}");
+    }
+
+    #[test]
+    fn an_atomic_write_replaces_existing_content_whole() {
+        let s = Scratch::new();
+        let target = s.0.join("manifest.json");
+        write_atomically(&target, "{\"id\":\"old\"}").expect("first");
+        write_atomically(&target, GOOD).expect("second");
+        assert_eq!(fs::read_to_string(&target).expect("read"), GOOD);
     }
 }


### PR DESCRIPTION
Reported from the field: eullm list answered with a bare parser position and nothing else. No listing, and no indication of which directory was at fault.

Two defects feeding each other. The manifest is written with fs::write, which truncates first and writes after, so a process that dies in between leaves a valid path holding invalid content. And list() parsed with a propagating ?, so one damaged file made every other model invisible. The two sibling readers in the same file already tolerated this; the listing was the strict one, and it is the one people run.

Writes now go through write_atomically: a temporary file in the same directory, then a rename. Same directory on purpose, since a rename across filesystems is not atomic and would fall back to a copy, which is the failure this exists to prevent. A reader sees either the old manifest or the new one. The listing skips an unreadable manifest with a warning naming the file and saying how to repair it.

Verified by reproducing the symptom against a store containing a truncated manifest: the published binary prints only the parser error, the fixed one lists the healthy model and names the broken one. Four tests, two of them covering the atomicity.

The first version of the fixture passed for the wrong reason: the healthy manifest was missing required fields, so it was skipped too and the empty listing satisfied the assertion.