### PR TITLE
fix(build): name the missing submodule instead of failing on a missin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,7 +915,9 @@ xcode-select --install && brew install cmake
 ```
 
 ```bash
-git clone https://github.com/eullm/eullm.git && cd eullm
+# --recursive is required: llama.cpp is a submodule. Without it the build
+# fails on a missing llama.h. Already cloned? git submodule update --init --recursive
+git clone --recursive https://github.com/eullm/eullm.git && cd eullm
 cargo build --release
 
 # Run any GGUF model — that's it
@@ -1208,7 +1210,8 @@ Detailed documentation is available in the [`docs/`](docs/) directory:
 ### Development setup
 
 ```bash
-git clone https://github.com/eullm/eullm.git
+# --recursive fetches the llama.cpp submodule; the build needs it.
+git clone --recursive https://github.com/eullm/eullm.git
 cd eullm
 
 # Build the engine (CPU only)

--- a/engine/vendor/llama-cpp-rs/llama-cpp-sys-2/build.rs
+++ b/engine/vendor/llama-cpp-rs/llama-cpp-sys-2/build.rs
@@ -240,6 +240,27 @@ fn main() {
     let target_dir = get_cargo_target_dir().unwrap();
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("Failed to get CARGO_MANIFEST_DIR");
     let llama_src = Path::new(&manifest_dir).join("llama.cpp");
+
+    // llama.cpp is a git submodule. A plain `git clone` leaves that directory
+    // empty, and a source archive downloaded from a release never contains it
+    // at all — GitHub's generated tarballs exclude submodules. Either way the
+    // first sign of trouble is bindgen failing on a missing `llama.h`, several
+    // minutes into a build, with a clang diagnostic that reads like a broken
+    // toolchain and sends people looking at their distribution. Checked here
+    // so the failure names its own fix.
+    if !llama_src.join("include/llama.h").is_file() {
+        panic!(
+            "llama.cpp sources are missing at {}.\n\n\
+             llama.cpp is a git submodule of this repository. Fetch it with:\n\
+             \x20   git submodule update --init --recursive\n\n\
+             (or clone with `git clone --recursive` next time). Note that the\n\
+             `Source code (zip/tar.gz)` archives on the releases page cannot\n\
+             work for this: GitHub generates them without submodule contents.\n\
+             Clone the repository, or download a prebuilt binary instead.",
+            llama_src.display()
+        );
+    }
+
     let build_shared_libs = cfg!(feature = "dynamic-link");
 
     let build_shared_libs = std::env::var("LLAMA_BUILD_SHARED_LIBS")


### PR DESCRIPTION
…g header

A plain `git clone` — which is exactly what the README printed — leaves the llama.cpp submodule empty, and the build then failed minutes later inside bindgen with "'llama.cpp/include/llama.h' file not found". That reads like a broken toolchain, so the first suspect is the distribution rather than the checkout (reported from openSUSE Tumbleweed, issue #286).

build.rs now checks for the sources up front and says how to fetch them. README clones with --recursive in both places it documents a build, and notes the fix for a clone already on disk.

The release source archives cannot build at all: GitHub generates them without submodule contents. Said so in the message rather than leaving it to be discovered.