### PR TITLE
fix: restore default math-formatting hint via user turn, not system m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,21 @@ something changed, less so for understanding what it means.
 
 ## 0.6.70 — 2026-08-05
 
-*Published so far only as the pre-release `EuLLM-v0.6.70-rc11`. The dynamic
+*Published so far only as the pre-release `EuLLM-v0.6.70-rc12`. The dynamic
 chat template further up has not been re-validated across every known model
 family yet — that is what this pre-release is for. More may accumulate
 under this version before the final release.*
 
 ### Fixed
+- **The default math-formatting hint is back on by default, without the
+  system-message turn that broke it.** rc11 fixed the regression below by
+  turning the hint off by default (opt-in from Settings), which also meant
+  losing the "just works" formula formatting for anyone who didn't know to
+  turn it back on. It's now folded into the outgoing *user* turn instead of
+  sent as a `system`-role message, gated on the existing math-rendering
+  setting (on by default) rather than the separate, still-opt-in free-form
+  system prompt field. Same nudge, same default-on behavior as before the
+  regression, without reintroducing a system turn.
 - **The browser chat's default system message broke every model tested
   except the one it was implicitly tuned for.** After the previous fix made
   `--cli` and the browser chat share the same template decision, real

--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -2022,17 +2022,29 @@ diligenza manuale.
   gemma-4-e4b l'effetto era diverso — allucinazioni di identità — ma
   scompariva comunque disattivando il messaggio di sistema di default.
 
-  Fix in `engine/src/ui/app.js`: `settings.system` ora parte vuoto invece
+  Fix in rc11 (`engine/src/ui/app.js`): `settings.system` parte vuoto invece
   del testo LaTeX. Entrambi i percorsi di invio (`/api/chat` multimodale e
   `/v1/chat/completions`) già saltano del tutto il turno di sistema quando
   `settings.system` è vuoto (`if (settings.system) ...`), quindi il default
-  ora è "nessun messaggio di sistema", non "messaggio di sistema vuoto" — lo
-  stesso comportamento di fatto già in uso da `--cli`. Il suggerimento LaTeX
-  resta disponibile, opt-in, da Settings.
+  diventa "nessun messaggio di sistema", non "messaggio di sistema vuoto" —
+  lo stesso comportamento di fatto già in uso da `--cli`. Il suggerimento
+  LaTeX resta disponibile, opt-in, da Settings.
+
+  **Seguito in rc12**: disattivare il suggerimento di default perdeva la
+  formattazione automatica delle formule per chiunque non sapesse di doverla
+  riattivare a mano — segnalato subito dall'utente ("non sapendo se ci
+  saranno formule o meno"). Corretto spostando `MATH_FORMAT_HINT` dal campo
+  libero `settings.system` (rimasto vuoto di default, riservato a istruzioni
+  scritte dall'utente e mandate come vero turno `system`) a un'aggiunta in
+  coda al turno **utente** in uscita, condizionata a `settings.math` (attivo
+  di default). Stesso suggerimento, stesso comportamento attivo-di-default di
+  prima della regressione, ma senza reintrodurre un turno di sistema — la
+  parte che effettivamente rompeva i modelli.
 
   Verificato in locale (senza GPU in questo ambiente): non è codice Rust,
   nessuna build da rifare. Da confermare su hardware reale che la chat web
-  torni a rispondere correttamente sui tre modelli con il default vuoto.
+  torni a rispondere correttamente sui tre modelli e che il suggerimento
+  LaTeX in coda al turno utente non introduca a sua volta problemi.
 ---
 
 ## Rimandi — voci già coperte dalle roadmap esistenti

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.70-rc11"
+version = "0.6.70-rc12"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/ui/app.js
+++ b/engine/src/ui/app.js
@@ -69,17 +69,27 @@
   // the same `images:[...]` field. Cleared after each send.
   let pendingMedia = null;
 
+  // Default math-formatting nudge — folded into the outgoing *user* turn
+  // (see MATH_FORMAT_HINT usage in send()), not sent as a system message.
+  // Real-hardware testing on rc10/rc11 found this exact instruction, sent as
+  // a system-role turn, broke DeepSeek-R1-Distill-Qwen-14B (an unrelated
+  // reasoning trace instead of answering the actual question) and produced
+  // identity hallucinations on Qwen2-VL-2B and gemma-4-e4b — while the CLI,
+  // which never sends a system turn, answered the identical question
+  // correctly on the same models. DeepSeek's own model card recommends
+  // against any system prompt for R1 models. Appending the hint to the user
+  // turn instead keeps the nudge on by default without reintroducing a
+  // system-role turn.
+  const MATH_FORMAT_HINT =
+    "When you write mathematics, wrap each complete formula — including the " +
+    "final result — in $...$ (inline) or $$...$$ (block) LaTeX delimiters. " +
+    "Never leave commands like \\frac or \\sqrt outside the delimiters.";
+
   const settings = {
-    // No default system message: real-hardware testing on rc10 found that a
-    // populated system turn (previously a LaTeX-formatting nudge, on by
-    // default) sent DeepSeek-R1-Distill-Qwen-14B into an unrelated reasoning
-    // trace instead of answering the actual question, and produced
-    // hallucinated identity responses on Qwen2-VL-2B and gemma-4-e4b — while
-    // the CLI, which has no such default, answered all three correctly. Both
-    // send paths below already skip the system message when this is empty,
-    // so leaving it blank means no system turn is sent at all. Users who want
-    // the LaTeX-formatting hint (or any other system prompt) can still set
-    // one in Settings.
+    // Free-form system prompt, opt-in, sent as a literal system-role message
+    // when set (e.g. persona/tone/language instructions the user types in
+    // Settings). Left empty by default — see MATH_FORMAT_HINT above for why
+    // a populated-by-default system turn is unsafe.
     system: "",
     temperature: 0.7,
     maxTokens: 2048,
@@ -705,7 +715,8 @@
         // audio both ride this field — the backend's mtmd path auto-detects
         // the media type from the bytes. History is intentionally omitted —
         // the mtmd MVP is a one-shot probe.
-        const userMsg = { role: "user", content: userText, images: [media.base64] };
+        const hintedText = settings.math ? `${userText}\n\n${MATH_FORMAT_HINT}` : userText;
+        const userMsg = { role: "user", content: hintedText, images: [media.base64] };
         const messagesToSend = settings.system
           ? [{ role: "system", content: settings.system }, userMsg]
           : [userMsg];
@@ -724,7 +735,16 @@
       } else {
         const messagesToSend = [];
         if (settings.system) messagesToSend.push({ role: "system", content: settings.system });
-        messagesToSend.push(...history);
+        // Append the math hint to the latest user turn only (not stored back
+        // into `history`, so it isn't duplicated on every subsequent send).
+        const lastIdx = history.length - 1;
+        messagesToSend.push(
+          ...history.map((m, i) =>
+            settings.math && i === lastIdx
+              ? { role: m.role, content: `${m.content}\n\n${MATH_FORMAT_HINT}` }
+              : m,
+          ),
+        );
         resp = await fetch("/v1/chat/completions", withAuth({
           method: "POST",
           headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
…essage

rc11 fixed the DeepSeek-R1/Qwen2-VL/gemma-4-e4b regression by turning the LaTeX-formatting hint off by default, which lost the "just works" formula formatting for anyone who didn't know to re-enable it in Settings.

The hint is now folded into the outgoing user turn instead of sent as a system-role message, gated on the existing math-rendering setting (on by default) rather than the separate free-form system prompt field. Same nudge, same default-on behavior as before the regression, without reintroducing the system turn that caused it.