### PR TITLE
fix(cli): --cli and --no-ui killed the engine on a sequentially loade…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ something changed, less so for understanding what it means.
 ## 0.6.51 — 2026-07-28
 
 ### Fixed
+- **`--cli` and `--no-ui` no longer make the engine exit immediately.** On a
+  model that loads in sequential mode — every multimodal model, and anything
+  run with `--batch-size 0` — asking to stay in the terminal printed "Type a
+  message to chat" and then quit without a word, taking the API server with it.
+  The terminal chat needs the batching scheduler, which those models do not
+  have. The engine now stays up and serves the API, and says plainly that the
+  terminal chat is unavailable for this model instead of promising it.
 - **A context that does not fit says what did not fit.** Asking for a large
   `--ctx-size` and getting `Failed to create context: null reference from
   llama.cpp` told you nothing: the window was the thing that failed, and its

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -2116,13 +2116,29 @@ async fn cmd_run(
     let has_backend = engine.is_some() || scheduler.is_some();
     let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdin());
 
+    // The REPL is driven by the scheduler, and a sequentially loaded model has
+    // none: every multimodal model, and anything run with --batch-size 0. That
+    // was not accounted for, so `--cli` and `--no-ui` on such a model printed
+    // "Type a message to chat", found no scheduler to hand the REPL, fell out
+    // of the branch, and ended `main` — killing the API server that had just
+    // been spawned. The engine started and exited with no error at all.
+    let repl_possible = has_backend && is_tty && !open_chat && repl_scheduler.is_some();
+
     // Banner must match what we're actually about to do (see REPL launch
     // condition below: `has_backend && is_tty && !open_chat`). If the browser
     // chat is going to take over, telling the user to "Type a message" in
     // this terminal is a lie.
-    if has_backend && is_tty && !open_chat {
+    if repl_possible {
         println!("Type a message to chat, /bye to quit.\n");
     } else {
+        if has_backend && is_tty && !open_chat {
+            // Asked for the terminal, cannot have it. Say which, and why.
+            println!(
+                "Interactive chat is not available for this model: it loads in sequential mode\n\
+                 (every multimodal model does, as does --batch-size 0) and the terminal chat\n\
+                 needs the batching scheduler. The API below is fully functional."
+            );
+        }
         println!("Press Ctrl+C to stop.\n");
     }
 
@@ -2189,7 +2205,7 @@ async fn cmd_run(
     // user is chatting there — the REPL would just compete for the same model
     // on the same line discipline. Only drop into the REPL when the browser
     // was suppressed (--cli / --no-chat) or unavailable (--no-ui).
-    if has_backend && is_tty && !open_chat {
+    if repl_possible {
         if let Some(sched) = repl_scheduler {
             interactive_chat(sched, &model_name, ctx_size, batch_size, web).await;
         }


### PR DESCRIPTION
…d model

Reported from a session that started and exited with no error: the API was not listening and no process remained.

The terminal REPL is driven by the scheduler. A multimodal model loads in sequential mode and has none, so with `--cli` or `--no-ui` the code entered the REPL branch, found `repl_scheduler` empty, did nothing, and fell off the end of `main` — which killed the API server spawned moments earlier. It had already printed "Type a message to chat" one line above.

The condition now includes the scheduler, so a model that cannot host the REPL waits on ctrl_c like any headless run, and the banner says the terminal chat is unavailable for this model rather than offering it.

Diagnosed after two wrong guesses of mine (a port conflict, then the wrong flag); `ps` and `ss` showed nothing listening, which is what sent me to the branch instead of the environment.