### PR TITLE
fix(ci): drop --strict from pip-audit, it fails on our own package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,9 +246,20 @@ jobs:
         # upgrade the pinned floor in `pyproject.toml`, or — when no fixed
         # release exists yet — to add `--ignore-vuln <ID>` here with the reason
         # and the date, so it is reviewed later instead of disappearing.
+        #
+        # Not `--strict`. That flag fails the audit when *any* package cannot be
+        # collected, and `pip install -e .` puts `eullm-forge` itself in the
+        # environment — a package that is not on PyPI and never will be. The
+        # first run failed on exactly that, with "Dependency not found on PyPI",
+        # which is a true statement about our own source tree and not a finding.
+        # `--skip-editable` does not rescue it: measured, a deliberately skipped
+        # package still fails `--strict`. Dropping `--strict` costs nothing that
+        # matters here — a vulnerability in a real dependency still exits
+        # non-zero — and only means an unauditable package is reported instead
+        # of fatal.
         run: |
           pip install pip-audit==2.10.1
-          pip-audit --strict --desc
+          pip-audit --desc --skip-editable
 
   # ── Windows installer pre-flight (FAST, <2 min, runs on every push) ──
   # Installer preflight removed in v0.5.7 alongside the installer build


### PR DESCRIPTION
The audit step added yesterday turned CI red on the first tagged commit that ran it. Not a vulnerability: --strict fails the audit when any package cannot be collected, and pip install -e . puts eullm-forge in the environment, which is not on PyPI and never will be. The error read "Dependency not found on PyPI and could not be audited: eullm-forge", a true statement about our own source tree.

--skip-editable does not fix it. Measured in a clean virtualenv with an editable package and no vulnerabilities present:

  pip-audit                          exit 0
  pip-audit --strict                 exit 1
  pip-audit --strict --skip-editable exit 1

A deliberately skipped package still fails --strict. So --strict goes and --skip-editable stays, the latter only so the skip line reads "marked as editable" rather than the misleading "not found on PyPI".

Nothing that matters is lost: --strict governs collection failures, not detection, and a vulnerability in a real dependency still exits non-zero. The cost is that a dependency which becomes unauditable is reported rather than fatal.

This blocked the 0.6.60-rc1 release: require_green_ci names needs.require_green_ci.result == 'success' explicitly, so the gate held and the builds were not published - which is the gate working, and why the tag carries only its source archives.