### PR TITLE
fix: remove the math-formatting hint injection entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,21 +15,24 @@ something changed, less so for understanding what it means.
 
 ## 0.6.70 — 2026-08-05
 
-*Published so far only as the pre-release `EuLLM-v0.6.70-rc12`. The dynamic
+*Published so far only as the pre-release `EuLLM-v0.6.70-rc13`. The dynamic
 chat template further up has not been re-validated across every known model
 family yet — that is what this pre-release is for. More may accumulate
 under this version before the final release.*
 
 ### Fixed
-- **The default math-formatting hint is back on by default, without the
-  system-message turn that broke it.** rc11 fixed the regression below by
-  turning the hint off by default (opt-in from Settings), which also meant
-  losing the "just works" formula formatting for anyone who didn't know to
-  turn it back on. It's now folded into the outgoing *user* turn instead of
-  sent as a `system`-role message, gated on the existing math-rendering
-  setting (on by default) rather than the separate, still-opt-in free-form
-  system prompt field. Same nudge, same default-on behavior as before the
-  regression, without reintroducing a system turn.
+- **The default math-formatting hint is gone for good, not just moved.**
+  rc12 tried to keep it on by default by folding it into the outgoing user
+  turn instead of a `system`-role message, on the theory that the system
+  role itself was the trigger. Real-hardware testing disproved that: the
+  identical question on the identical model (DeepSeek-R1-Distill-Qwen-14B)
+  still hallucinated — this time inventing the name "MathAI" — with the
+  hint riding along in the user turn (prompt token count confirmed it: 57
+  tokens web vs. 16 tokens `--cli` for the same question). The common factor
+  across both failed attempts was appending unsolicited instructions to a
+  short, unrelated prompt, not which role carried them. There is no default
+  nudge anymore in either place; it's opt-in only, typed into the system
+  prompt field in Settings.
 - **The browser chat's default system message broke every model tested
   except the one it was implicitly tuned for.** After the previous fix made
   `--cli` and the browser chat share the same template decision, real

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.70-rc11"
+version = "0.6.70-rc12"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -2045,6 +2045,30 @@ diligenza manuale.
   nessuna build da rifare. Da confermare su hardware reale che la chat web
   torni a rispondere correttamente sui tre modelli e che il suggerimento
   LaTeX in coda al turno utente non introduca a sua volta problemi.
+
+  **Confutato su hardware reale, stesso giorno**: la teoria di rc12 (era il
+  turno `system` il problema, non il contenuto) non ha retto alla prova.
+  Stessa domanda ("ciao come ti chiami"), stesso modello
+  (DeepSeek-R1-Distill-Qwen-14B): il log del server mostra `prompt=57
+  tokens` per la richiesta web contro i `prompt=16 tokens` di `--cli` per la
+  domanda identica — i 41 token in più sono `MATH_FORMAT_HINT`, quindi
+  l'iniezione nel turno utente stava avvenendo come previsto. Il risultato è
+  comunque un'allucinazione di identità, stavolta diversa ("Mi chiamo
+  MathAI" invece di rispondere normalmente). Il fattore comune ai due
+  tentativi falliti non era il ruolo del messaggio ma l'aver accodato
+  un'istruzione estranea a un prompt corto e non correlato — `--cli`, che
+  non manda niente del genere, risponde correttamente ogni volta.
+
+  Corretto in rc13 rimuovendo del tutto `MATH_FORMAT_HINT` e la sua
+  iniezione automatica (sia nel turno utente del ramo multimodale sia in
+  quello del ramo testo). Nessun suggerimento di default in nessuna forma;
+  resta disponibile solo scrivendolo a mano nel campo "System prompt" di
+  Settings, inviato come vero turno `system` — comportamento invariato per
+  chi lo usa già così.
+
+  Verificato in locale (senza GPU in questo ambiente): non è codice Rust,
+  nessuna build da rifare. Da confermare su hardware reale che senza alcuna
+  iniezione automatica la chat web risponda come `--cli` sui tre modelli.
 ---
 
 ## Rimandi — voci già coperte dalle roadmap esistenti

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.70-rc12"
+version = "0.6.70-rc13"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/ui/app.js
+++ b/engine/src/ui/app.js
@@ -69,27 +69,23 @@
   // the same `images:[...]` field. Cleared after each send.
   let pendingMedia = null;
 
-  // Default math-formatting nudge — folded into the outgoing *user* turn
-  // (see MATH_FORMAT_HINT usage in send()), not sent as a system message.
-  // Real-hardware testing on rc10/rc11 found this exact instruction, sent as
-  // a system-role turn, broke DeepSeek-R1-Distill-Qwen-14B (an unrelated
-  // reasoning trace instead of answering the actual question) and produced
-  // identity hallucinations on Qwen2-VL-2B and gemma-4-e4b — while the CLI,
-  // which never sends a system turn, answered the identical question
-  // correctly on the same models. DeepSeek's own model card recommends
-  // against any system prompt for R1 models. Appending the hint to the user
-  // turn instead keeps the nudge on by default without reintroducing a
-  // system-role turn.
-  const MATH_FORMAT_HINT =
-    "When you write mathematics, wrap each complete formula — including the " +
-    "final result — in $...$ (inline) or $$...$$ (block) LaTeX delimiters. " +
-    "Never leave commands like \\frac or \\sqrt outside the delimiters.";
-
   const settings = {
     // Free-form system prompt, opt-in, sent as a literal system-role message
     // when set (e.g. persona/tone/language instructions the user types in
-    // Settings). Left empty by default — see MATH_FORMAT_HINT above for why
-    // a populated-by-default system turn is unsafe.
+    // Settings). Left empty by default.
+    //
+    // A default math-formatting nudge lived here through rc10-rc12 and was
+    // removed for good after two separate real-hardware failures: as a
+    // system-role message (rc10) it sent DeepSeek-R1-Distill-Qwen-14B into
+    // an unrelated reasoning trace and hallucinated identities on
+    // Qwen2-VL-2B/gemma-4-e4b; moving it into the user turn instead (rc12,
+    // to dodge R1's documented sensitivity to system prompts) did not fix
+    // it — same question, same model, still hallucinated (invented the name
+    // "MathAI") once the hint text rode along in the same turn. The common
+    // factor both times was appending unsolicited instructions to a short,
+    // unrelated prompt, not which role carried them. `--cli`, which sends
+    // neither, answers correctly every time. Any such nudge is opt-in only
+    // now, typed by the user into this field.
     system: "",
     temperature: 0.7,
     maxTokens: 2048,
@@ -715,8 +711,7 @@
         // audio both ride this field — the backend's mtmd path auto-detects
         // the media type from the bytes. History is intentionally omitted —
         // the mtmd MVP is a one-shot probe.
-        const hintedText = settings.math ? `${userText}\n\n${MATH_FORMAT_HINT}` : userText;
-        const userMsg = { role: "user", content: hintedText, images: [media.base64] };
+        const userMsg = { role: "user", content: userText, images: [media.base64] };
         const messagesToSend = settings.system
           ? [{ role: "system", content: settings.system }, userMsg]
           : [userMsg];
@@ -735,16 +730,7 @@
       } else {
         const messagesToSend = [];
         if (settings.system) messagesToSend.push({ role: "system", content: settings.system });
-        // Append the math hint to the latest user turn only (not stored back
-        // into `history`, so it isn't duplicated on every subsequent send).
-        const lastIdx = history.length - 1;
-        messagesToSend.push(
-          ...history.map((m, i) =>
-            settings.math && i === lastIdx
-              ? { role: m.role, content: `${m.content}\n\n${MATH_FORMAT_HINT}` }
-              : m,
-          ),
-        );
+        messagesToSend.push(...history);
         resp = await fetch("/v1/chat/completions", withAuth({
           method: "POST",
           headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
rc12's theory was wrong: moving the LaTeX hint from a system-role message into the outgoing user turn did not fix the regression, it just changed its shape. Real-hardware testing on the identical model and question (DeepSeek-R1-Distill-Qwen-14B, "ciao come ti chiami") confirmed the hint was still being sent (prompt=57 tokens web vs. 16 tokens --cli) and still produced a hallucination, this time inventing the name "MathAI" instead of answering. The common factor was appending unsolicited instructions to a short, unrelated prompt, not which role carried them.

Both send paths now send exactly what the user typed, with no hidden injection. The formatting hint is still available, opt-in, from the Settings system prompt field.