### PR TITLE
fix(engine): stop sizing the multimodal batch off the text n_batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,23 @@ something changed, less so for understanding what it means.
 
 ## 0.6.70 — 2026-08-03
 
-*Published so far only as the pre-release `EuLLM-v0.6.70-rc5`. More may
+*Published so far only as the pre-release `EuLLM-v0.6.70-rc6`. More may
 accumulate under this version before the final release.*
 
 ### Fixed
+- **A multimodal model no longer reserves a compute buffer sized for a
+  2048-token image when the image itself needs a few hundred.** The fix above
+  (probing with the same batch a real image request uses) exposed a second,
+  pre-existing sizing problem: that batch defaulted to the general text
+  prefill batch (`--n-batch`, 2048), not to how many tokens an image actually
+  encodes to. Found immediately after shipping the probe fix, on the same real
+  hardware: a 12B Q8 vision model that needs its context reduced all the way
+  to 1024 to fit, even though Gemma 4's own projector output for that image
+  was ~266 tokens — nowhere near 2048. `EULLM_IMAGE_MAX_TOKENS` still raises
+  this explicitly for higher-resolution images; absent that, the floor is now
+  512 (comfortably above a typical single image slice) instead of following
+  the text batch size upward. Every multimodal model gets a meaningfully
+  larger usable context as a result.
 - **The context probe at load time now proves what a real image request will
   actually need, not a smaller stand-in.** `generate_multimodal` sizes its
   batch/micro-batch to fit a whole image in one pass — larger than the plain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.70-rc5"
+version = "0.6.70-rc6"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -1832,6 +1832,26 @@ diligenza manuale.
   in locale (senza GPU in questo ambiente): `cargo build`/`clippy` puliti con
   e senza `--features multimodal`, le 225 unit test passano. Da confermare su
   hardware reale con lo stesso modello che ha esposto il problema, in `rc5`.
+
+  **Confermato su hardware reale in `rc5`, il 3 agosto**: niente più crash al
+  primo messaggio con immagine, a `--ctx-size 4096` e a `16384` — in entrambi i
+  casi il probe scende in modo consistente fino a `1024`, che è quindi il vero
+  tetto trovato, non un artefatto del valore di partenza. Ma `1024` si è
+  rivelato troppo stretto per una chat multi-turno con immagine (risposte
+  tagliate a metà frase per esaurimento del contesto condiviso — vedi i log
+  con `num_predict capped`), e ha esposto un **secondo problema**, distinto da
+  quello che questa voce descriveva in origine: `mm_batch` di default seguiva
+  `--n-batch` (2048, il batch di testo), non la reale dimensione in token
+  dell'immagine (~266 per una slice di Gemma 4, verificato dal log
+  `n_tokens_batch = 266` dello stesso caricamento). Un buffer di calcolo
+  dimensionato per 2048 token quando ne servono ~266 schiacciava la KV cache
+  ben oltre il necessario. Corretto in `rc6`: `multimodal_batch_size` non
+  dipende più da `config.n_batch` — usa `EULLM_IMAGE_MAX_TOKENS` se impostata,
+  altrimenti il pavimento di 512 già previsto. Da confermare su hardware reale
+  quanto sale il tetto rispetto a `1024`, e se resta un divario rispetto ai
+  16k che `llama-cli`/`llama-server` gestiscono sullo stesso modello — divario
+  non ancora spiegato del tutto (vedi la sessione di debug comparativo di
+  prima di questo bump, mai conclusa).
 ---
 
 ## Rimandi — voci già coperte dalle roadmap esistenti

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.70-rc5"
+version = "0.6.70-rc6"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -125,20 +125,26 @@ pub fn cpu_features_summary() -> String {
 }
 
 /// Vision encoders use NON-causal attention, which requires the entire image
-/// to land in a single micro-batch: `n_ubatch >= image_tokens`. The default
-/// n_ubatch (512, or whatever `build_ctx_params` derives from `config.n_batch`)
-/// silently caps effective image resolution and hard-aborts above it (GGML_ASSERT
-/// "non-causal attention requires n_ubatch >= n_tokens"). Sized to the image
-/// token budget (`EULLM_IMAGE_MAX_TOKENS`) so a higher budget genuinely raises
-/// resolution instead of crashing. Shared between `generate_multimodal`'s real
-/// context and `probe_and_shrink_context`'s probe, which must agree — a probe
-/// built from a smaller batch than the request that follows it proves nothing.
-fn multimodal_batch_size(config: &InferenceConfig) -> u32 {
+/// to land in a single micro-batch: `n_ubatch >= image_tokens`. Sized to the
+/// image token budget (`EULLM_IMAGE_MAX_TOKENS`) so a higher budget genuinely
+/// raises resolution instead of hard-aborting (GGML_ASSERT "non-causal
+/// attention requires n_ubatch >= n_tokens"). Deliberately NOT derived from
+/// `config.n_batch` (the text prefill batch, 2048 by default): that batch size
+/// has nothing to do with how many tokens one image encodes to (Gemma 4's clip
+/// output is ~256-300 tokens per slice — verified against a real load's
+/// `n_tokens_batch` log line), and reserving a compute buffer sized for a
+/// 2048-token micro-batch by default squeezed the KV cache — and so n_ctx —
+/// far more than any single image actually required. 512 is the floor,
+/// comfortably above a typical single-slice image. Shared between
+/// `generate_multimodal`'s real context and `probe_and_shrink_context`'s
+/// probe, which must agree — a probe built from a smaller batch than the
+/// request that follows it proves nothing.
+fn multimodal_batch_size() -> u32 {
     let img_budget = std::env::var("EULLM_IMAGE_MAX_TOKENS")
         .ok()
         .and_then(|v| v.parse::<u32>().ok())
         .unwrap_or(0);
-    config.n_batch.max(img_budget).max(512)
+    img_budget.max(512)
 }
 
 /// Build context params with flash attention, n_batch, and KV cache types applied.
@@ -1069,7 +1075,7 @@ impl InferenceEngine {
             // built to catch.
             let mut probe_params = build_ctx_params(config, ctx_size);
             if config.mmproj_path.is_some() {
-                let mm_batch = multimodal_batch_size(config);
+                let mm_batch = multimodal_batch_size();
                 probe_params = probe_params.with_n_batch(mm_batch).with_n_ubatch(mm_batch);
             }
             match model.new_context(backend, probe_params) {
@@ -1714,7 +1720,7 @@ impl InferenceEngine {
 
         // See `multimodal_batch_size` — must match what `probe_and_shrink_context`
         // used to prove this context size fits, or the probe proves nothing.
-        let mm_batch = multimodal_batch_size(&self.config);
+        let mm_batch = multimodal_batch_size();
         let mk_params = |ctk, ctv| {
             build_ctx_params_with_cache(&self.config, ctx_size, ctk, ctv)
                 .with_n_batch(mm_batch)


### PR DESCRIPTION
multimodal_batch_size defaulted to config.n_batch (2048, the text prefill batch) whenever EULLM_IMAGE_MAX_TOKENS wasn't set, even though that value has nothing to do with how many tokens an image actually encodes to. Found immediately after shipping the previous probe fix, on the same real hardware: a 12B Q8 vision model needed --ctx-size reduced all the way to 1024 to fit, even though the image's own projector output was ~266 tokens - nowhere near 2048. The oversized compute buffer this reserved was squeezing the KV cache far more than any single image required, making multi-turn multimodal chat cut off mid-response from context exhaustion.

multimodal_batch_size no longer takes n_batch into account at all: it uses EULLM_IMAGE_MAX_TOKENS if set, otherwise the existing 512 floor, which comfortably covers a typical single image slice.

Verified locally (no GPU here): cargo build/clippy clean with and without --features multimodal, 225 unit tests pass. Confirmation that this actually raises the usable context on the hardware that found the problem is still pending.