### PR TITLE
fix(engine): say what did not fit when a context cannot be allocated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Entries for **0.6.36 and later** are written by hand. Everything below that is
 derived from the commit history and reads like it: useful for tracing when
 something changed, less so for understanding what it means.
 
+## 0.6.51 — 2026-07-28
+
+### Fixed
+- **A context that does not fit says what did not fit.** Asking for a large
+  `--ctx-size` and getting `Failed to create context: null reference from
+  llama.cpp` told you nothing: the window was the thing that failed, and its
+  cost was on screen two lines earlier. The error now names the window, the
+  memory its KV cache needs, and the two flags that change it. Seen with
+  `--ctx-size 131072` on a 4B model, where the cache alone wants about 17 GB.
+
 ## 0.6.50 — 2026-07-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.50"
+version = "0.6.51"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.50"
+version = "0.6.51"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -871,6 +871,23 @@ pub struct InferenceEngine {
 unsafe impl Send for InferenceEngine {}
 unsafe impl Sync for InferenceEngine {}
 
+/// Explain a failed context allocation in terms of what the user chose.
+///
+/// llama.cpp answers a KV cache that does not fit with a null pointer, which
+/// reaches the client as "Failed to create context: null reference from
+/// llama.cpp" — true, and useless. The window and the memory it costs are
+/// both known here, and the flag that changes them is the one the user just
+/// set. Seen with `--ctx-size 131072` on a 4B model: 17 GB of KV cache, an
+/// allocation that could not be served, and nothing on screen connecting the
+/// three.
+fn context_alloc_error(err: &impl std::fmt::Display, ctx_size: u32, kv_mib: f64) -> String {
+    format!(
+        "could not allocate a context of {ctx_size} tokens: {err}. Its KV cache alone needs about \
+         {kv_mib:.0} MiB, which did not fit. Lower it with --ctx-size, or halve the cache with \
+         --cache-type-k q8_0 --cache-type-v q8_0."
+    )
+}
+
 impl InferenceEngine {
     /// The same load-time facts the scheduler reports, for the sequential
     /// path. Without this the startup banner silently prints less depending
@@ -1279,8 +1296,17 @@ impl InferenceEngine {
                 }
             }
             Err(e) => {
-                let _ =
-                    tx.blocking_send(StreamEvent::Error(format!("Failed to create context: {e}")));
+                let info = crate::inference::scheduler::estimate_kv_memory(
+                    &self.model,
+                    u64::from(self.config.context_size),
+                    &self.config.cache_type_k,
+                    &self.config.cache_type_v,
+                );
+                let _ = tx.blocking_send(StreamEvent::Error(context_alloc_error(
+                    &e,
+                    self.config.context_size,
+                    info.kv_k_mib + info.kv_v_mib,
+                )));
                 return;
             }
         };
@@ -1580,8 +1606,17 @@ impl InferenceEngine {
                 }
             }
             Err(e) => {
-                let _ =
-                    tx.blocking_send(StreamEvent::Error(format!("Failed to create context: {e}")));
+                let info = crate::inference::scheduler::estimate_kv_memory(
+                    &self.model,
+                    u64::from(self.config.context_size),
+                    &self.config.cache_type_k,
+                    &self.config.cache_type_v,
+                );
+                let _ = tx.blocking_send(StreamEvent::Error(context_alloc_error(
+                    &e,
+                    self.config.context_size,
+                    info.kv_k_mib + info.kv_v_mib,
+                )));
                 return;
             }
         };


### PR DESCRIPTION
`--ctx-size 131072` on a 4B model produced "Failed to create context: null reference from llama.cpp" on every request. True and useless: llama.cpp answers an oversized KV cache with a null pointer, and we passed that through verbatim. The banner two lines earlier had already printed the cost — K=8704 MiB, V=8704 MiB — and nothing connected the two.

The error now names the window that failed, the memory its cache needs, and the flags that change it: --ctx-size, or q8_0 KV to halve it. Same message on the text and multimodal paths, which had separate copies of the opaque one.

Release 0.6.51.