### PR TITLE
ci: refuse to publish a release whose tag does not match the crate ve…

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -94,6 +94,19 @@ Earlier versions (v0.5.x) shipped a TurboQuant-experimental variant via the Ames
 
 **Nuclear option** if cache contamination is ever suspected: bump the cache key suffix (e.g., `sccache-windows-cuda-v2-...`). Full miss next run, fresh state.
 
+### The bump commit must be on `main` before the tag is pushed
+
+Enforced by `require_version_match` in `release-engine.yml`: a tag whose version
+does not equal `engine/Cargo.toml`'s fails in seconds and blocks `release`, so
+nothing is published. Learned from v0.6.43, which was tagged one merge before
+its bump: nine binaries went out answering `0.6.42` to `-V`, and the release
+also missed the last fix that was supposed to be in it. Nothing failed at the
+time and nothing looked wrong on the release page.
+
+A published tag is not moved to fix this. The release page and its checksums
+are already in users' hands; ship the next patch version and say in
+`CHANGELOG.md` what the mis-tagged one actually contains.
+
 ### Every release updates `CHANGELOG.md` (MANDATORY)
 
 Before pushing a `EuLLM-v*` tag, add the version's section to `CHANGELOG.md`.

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -122,6 +122,41 @@ jobs:
             sleep 30
           done
 
+  # ── Gate: the tag must name the version the crate actually reports ──────────
+  #
+  # A tag is pushed by hand, and the version bump is a separate commit. Get the
+  # order wrong and the release publishes binaries that answer with the previous
+  # version: v0.6.43 shipped nine binaries reporting 0.6.42, because the bump
+  # landed one merge after the tag. Nothing failed, nothing looked wrong, and
+  # the mismatch is only visible by running `-V` on a downloaded artifact.
+  #
+  # Deliberately cheap and first: it finishes in seconds, so a bad tag is red
+  # long before the long-pole builds are done and can be deleted and re-pushed
+  # (the workflow's concurrency group cancels the stale run). Like
+  # require_green_ci it gates `release` only — compiling from a mis-tagged
+  # commit wastes nothing that matters, publishing from one does.
+  require_version_match:
+    name: Require the tag to match engine/Cargo.toml
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Compare the tag with the crate version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          want="${TAG#EuLLM-v}"
+          want="${want#engine-v}"
+          # Anchored: a dependency's version is `foo = { version = "…" }` or
+          # `foo = "…"`, never a line starting with `version`.
+          have=$(grep -m1 '^version = ' engine/Cargo.toml | cut -d'"' -f2)
+          echo "tag says $want, engine/Cargo.toml says $have"
+          if [ "$want" != "$have" ]; then
+            echo "::error::Tag $TAG does not match engine/Cargo.toml ($have). Bump the version, merge it to main, and tag that commit. Delete this tag and push it again once the bump is in: git tag -d $TAG && git push origin :refs/tags/$TAG"
+            exit 1
+          fi
+
   build:
     # Manual dispatch is for testing build-arm-cix-p1 in isolation - skip
     # the rest of the matrix there.
@@ -885,6 +920,7 @@ jobs:
   release:
     needs:
       - require_green_ci
+      - require_version_match
       - build
       - build-cuda
       - build-cuda-arm64
@@ -905,7 +941,8 @@ jobs:
     if: >-
       ${{ !cancelled()
           && github.event_name == 'push'
-          && needs.require_green_ci.result == 'success' }}
+          && needs.require_green_ci.result == 'success'
+          && needs.require_version_match.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
…rsion

v0.6.43 was tagged one merge before its version bump, so nine binaries were published answering 0.6.42 to `-V`, and the release also missed the last fix it was meant to carry. Nothing failed and the release page looked normal; the mismatch was only visible by running a downloaded artifact.

A new require_version_match job compares the tag against engine/Cargo.toml and gates `release`, alongside require_green_ci. It runs in seconds, so a bad tag goes red long before the long-pole builds finish and can be deleted and re-pushed while they are still running.

Gates publishing only, not the builds: compiling from a mis-tagged commit wastes nothing that matters.