### PR TITLE
fix: remove default system prompt from web chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,28 @@ something changed, less so for understanding what it means.
 
 ## 0.6.70 — 2026-08-05
 
-*Published so far only as the pre-release `EuLLM-v0.6.70-rc10`. The dynamic
+*Published so far only as the pre-release `EuLLM-v0.6.70-rc11`. The dynamic
 chat template further up has not been re-validated across every known model
 family yet — that is what this pre-release is for. More may accumulate
 under this version before the final release.*
 
 ### Fixed
+- **The browser chat's default system message broke every model tested
+  except the one it was implicitly tuned for.** After the previous fix made
+  `--cli` and the browser chat share the same template decision, real
+  hardware testing surfaced a browser-only regression: with the identical
+  question ("ciao come ti chiami") and the identical model, `--cli` answered
+  correctly while the browser chat did not — ruling out the chat template
+  itself and pointing at the one thing still different between the two.
+  That was the browser's always-on default system message, a LaTeX
+  formatting hint. On DeepSeek-R1-Distill-Qwen-14B it produced an entire
+  unrelated calculus derivation instead of a greeting — DeepSeek's own
+  model card recommends against any system prompt for R1 models, and an
+  atypical one appears to send them into a stereotyped reasoning trace from
+  training instead of engaging with the actual turn. On Qwen2-VL-2B and
+  gemma-4-e4b it produced unrelated hallucinated identity claims. The
+  browser chat now starts with no default system message, matching the
+  CLI; the LaTeX hint is still available, opt-in, from Settings.
 - **`eullm run --cli` answered differently than the browser chat for the
   identical model and question.** The dynamic GGUF chat template added
   earlier in this version only reached the web/API chat handlers; the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.70-rc10"
+version = "0.6.70-rc11"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -1934,6 +1934,20 @@ diligenza manuale.
   blocco di ragionamento (`thinking_start_tag`/`thinking_end_tag`), ancora
   affidata solo ai filtri Harmony esistenti.
 
+  **Aggiornamento 6 agosto**: il sospetto sopra sembrava confermato — test su
+  hardware reale con DeepSeek-R1-Distill-Qwen-14B, Qwen2-VL-2B e la variante
+  da 7.1GB di gemma-4-e4b hanno prodotto risposte a vanvera via chat web
+  (DeepSeek: un'intera derivazione di calcolo integrale invece di rispondere
+  "come ti chiami"; gli altri due: allucinazioni di identità tipo "sono il
+  software OpenOffice.org calc"). La causa reale però non era il template
+  dinamico: la stessa identica domanda sullo stesso modello via `--cli` ha
+  risposto correttamente (vedi H3-W). Il meccanismo del template dinamico —
+  la parte che questa voce copre — è quindi scagionato per DeepSeek R1 da un
+  confronto diretto sullo stesso modello. Resta comunque da confermare via
+  `--cli` anche su Qwen2-VL-2B e gemma-4-e4b (finora testati solo via web,
+  dove il vero colpevole — il messaggio di sistema di default — era
+  comunque presente), e resta da validare Qwen3 come già annotato sopra.
+
 - [x] **H3-V · `probe_and_shrink_context` si ferma al primo tentativo che
   passa, non cerca il vero massimo** *(nice to have)*
   Osservato il 4 agosto 2026 testando `rc7` con un valore deliberatamente
@@ -1980,6 +1994,45 @@ diligenza manuale.
   `clippy` puliti con e senza `--features multimodal`, le 225 unit test
   passano. Da confermare su hardware reale che il crash non si ripresenti e
   che il raffinamento recuperi davvero contesto utile tra i valori dimezzati.
+
+- [x] **H3-W · Il messaggio di sistema di default della chat web mandava in
+  crisi modelli diversi da quello per cui sembrava pensato** *(P1)*
+  Trovato il 6 agosto 2026, subito dopo aver reso coerenti CLI e chat web
+  (H3-U): con lo stesso identico modello e la stessa identica domanda ("ciao
+  come ti chiami"), `--cli` rispondeva correttamente e la chat web no, su tre
+  modelli diversi — DeepSeek-R1-Distill-Qwen-14B, Qwen2-VL-2B, gemma-4-e4b
+  (variante 7.1GB). Questo esclude il template dinamico come causa (H3-U):
+  se fosse stato quello, `--cli` avrebbe fallito allo stesso modo, dato che
+  usa la stessa identica funzione di decisione. L'unica differenza reale tra
+  le due porte era il messaggio di sistema: `--cli` parte con un generico
+  "You are a helpful assistant.", la chat web mandava di default un
+  messaggio più elaborato (un suggerimento di formattazione LaTeX, aggiunto
+  in una sessione precedente).
+
+  Su DeepSeek-R1-Distill-Qwen-14B l'effetto era netto: invece di rispondere
+  al saluto, il modello ha prodotto un'intera derivazione di calcolo
+  (l'integrale di eˣsin(nx)) — nessun esempio del genere è presente nel testo
+  del messaggio di sistema stesso, quindi non è un caso di "ripete quello che
+  gli è stato scritto". La spiegazione più coerente: DeepSeek sconsiglia
+  esplicitamente l'uso di un system prompt con i modelli R1 (la scheda del
+  modello raccomanda di mettere le istruzioni nel turno utente), e un
+  messaggio di sistema insolito sembra spingerli a replicare una traccia di
+  ragionamento stereotipata vista in training (fortemente sbilanciata su
+  matematica/codice) invece di rispondere al turno reale. Su Qwen2-VL-2B e
+  gemma-4-e4b l'effetto era diverso — allucinazioni di identità — ma
+  scompariva comunque disattivando il messaggio di sistema di default.
+
+  Fix in `engine/src/ui/app.js`: `settings.system` ora parte vuoto invece
+  del testo LaTeX. Entrambi i percorsi di invio (`/api/chat` multimodale e
+  `/v1/chat/completions`) già saltano del tutto il turno di sistema quando
+  `settings.system` è vuoto (`if (settings.system) ...`), quindi il default
+  ora è "nessun messaggio di sistema", non "messaggio di sistema vuoto" — lo
+  stesso comportamento di fatto già in uso da `--cli`. Il suggerimento LaTeX
+  resta disponibile, opt-in, da Settings.
+
+  Verificato in locale (senza GPU in questo ambiente): non è codice Rust,
+  nessuna build da rifare. Da confermare su hardware reale che la chat web
+  torni a rispondere correttamente sui tre modelli con il default vuoto.
 ---
 
 ## Rimandi — voci già coperte dalle roadmap esistenti

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.70-rc10"
+version = "0.6.70-rc11"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/ui/app.js
+++ b/engine/src/ui/app.js
@@ -70,13 +70,17 @@
   let pendingMedia = null;
 
   const settings = {
-    // Default math-formatting nudge: some models close a $...$ block before the
-    // final fraction, leaving raw LaTeX. This asks them to delimit every full
-    // formula. Purely a formatting hint — the user can clear it in Settings.
-    system:
-      "When you write mathematics, wrap each complete formula — including the " +
-      "final result — in $...$ (inline) or $$...$$ (block) LaTeX delimiters. " +
-      "Never leave commands like \\frac or \\sqrt outside the delimiters.",
+    // No default system message: real-hardware testing on rc10 found that a
+    // populated system turn (previously a LaTeX-formatting nudge, on by
+    // default) sent DeepSeek-R1-Distill-Qwen-14B into an unrelated reasoning
+    // trace instead of answering the actual question, and produced
+    // hallucinated identity responses on Qwen2-VL-2B and gemma-4-e4b — while
+    // the CLI, which has no such default, answered all three correctly. Both
+    // send paths below already skip the system message when this is empty,
+    // so leaving it blank means no system turn is sent at all. Users who want
+    // the LaTeX-formatting hint (or any other system prompt) can still set
+    // one in Settings.
+    system: "",
     temperature: 0.7,
     maxTokens: 2048,
     // Reasoning ON by default. Reasoning models (DeepSeek-R1, QwQ) are trained


### PR DESCRIPTION
Real-hardware testing found the browser chat's always-on LaTeX-formatting system message broke DeepSeek-R1-Distill-Qwen-14B (unrelated calculus derivation instead of answering the actual question), Qwen2-VL-2B, and gemma-4-e4b (identity hallucinations). A same-question CLI-vs-web A/B test on the identical model showed --cli, which has no such default, answering correctly — ruling out the dynamic chat template itself and isolating the web-only system message as the cause.

settings.system now defaults to empty; both send paths already skip the system turn entirely when it's empty, so the web chat now starts with no default system message, matching --cli. The LaTeX-formatting hint remains available, opt-in, from Settings.