### PR TITLE
fix(engine): make --cli use the same chat template decision as the we…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,22 @@ something changed, less so for understanding what it means.
 
 ## 0.6.70 — 2026-08-05
 
-*Published so far only as the pre-release `EuLLM-v0.6.70-rc9`. The dynamic
+*Published so far only as the pre-release `EuLLM-v0.6.70-rc10`. The dynamic
 chat template further up has not been re-validated across every known model
 family yet — that is what this pre-release is for. More may accumulate
 under this version before the final release.*
 
 ### Fixed
+- **`eullm run --cli` answered differently than the browser chat for the
+  identical model and question.** The dynamic GGUF chat template added
+  earlier in this version only reached the web/API chat handlers; the
+  terminal chat built its prompt exactly as before, always through the
+  hardcoded per-family template. Two doors onto the same loaded model
+  deciding differently depending only on which one was used to ask. `--cli`
+  now goes through the same decision (`build_cli_prompt`, mirroring
+  `api::routes::build_chat_prompt`): the model's own embedded template first
+  in sequential mode, the hardcoded fallback otherwise — identically to the
+  browser chat.
 - **A context that barely fit at load time could crash outright — not just
   fail cleanly — on the very first real request.** Found on real hardware
   running rc8: `--ctx-size 65536` reduced to 4096 with no warning of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.70-rc9"
+version = "0.6.70-rc10"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -1915,11 +1915,24 @@ diligenza manuale.
 
   Verificato in locale (senza GPU in questo ambiente): `cargo build`/
   `clippy` puliti con e senza `--features multimodal`, le 225 unit test
-  passano. **Non ancora verificato su hardware reale** — né che il fix
-  risolva davvero la risposta di `gemma-4-12b-q8`, né che non cambi
-  comportamento sugli altri modelli già validati (DeepSeek R1, Qwen3) se
-  anche i loro GGUF portano un template incorporato che ora prende il posto
-  di quello scritto a mano per loro.
+  passano. **Confermato su hardware reale il 5 agosto** per i messaggi di
+  solo testo via chat web: la risposta ora mostra il blocco di ragionamento
+  reale del template, coerente con quanto osservato su `llama-server`.
+
+  **Incoerenza trovata lo stesso giorno**: il fix copriva solo `routes.rs`
+  (chat web/API) — `eullm run --cli` continuava a costruire il prompt col
+  solo template hardcoded, invariato, quindi la stessa domanda allo stesso
+  modello dava risposte diverse a seconda della porta usata per chiederla.
+  Corretto con `build_cli_prompt` in `main.rs`, che rispecchia esattamente
+  `api::routes::build_chat_prompt` (stessa politica: template dinamico solo
+  in modalità sequenziale, altrimenti il fallback hardcoded).
+
+  Resta da confermare su hardware reale che non cambi comportamento sugli
+  altri modelli già validati (DeepSeek R1, Qwen3) se anche i loro GGUF
+  portano un template incorporato che ora prende il posto di quello scritto
+  a mano per loro — e resta non collegata la pulizia della risposta dal
+  blocco di ragionamento (`thinking_start_tag`/`thinking_end_tag`), ancora
+  affidata solo ai filtri Harmony esistenti.
 
 - [x] **H3-V · `probe_and_shrink_context` si ferma al primo tentativo che
   passa, non cerca il vero massimo** *(nice to have)*

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.70-rc9"
+version = "0.6.70-rc10"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -2697,6 +2697,32 @@ impl ChatBackend {
     }
 }
 
+/// Build the prompt (and matching stop sequences) for one `--cli` turn.
+///
+/// Mirrors `api::routes::build_chat_prompt` exactly, on purpose: the web/API
+/// path and this terminal one are two doors onto the same loaded model, and
+/// they must decide the same way or the same conversation answers
+/// differently depending only on which door was used to ask — which is
+/// exactly what happened before this existed (`--cli` never got the dynamic
+/// GGUF template `build_chat_prompt` added for the web/API path). Tries the
+/// model's own embedded chat template first, in sequential mode only (a
+/// batching scheduler has no model reference to call this on); falls back
+/// to the hardcoded per-family `template` otherwise, exactly as `--cli`
+/// always has.
+fn build_cli_prompt(
+    backend: &ChatBackend,
+    template: &chat_template::ChatTemplate,
+    pairs: &[(&str, &str)],
+    think_arg: bool,
+) -> (String, Vec<String>) {
+    if let ChatBackend::Sequential(engine) = backend
+        && let Some(dynamic) = engine.apply_jinja_chat_template(pairs)
+    {
+        return (dynamic.prompt, Vec::new());
+    }
+    (template.build_prompt(pairs, think_arg), template.stop_sequences())
+}
+
 async fn interactive_chat(
     backend: ChatBackend,
     model_name: &str,
@@ -2871,7 +2897,7 @@ async fn interactive_chat(
         // TEMPORARY message list — web content is NOT stored in history so it
         // doesn't accumulate across turns and bloat the context.
         let template = crate::chat_template::ChatTemplate::detect(model_name);
-        let prompt = if web_enabled {
+        let (prompt, stop_sequences) = if web_enabled {
             let urls = crate::tools::extract_urls(&input);
             if !urls.is_empty() {
                 let existing_chars: usize = history.iter().map(|m| m.content.len()).sum();
@@ -2919,27 +2945,27 @@ async fn interactive_chat(
                     tmp.push(history.last().unwrap());
                     let pairs: Vec<(&str, &str)> =
                         tmp.iter().map(|m| (m.role, m.content.as_str())).collect();
-                    template.build_prompt(&pairs, think_arg)
+                    build_cli_prompt(&backend, &template, &pairs, think_arg)
                 } else {
                     let pairs: Vec<(&str, &str)> = history
                         .iter()
                         .map(|m| (m.role, m.content.as_str()))
                         .collect();
-                    template.build_prompt(&pairs, think_arg)
+                    build_cli_prompt(&backend, &template, &pairs, think_arg)
                 }
             } else {
                 let pairs: Vec<(&str, &str)> = history
                     .iter()
                     .map(|m| (m.role, m.content.as_str()))
                     .collect();
-                template.build_prompt(&pairs, think_arg)
+                build_cli_prompt(&backend, &template, &pairs, think_arg)
             }
         } else {
             let pairs: Vec<(&str, &str)> = history
                 .iter()
                 .map(|m| (m.role, m.content.as_str()))
                 .collect();
-            template.build_prompt(&pairs, think_arg)
+            build_cli_prompt(&backend, &template, &pairs, think_arg)
         };
 
         // Rough token estimate: ~4 chars per token. Leave room for the response.
@@ -2956,7 +2982,7 @@ async fn interactive_chat(
             prompt,
             max_tokens: max_tokens.min(max_reply_tokens),
             temperature,
-            stop_sequences: template.stop_sequences(),
+            stop_sequences,
             ..Default::default()
         };
 


### PR DESCRIPTION
…b/API

The dynamic GGUF chat template (build_chat_prompt in api::routes) only reached the browser/API chat handlers - eullm run --cli built its prompt exactly as before, always through the hardcoded per-family template. Two interfaces onto the same loaded model answering differently depending only on which one was used to ask.

Adds build_cli_prompt in main.rs, mirroring build_chat_prompt: tries InferenceEngine::apply_jinja_chat_template first when running against the sequential engine (ChatBackend::Sequential), falls back to the existing hardcoded template + its stop_sequences otherwise - the exact same policy, so the same model gives the same answer regardless of which door was used to ask it.

Verified locally (no GPU here): cargo build/clippy clean with and without --features multimodal, 225 unit tests pass.