### PR TITLE
feat(engine): use a projector found beside the weights, and add --mmproj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,21 @@ something changed, less so for understanding what it means.
   the release published the other nine binaries without it. This is the version
   that actually has it.
 
+### Added
+- **A projector next to the weights is found on its own, and `--mmproj` names
+  one that is not.** Vision and audio models only worked when pulled from the
+  catalog: the projector was looked up by model id inside the model store, so a
+  GGUF you downloaded yourself could never be multimodal, whatever sat beside
+  it. A file called `mmproj*.gguf` in the same folder as the weights is now
+  used automatically — the layout every HuggingFace vision repo ships — and
+  `--mmproj <path>` covers the case where the two live apart. Available on both
+  `run` and `serve`.
+
 ### Fixed
+- **Asking a text-only model for an image now says what to do about it.** The
+  refusal read "engine is in batched (text-only) mode", which is true and
+  useless: it named an internal mode rather than the missing projector. It now
+  names the model, and says both ways to get one.
 - **A model you pulled yourself now appears in the model lists.** Both
   `/v1/models` and `/api/tags` were assembled from the built-in catalog and
   whatever was loaded at that moment, so a model downloaded from a URL or a

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -117,6 +117,10 @@ pub struct AppState {
     /// and so the posture is logged before the first fetch rather than after.
     pub web_policy: crate::tools::guard::WebPolicy,
 
+    /// Projector to fall back on when the model being loaded declares none
+    /// of its own, from `serve --mmproj`. Normally `None`.
+    pub fallback_mmproj: Option<PathBuf>,
+
     /// Whether a request's `model` field may name an arbitrary filesystem
     /// path. Off by default — see `resolve_model`.
     pub allow_model_paths: bool,
@@ -212,7 +216,25 @@ impl AppState {
         // declares one. Presence of a projector is the signal that this is
         // a multimodal model — we then force sequential loading (next step)
         // because the continuous-batching scheduler is text-only.
-        let mmproj_path = self.store.mmproj_path(&normalized);
+        // A projector beside the weights counts too: that is how every
+        // HuggingFace vision repo is laid out, and a model resolved from a
+        // path has no store entry to declare one. `--mmproj` is the last
+        // resort, and it is logged loudly because pairing a projector with
+        // weights it was not trained on produces confident nonsense rather
+        // than an error.
+        let mmproj_path = self
+            .store
+            .mmproj_path(&normalized)
+            .or_else(|| crate::models::store::mmproj_beside(&gguf_path))
+            .or_else(|| {
+                self.fallback_mmproj.clone().inspect(|p| {
+                    tracing::warn!(
+                        "no projector of its own for {}; using --mmproj {}",
+                        crate::audit::sanitize_for_log(&normalized),
+                        p.display()
+                    );
+                })
+            });
         if let Some(ref p) = mmproj_path {
             tracing::info!("Multimodal model detected — mmproj: {}", p.display());
         }
@@ -494,6 +516,8 @@ fn normalize_model_name(name: &str) -> String {
 /// Configuration for starting the API server.
 pub struct ServeConfig {
     pub port: u16,
+    /// See `AppState::fallback_mmproj`.
+    pub mmproj: Option<PathBuf>,
     pub model_name: Option<String>,
     pub engine: Option<Arc<InferenceEngine>>,
     pub scheduler: Option<SchedulerHandle>,
@@ -639,6 +663,7 @@ pub async fn serve(cfg: ServeConfig) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let state = Arc::new(AppState {
+        fallback_mmproj: cfg.mmproj.clone(),
         slot: tokio::sync::RwLock::new(ModelSlot {
             model_name: cfg.model_name,
             engine: cfg.engine,

--- a/engine/src/api/routes.rs
+++ b/engine/src/api/routes.rs
@@ -868,7 +868,10 @@ async fn chat(
         return Err((
             StatusCode::NOT_IMPLEMENTED,
             Json(json!({
-                "error": "This build has no multimodal support, so the attached media cannot be                           read. The published binaries include it; a build from source needs                           `--features multimodal` (combine it with a backend, e.g.                           `--features \"vulkan,multimodal\"`)."
+                "error": "This build has no multimodal support, so the attached media cannot be read. \
+                          The published binaries include it; a build from source needs \
+                          `--features multimodal` (combine it with a backend, e.g. \
+                          `--features \"vulkan,multimodal\"`)."
             })),
         ));
     }
@@ -887,8 +890,14 @@ async fn chat(
                 return Err((
                     StatusCode::SERVICE_UNAVAILABLE,
                     Json(json!({
-                        "error": "Multimodal request but engine is in batched (text-only) mode \
-                                 — the loaded model has no mmproj projector."
+                        "error": format!(
+                            "`{}` has no multimodal projector, so it cannot read images or audio. \
+                             Either use a model that ships one — `eullm pull gemma-4-e4b` fetches \
+                             the weights and the projector together — or point at a projector you \
+                             already have with `--mmproj <path>`. A projector found next to the \
+                             weights as `mmproj*.gguf` is picked up on its own.",
+                            snap.model_name
+                        )
                     })),
                 ));
             }

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -249,6 +249,18 @@ enum Commands {
         /// for that.
         #[arg(long)]
         rust_debug: bool,
+
+        /// Path to a multimodal projector (mmproj GGUF) for this model.
+        ///
+        /// Normally unnecessary: a model pulled from the catalog gets its
+        /// projector alongside the weights, and one sitting next to the GGUF
+        /// as `mmproj*.gguf` is picked up on its own. Needed when the two
+        /// live apart, which is common for a model assembled by hand from a
+        /// HuggingFace repo. A projector belongs to the model it was trained
+        /// with: pairing it with different weights produces confident
+        /// nonsense rather than an error.
+        #[arg(long, value_name = "PATH")]
+        mmproj: Option<PathBuf>,
     },
     /// List locally available models
     List,
@@ -396,6 +408,17 @@ enum Commands {
         /// See `eullm run --help` for the full rationale.
         #[arg(long)]
         rust_debug: bool,
+
+        /// Fallback multimodal projector (mmproj GGUF) for models that do not
+        /// carry one of their own.
+        ///
+        /// Only used when the model being loaded has no projector in the
+        /// store and none beside its weights. A projector belongs to the
+        /// model it was trained with, so on a server that swaps between
+        /// models this is a last resort for one you know needs it, not a
+        /// default to leave on — the pairing is logged whenever it applies.
+        #[arg(long, value_name = "PATH")]
+        mmproj: Option<PathBuf>,
     },
     /// Unload the currently loaded model from a running eullm server,
     /// freeing its VRAM — without restarting the server.
@@ -571,6 +594,7 @@ async fn main() {
                 pidfile: DEFAULT_PIDFILE.into(),
                 image: None,
                 rust_debug: false,
+                mmproj: None,
             },
             Some(picker::Picked::Catalog(entry)) => Commands::Run {
                 model: Some(entry.id.clone()),
@@ -599,6 +623,7 @@ async fn main() {
                 pidfile: DEFAULT_PIDFILE.into(),
                 image: None,
                 rust_debug: false,
+                mmproj: None,
             },
             Some(picker::Picked::Url(_url)) => {
                 eprintln!(
@@ -655,6 +680,7 @@ async fn main() {
             pidfile,
             image,
             rust_debug,
+            mmproj,
         } => {
             // `eullm run` with no model → picker, dispatch back through the same Run.
             let model = match model {
@@ -743,6 +769,7 @@ async fn main() {
                 open_chat,
                 image,
                 rust_debug,
+                mmproj,
             )
             .await;
         }
@@ -771,6 +798,7 @@ async fn main() {
             daemon,
             pidfile,
             rust_debug,
+            mmproj,
         } => {
             let _ = (daemon, pidfile);
             if cpu_moe && n_cpu_moe > 0 {
@@ -816,6 +844,7 @@ async fn main() {
                 ctx_checkpoints,
                 checkpoint_min_step,
                 rust_debug,
+                mmproj,
             )
             .await;
         }
@@ -1635,6 +1664,7 @@ async fn cmd_run(
     open_chat: bool,
     image: Option<PathBuf>,
     rust_debug: bool,
+    mmproj: Option<PathBuf>,
 ) {
     // `--image` is a one-shot multimodal probe: load, send the bytes + prompt,
     // print the output, exit. Forces sequential mode (the scheduler does not
@@ -1659,6 +1689,9 @@ async fn cmd_run(
     // `api::AppState::launch_model`) because `gguf_path` itself is moved into
     // the loader.
     let launch_gguf_path: Option<PathBuf>;
+    // Carried out of the load block so the API can keep it as the fallback
+    // projector for a later model swap.
+    let mut api_mmproj: Option<PathBuf> = None;
     let mut engine: Option<Arc<InferenceEngine>> = None;
     let mut scheduler: Option<inference::SchedulerHandle> = None;
     let mut n_ctx_train: u32 = 0;
@@ -1769,12 +1802,19 @@ async fn cmd_run(
         // alongside the GGUF). On text-only builds the value is read but
         // ignored at InferenceConfig level; on multimodal builds it is
         // what enables `generate_multimodal`.
-        let mmproj_for_config = store
-            .mmproj_path(&model_name)
-            .or_else(|| store.mmproj_path(model)); // also try the user-typed id
+        // Order of precedence, most explicit first: what the user named, what
+        // the store recorded when the model was pulled, and finally a
+        // projector sitting next to the weights — the layout of every
+        // HuggingFace vision repo, and the case that used to be unreachable.
+        let mmproj_for_config = mmproj
+            .clone()
+            .or_else(|| store.mmproj_path(&model_name))
+            .or_else(|| store.mmproj_path(model))
+            .or_else(|| crate::models::store::mmproj_beside(&gguf_path));
         if let Some(ref p) = mmproj_for_config {
             println!("Found mmproj: {}", p.display());
         }
+        api_mmproj = mmproj_for_config.clone();
 
         let config = InferenceConfig {
             model_path: gguf_path,
@@ -2031,6 +2071,9 @@ async fn cmd_run(
     tokio::spawn(async move {
         if let Err(e) = api::serve(api::ServeConfig {
             port,
+            // `run` resolves the projector itself and hands the loaded engine
+            // over; this is only the fallback for a later swap.
+            mmproj: api_mmproj,
             model_name: Some(api_model_name),
             engine,
             scheduler,
@@ -2112,6 +2155,7 @@ async fn cmd_serve(
     ctx_checkpoints: usize,
     checkpoint_min_step: u32,
     rust_debug: bool,
+    mmproj: Option<PathBuf>,
 ) {
     ensure_port_available(port, replace).await;
     if let Some(p) = ui_port {
@@ -2135,6 +2179,7 @@ async fn cmd_serve(
 
     if let Err(e) = api::serve(api::ServeConfig {
         port,
+        mmproj,
         model_name: None,
         engine: None,
         scheduler: None,

--- a/engine/src/models/store.rs
+++ b/engine/src/models/store.rs
@@ -72,6 +72,27 @@ pub struct ModelStore {
     root: PathBuf,
 }
 
+/// Find a multimodal projector sitting next to a GGUF file.
+///
+/// `ModelStore::mmproj_path` only looks inside the store, keyed by model id, so
+/// a model run straight from a path — `eullm run ./gemma-4-12b-Q4.gguf`, or
+/// anything pulled from a URL — could never be multimodal however many
+/// `mmproj-F16.gguf` files sat in the same folder. That is also the layout
+/// every HuggingFace vision repo ships, and what llama.cpp users expect to
+/// work.
+pub fn mmproj_beside(gguf: &Path) -> Option<PathBuf> {
+    let dir = gguf.parent()?;
+    let entries = fs::read_dir(dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path.file_name()?.to_str()?.to_ascii_lowercase();
+        if name.starts_with("mmproj") && name.ends_with(".gguf") {
+            return Some(path);
+        }
+    }
+    None
+}
+
 /// Write a file so a reader never sees it half-written.
 ///
 /// `fs::write` truncates first and writes after, so a process that dies in


### PR DESCRIPTION
A vision model only worked if it came from our catalog. The projector was resolved through the model store, keyed by model id, so a GGUF downloaded by hand could never be multimodal no matter how many mmproj files sat next to it — and running one produced a refusal that named an internal loader mode instead of the missing projector.

- `mmproj*.gguf` beside the weights is picked up automatically. That is the layout every HuggingFace vision repo ships and what llama.cpp users expect.
- `--mmproj <path>` for when the two live apart, on `run` and on `serve` per the flag-parity rule. On `serve` it is a fallback for models that declare none of their own, and applying it is logged: a projector paired with weights it was not trained on produces confident nonsense, not an error.
- The refusal names the model and both ways to fix it (issue #286).