### PR TITLE
chore: release 0.6.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries for **0.6.36 and later** are written by hand. Everything below that is
 derived from the commit history and reads like it: useful for tracing when
 something changed, less so for understanding what it means.
 
-## 0.6.46 — 2026-07-28
+## 0.6.47 — 2026-07-28
 
 ### Added
 - **A Vulkan binary, `eullm-linux-x64-vulkan`.** Until now the published GPU
@@ -23,10 +23,11 @@ something changed, less so for understanding what it means.
   machine (mesa RADV, amdvlk, NVIDIA, Intel ANV) and `libvulkan.so.1`; nothing
   is bundled, unlike the CUDA builds which ship their runtime. First community
   run: a Ryzen AI 9 HX 470 with Radeon 890M, all layers offloaded.
-- **Image and audio input now work on a build from source.** Multimodal is a
-  default feature, so `cargo build --release --features vulkan` (or cuda, or
-  rocm) gets it without asking. Every published binary already had it; only
-  hand-built ones did not.
+
+  0.6.46 announced this binary and did not ship it: the build job failed on a
+  package that does not exist on the distribution the release is built on, and
+  the release published the other nine binaries without it. This is the version
+  that actually has it.
 
 ### Fixed
 - **A model you pulled yourself now appears in the model lists.** Both
@@ -37,6 +38,16 @@ something changed, less so for understanding what it means.
   endpoint names, so one it never names cannot be selected at all. Reported by
   a user whose pulled 35B ran fine in the chat UI and could not be reached from
   the editor.
+
+## 0.6.46 — 2026-07-28
+
+### Added
+- **Image and audio input now work on a build from source.** Multimodal is a
+  default feature, so `cargo build --release --features vulkan` (or cuda, or
+  rocm) gets it without asking. Every published binary already had it; only
+  hand-built ones did not.
+
+### Fixed
 - **A build that cannot read media says so instead of ignoring it.** Attaching
   a photo to a binary compiled without multimodal support used to drop the
   image on the way in and pass the question through as plain text, so the model

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.46"
+version = "0.6.47"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.46"
+version = "0.6.47"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"


### PR DESCRIPTION
Two entries move here from 0.6.46, which announced them without shipping them: the Vulkan binary, whose build job failed on a package the release runner's distribution does not have, and the model-list fix, which landed one commit after that tag. The 0.6.46 note now says which of the two it actually carried.

The Vulkan toolchain was validated on a manual dispatch before this bump rather than by tagging and finding out.