### PR TITLE
fix(engine): probe the context multimodal requests will actually use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,23 @@ Entries for **0.6.36 and later** are written by hand. Everything below that is
 derived from the commit history and reads like it: useful for tracing when
 something changed, less so for understanding what it means.
 
-## 0.6.70 — 2026-07-31
+## 0.6.70 — 2026-08-03
 
-*Published so far only as the pre-release `EuLLM-v0.6.70-rc4`. The context
-auto-shrink fix and the llama.cpp bump below have not been run against real
-hardware yet — that is what this pre-release is for. More may accumulate
-under this version before the final release.*
+*Published so far only as the pre-release `EuLLM-v0.6.70-rc5`. More may
+accumulate under this version before the final release.*
+
+### Fixed
+- **The context probe at load time now proves what a real image request will
+  actually need, not a smaller stand-in.** `generate_multimodal` sizes its
+  batch/micro-batch to fit a whole image in one pass — larger than the plain
+  text batch the load-time probe (added earlier in this same pre-release) was
+  using. Found on real hardware, on rc4: a 12B Q8 vision model loaded clean at
+  `--ctx-size 4096` — the probe passed — and then the same OOM the probe
+  exists to catch anyway on the first message with an attached image, because
+  that request's compute buffer was sized differently than the one just
+  proven to fit. The probe now uses the same multimodal batch sizing as the
+  real request whenever an mmproj is configured, so a load-time pass means an
+  image request will actually go through.
 
 ### Changed
 - **Bumped the pinned `llama.cpp` from a commit six weeks old to tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.70-rc4"
+version = "0.6.70-rc5"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -1798,15 +1798,40 @@ diligenza manuale.
   quelle che affermano esplicitamente i default di `use_mmap`/`use_mlock`;
   le 225 unit test di `eullm-engine` passano.
 
-  **Non ancora fatto, ed è la condizione per far uscire una rc**: la
-  validazione su hardware reale richiesta dalla regola appena scritta in
-  CLAUDE.md — ricaricare ogni famiglia di modelli locale, incluso un
-  multimodale e il template di ragionamento DeepSeek, per verificare che il
-  sizing della KV cache (`estimate_kv_memory`, `probe_and_shrink_context`,
-  `correct_kv_cache_for_model`) e i template di chat si comportino ancora
-  come atteso contro il comportamento reale di `b10200`, non solo contro
-  quello di `9e3b928` su cui erano stati scritti e validati.
+  **Validazione su hardware reale iniziata il 3 agosto, su `rc4`**: ha trovato
+  subito un gap reale nel probe di `probe_and_shrink_context` — vedi H3-T,
+  già corretto nella stessa giornata. Restano da ricaricare le altre famiglie
+  di modelli (incluso il template di ragionamento DeepSeek) prima di
+  considerare `0.6.70` pronta per l'uscita definitiva.
 
+- [ ] **H3-T · Il probe del contesto non usava lo stesso sizing della vera
+  richiesta multimodale** *(P2)*
+  Trovato il 3 agosto 2026 testando `rc4` su hardware reale: un modello
+  vision 12B Q8 caricava pulito a `--ctx-size 4096` (il probe di
+  `probe_and_shrink_context` passava), e poi il primo messaggio con
+  un'immagine allegata falliva con lo stesso errore di allocazione che il
+  probe esiste apposta per intercettare — `could not allocate a context of
+  4096 tokens ... Its KV cache alone needs about 3072 MiB`.
+
+  Causa: `generate_multimodal` dimensiona `n_batch`/`n_ubatch` diversamente
+  dal resto — un encoder visivo usa attenzione non causale, quindi l'intera
+  immagine deve entrare in un solo micro-batch (`n_ubatch >= image_tokens`,
+  altrimenti `GGML_ASSERT` va in crash). Questo sizing (`mm_batch`, funzione
+  `multimodal_batch_size`) era più grande di quello usato dal probe a
+  caricamento (`build_ctx_params`, che deriva `n_ubatch` da `config.n_batch`
+  limitato a 1024). Un buffer di calcolo più grande serve più VRAM: il probe
+  provava una richiesta più leggera di quella che una vera immagine avrebbe
+  fatto, quindi "ci sta" a caricamento non garantiva "ci sta" al primo
+  messaggio con immagine — esattamente il divario che la validazione su
+  hardware reale, e non la build pulita, doveva scoprire.
+
+  Fix: `multimodal_batch_size` estratta come funzione condivisa; il probe in
+  `probe_and_shrink_context` ora, quando `config.mmproj_path` è impostato,
+  costruisce i parametri di prova con lo stesso `mm_batch` di
+  `generate_multimodal`, non più con i parametri di testo semplice. Verificato
+  in locale (senza GPU in questo ambiente): `cargo build`/`clippy` puliti con
+  e senza `--features multimodal`, le 225 unit test passano. Da confermare su
+  hardware reale con lo stesso modello che ha esposto il problema, in `rc5`.
 ---
 
 ## Rimandi — voci già coperte dalle roadmap esistenti

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.70-rc4"
+version = "0.6.70-rc5"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -124,6 +124,23 @@ pub fn cpu_features_summary() -> String {
         .into_owned()
 }
 
+/// Vision encoders use NON-causal attention, which requires the entire image
+/// to land in a single micro-batch: `n_ubatch >= image_tokens`. The default
+/// n_ubatch (512, or whatever `build_ctx_params` derives from `config.n_batch`)
+/// silently caps effective image resolution and hard-aborts above it (GGML_ASSERT
+/// "non-causal attention requires n_ubatch >= n_tokens"). Sized to the image
+/// token budget (`EULLM_IMAGE_MAX_TOKENS`) so a higher budget genuinely raises
+/// resolution instead of crashing. Shared between `generate_multimodal`'s real
+/// context and `probe_and_shrink_context`'s probe, which must agree — a probe
+/// built from a smaller batch than the request that follows it proves nothing.
+fn multimodal_batch_size(config: &InferenceConfig) -> u32 {
+    let img_budget = std::env::var("EULLM_IMAGE_MAX_TOKENS")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(0);
+    config.n_batch.max(img_budget).max(512)
+}
+
 /// Build context params with flash attention, n_batch, and KV cache types applied.
 pub(crate) fn build_ctx_params(
     config: &InferenceConfig,
@@ -1041,7 +1058,21 @@ impl InferenceEngine {
                  from 0 above) and is only ever produced by `candidate / 2`, floored at \
                  FLOOR which is nonzero",
             );
-            match model.new_context(backend, build_ctx_params(config, ctx_size)) {
+            // A model loaded with an mmproj gets requests through
+            // `generate_multimodal`, whose context uses `multimodal_batch_size`
+            // instead of `config.n_batch`/`n_ubatch` — larger, since a whole
+            // image must fit in one micro-batch. Probing with the plain text
+            // batch size would prove a compute-buffer requirement smaller than
+            // the one a real image request makes, which is exactly the gap a
+            // 12B Q8 vision model on real hardware exposed: load-time probe
+            // passed, first image sent failed with the same OOM the probe was
+            // built to catch.
+            let mut probe_params = build_ctx_params(config, ctx_size);
+            if config.mmproj_path.is_some() {
+                let mm_batch = multimodal_batch_size(config);
+                probe_params = probe_params.with_n_batch(mm_batch).with_n_ubatch(mm_batch);
+            }
+            match model.new_context(backend, probe_params) {
                 Ok(ctx) => {
                     drop(ctx); // probing fit, not keeping it — see the load()-site comment
                     if candidate < requested {
@@ -1681,19 +1712,9 @@ impl InferenceEngine {
         let has_quantized_cache = self.config.cache_type_k != KvCacheType::F16
             || self.config.cache_type_v != KvCacheType::F16;
 
-        // Vision encoders use NON-causal attention, which requires the entire
-        // image to land in a single micro-batch: `n_ubatch >= image_tokens`.
-        // The default n_ubatch (512) silently caps effective image resolution
-        // and hard-aborts above it (GGML_ASSERT "non-causal attention requires
-        // n_ubatch >= n_tokens"). Size both n_batch and n_ubatch to the image
-        // token budget so a higher EULLM_IMAGE_MAX_TOKENS genuinely raises
-        // resolution instead of crashing. Multimodal-only — text/scheduler
-        // contexts are untouched.
-        let img_budget = std::env::var("EULLM_IMAGE_MAX_TOKENS")
-            .ok()
-            .and_then(|v| v.parse::<u32>().ok())
-            .unwrap_or(0);
-        let mm_batch = self.config.n_batch.max(img_budget).max(512);
+        // See `multimodal_batch_size` — must match what `probe_and_shrink_context`
+        // used to prove this context size fits, or the probe proves nothing.
+        let mm_batch = multimodal_batch_size(&self.config);
         let mk_params = |ctk, ctv| {
             build_ctx_params_with_cache(&self.config, ctx_size, ctk, ctv)
                 .with_n_batch(mm_batch)


### PR DESCRIPTION
Found on real hardware testing rc4: a 12B Q8 vision model loaded clean at --ctx-size 4096 (the load-time probe passed), then the first message with an attached image failed with the exact OOM the probe exists to catch. generate_multimodal sizes n_batch/n_ubatch to fit a whole image in one micro-batch (vision encoders need non-causal attention over the full image), which is larger than the plain text batch the probe was built with - proving a smaller compute buffer requirement than the real request would make.

Extract that sizing into multimodal_batch_size, shared between generate_multimodal and probe_and_shrink_context. The probe now uses it whenever config.mmproj_path is set, so a load-time pass means an image request will actually go through.

Verified locally (no GPU here): cargo build/clippy clean with and without --features multimodal, 225 unit tests pass. Logged as H3-T; still need to confirm on the hardware that found it.