### PR TITLE
chore: release 0.6.42 — multimodal on every published binary

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -145,9 +145,11 @@ jobs:
             # SIGILL crash instead of a slow-but-working binary — see
             # docs/x86-64-baseline.md for the compatibility trade-off writeup.
             rustflags: "-C target-cpu=x86-64-v3"
+            features: multimodal
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04
             artifact: eullm-linux-arm64
+            features: multimodal
           - target: x86_64-apple-darwin
             # Native Intel runner, NOT macos-15 (Apple Silicon) with a
             # cross-compile. This was the last unexamined variable behind the
@@ -166,19 +168,22 @@ jobs:
             # Same x86-64-v3 baseline as eullm-linux-x64 above — see that
             # entry's comment.
             #
-            # This target carries no `features:` entry, and from v0.6.39 that
+            # This target carries no `metal` feature, and from v0.6.39 that
             # genuinely means no Metal. Between v0.6.30 and v0.6.38 it did
             # not: ggml's CMake enables the Metal backend on every Apple
             # target regardless of cargo features, so dropping the feature
             # changed nothing and this binary kept offloading whole models
             # onto Intel-Mac GPUs (issue #140). llama-cpp-sys-2's build.rs now
             # passes -DGGML_METAL=OFF when the feature is absent, matching how
-            # llama.cpp builds its own macOS x64 release.
+            # llama.cpp builds its own macOS x64 release. `multimodal` is
+            # unrelated to that: it compiles llama.cpp's mtmd helper and
+            # touches no backend.
             rustflags: "-C target-cpu=x86-64-v3"
+            features: multimodal
           - target: aarch64-apple-darwin
             os: macos-15
             artifact: eullm-macos-arm64
-            features: metal
+            features: metal,multimodal
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -572,7 +577,7 @@ jobs:
         run: sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake build-essential pkg-config libssl-dev
 
       - name: Build engine (CIX P1 profile)
-        run: cargo build --release -p eullm-engine
+        run: cargo build --release --features multimodal -p eullm-engine
         env:
           # Read by engine/vendor/llama-cpp-rs/llama-cpp-sys-2/build.rs; falls
           # back to the generic armv8-a baseline everywhere this isn't set.
@@ -655,7 +660,7 @@ jobs:
           # Same x86-64-v3 baseline as eullm-linux-x64/eullm-macos-x64 — see
           # docs/x86-64-baseline.md.
           RUSTFLAGS: "-C target-cpu=x86-64-v3"
-        run: cargo build --release --target x86_64-pc-windows-msvc -p eullm-engine
+        run: cargo build --release --target x86_64-pc-windows-msvc --features multimodal -p eullm-engine
 
       - name: sccache stats (visibility into S3 hit/miss)
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,42 @@ Entries for **0.6.36 and later** are written by hand. Everything below that is
 derived from the commit history and reads like it: useful for tracing when
 something changed, less so for understanding what it means.
 
+## 0.6.42 — 2026-07-27
+
+### Added
+- **Images work without a GPU.** Multimodal input used to be compiled only into
+  the three CUDA builds, so sending an image to any other binary failed no
+  matter how much memory the machine had. Every published binary now reads
+  images: Linux x64 and arm64, both macOS builds, Windows, and the CIX P1
+  board. Expect it to be slow on CPU — the image encoder is the expensive part,
+  and a large photo can take tens of seconds before the first word — but on a
+  machine with shared memory it is the difference between slow and impossible.
+  The binaries are about 4 MB larger; nothing changes if you never send an
+  image.
+
+### Fixed
+- **`eullm list` no longer fails completely because of one damaged model.** A
+  `manifest.json` truncated by an interrupted download or a full disk made the
+  command answer with a parser error and nothing else, hiding every healthy
+  model. The damaged one is now skipped with a warning that names the directory,
+  and manifests are written atomically so an interrupted write cannot produce
+  that state in the first place.
+- **`list` and the server now say which model directory they are using.** When
+  `EULLM_MODELS_DIR` is set in one shell and not in another, `list` would show a
+  model as installed while the API answered `404` for the same name, and both
+  were right. Each now prints the directory it reads, and where that setting
+  came from.
+- **A model whose file is missing is no longer reported as ready.** `list` was
+  repeating the status recorded at download time, so a model whose weights were
+  deleted, or never fully arrived, stayed `ready` forever. It now checks the
+  disk and reports `ready (file missing)`.
+- **The model chooser finds your local models again.** The screen shown by a
+  plain `eullm` looked them up by their display title rather than their name, so
+  most models on disk were missing from the `LOCAL` section, and it ignored
+  `EULLM_MODELS_DIR` when scanning for loose `.gguf` files. The `[local]` tag
+  next to a catalog entry now means the weights are actually present, not just
+  that a download was started.
+
 ## 0.6.41 — 2026-07-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.41"
+version = "0.6.42"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.41"
+version = "0.6.42"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"


### PR DESCRIPTION
Image input was compiled only into the three CUDA builds, so any machine without an NVIDIA GPU got a decode failure regardless of how much memory it had. The mtmd helper is plain C++ and touches no backend, so there was no reason for the restriction beyond how the feature was first shipped.

Enabled on the four matrix targets, the CIX P1 board and Windows. On the Intel macOS target this is unrelated to the Metal question: `multimodal` does not imply `metal`, and build.rs still passes -DGGML_METAL=OFF there.

Cost measured earlier at about 4 MB per binary.