### PR TITLE
fix: tolerate big-vocab GGUF metadata overrunning the fit parser's re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,29 @@ something changed, less so for understanding what it means.
 
 ## 0.6.70 — 2026-08-05
 
-*Published so far only as the pre-release `EuLLM-v0.6.70-rc14`. The dynamic
+*Published so far only as the pre-release `EuLLM-v0.6.70-rc15`. The dynamic
 chat template further up has not been re-validated across every known model
 family yet — that is what this pre-release is for. More may accumulate
 under this version before the final release.*
+
+### Fixed
+- **`--fit` failed outright on big-vocabulary models — including the one
+  MoE model the new auto-sizing was built for.** Found on real hardware
+  immediately after rc14: picking Qwen3.6-35B-A3B from the menu printed
+  "--fit could not size the model: could not parse layer count", fell back
+  to `--gpu-layers all`, and OOM'd — the exact failure `--fit` exists to
+  prevent. The file's layer count was present and readable; the parser read
+  only the first 8 MiB of the file and gave up wholesale when the metadata
+  ran past that — and this model's 248k-token vocabulary alone overruns it.
+  The header parser now keeps what it has already read when the buffer ends
+  (the layer count and attention dims sit well before the tokenizer block,
+  which is also why it now stops as soon as it has them), and the MoE
+  tensor-layout reader — which genuinely needs the full metadata span,
+  since the tensor table sits after it — retries with larger read budgets
+  instead of failing. The MoE sizing decision also moved *before* the
+  "doesn't fit, continue?" prompt: it always resolves to a loadable
+  configuration, so there is nothing left to ask — previously the prompt
+  quoted a whole-layer split that the MoE step was about to override.
 
 ### Added
 - **`--fit` now auto-sizes MoE expert offload too, not just whole GPU

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.70-rc13"
+version = "0.6.70-rc14"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -2069,6 +2069,29 @@ diligenza manuale.
   Verificato in locale (senza GPU in questo ambiente): non è codice Rust,
   nessuna build da rifare. Da confermare su hardware reale che senza alcuna
   iniezione automatica la chat web risponda come `--cli` sui tre modelli.
+
+- [ ] **H3-X · QwQ-32B-Preview via chat web: `<|im_start|>` trapela nel
+  testo e la risposta si tronca a 7 token** *(P2)*
+  Trovato il 7 agosto 2026 su rc14, testando `eullm run --fit` con
+  `qwq-32b` (QwQ-32B-Preview-Q4_K_M) scelto dal picker: alla domanda "ciao
+  come ti chiami?" la chat web ha risposto `Mi chiamo AI.<|im_start|>` — 7
+  token totali (confermato dall'audit log: `output_tokens=7`), col marker
+  ChatML renderizzato come testo visibile e la generazione interrotta lì.
+  Il modello si era caricato correttamente (split 43/64 layer via `--fit`,
+  nessun OOM) — il problema è a valle, nella costruzione del prompt o nella
+  gestione dei token di stop, non nel caricamento.
+
+  Sospetti da verificare, in ordine: (a) QwQ-32B-Preview è un modello
+  reasoning con un template proprio — il template dinamico (H3-U) potrebbe
+  renderizzarlo in una forma che il modello non si aspetta, come già visto
+  per gemma-4-12b-q8; (b) sul percorso dinamico `stop_sequences` è vuoto e
+  lo stop dipende solo da `is_eog_token` — se il modello emette
+  `<|im_start|>` (inizio turno, non fine) come testo e *poi* qualcosa lo
+  ferma a 7 token, c'è anche una domanda su cosa abbia fermato la
+  generazione così presto. Da testare la stessa domanda via `--cli` sullo
+  stesso modello (stesso metodo di isolamento che ha chiuso H3-W) e
+  ispezionare il template GGUF incorporato del file con lo script già
+  usato per gemma-4.
 ---
 
 ## Rimandi — voci già coperte dalle roadmap esistenti

--- a/docs/roadmap-engine-0.7-1.0.md
+++ b/docs/roadmap-engine-0.7-1.0.md
@@ -107,6 +107,23 @@ nessun blocco prolungato del decode durante prefill lunghi; riuso KV validato su
   — restano validi come riferimento se in futuro si vorrà ottimizzare oltre
   al solo "deve partire".
 
+  **Correzione rc15, trovata al primo test su hardware reale (7 agosto)**:
+  proprio Qwen3.6-35B-A3B (UD-Q4_K_M, vocabolario da 248k token) faceva
+  fallire `--fit` a monte — "could not parse layer count" → fallback a
+  `--gpu-layers all` → OOM. Il parser dell'header leggeva i primi 8 MiB e
+  scartava *tutto* se i metadati sforavano (gli array del tokenizer di quel
+  modello da soli superano il budget), buttando via il `block_count` già
+  letto 20 chiavi prima. Ora `parse_gguf_header` tollera il troncamento
+  (restituisce il parziale, e si ferma appena ha tutti i campi voluti) e
+  `read_gguf_moe_layout` — che la tabella tensori la trova solo *dopo*
+  tutti i metadati, quindi il troncamento lì non è tollerabile — ritenta
+  con budget crescenti (8→32→128 MiB). Spostata anche la decisione MoE
+  *prima* del prompt continua/annulla di `run_fit`: risolve sempre in una
+  configurazione caricabile, quindi non c'è niente da chiedere (prima il
+  prompt citava uno split per layer interi che il passo MoE stava per
+  sovrascrivere). Resta da validare su hardware reale che il 35B ora parta
+  dal picker.
+
 ---
 
 ## 0.8 — Contesto elastico e pipeline RAG completa

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.70-rc14"
+version = "0.6.70-rc15"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/fit.rs
+++ b/engine/src/fit.rs
@@ -217,9 +217,22 @@ pub fn parse_gguf_header(data: &[u8]) -> Option<GgufInfo> {
     // The metadata keys we want, each an integer stored as u32 or u64 depending
     // on the exporter. The `_kv` head count is checked before the plain head
     // count because the former does NOT end with `.attention.head_count`.
+    //
+    // Running out of buffer mid-metadata breaks out with whatever was parsed
+    // so far instead of returning `None`. Exporters write the hyperparameter
+    // keys before the tokenizer block, and a big-vocab model's tokenizer
+    // arrays alone can overrun any fixed read budget — found on real
+    // hardware with Qwen3.6-35B-A3B (248k-token vocabulary): its
+    // `block_count` sat 20 keys before the truncation point, and discarding
+    // it made `--fit` report "could not parse layer count", fall back to
+    // `--gpu-layers all`, and OOM on a model the sizer exists to handle.
     for _ in 0..metadata_kv_count {
-        let key_bytes = c.gguf_string()?;
-        let value_type = c.u32()?;
+        let Some(key_bytes) = c.gguf_string() else {
+            break;
+        };
+        let Some(value_type) = c.u32() else {
+            break;
+        };
 
         // Pick which field (if any) this key feeds. All are scalar integers;
         // an array-typed match is ignored (skipped) to stay aligned.
@@ -241,18 +254,34 @@ pub fn parse_gguf_header(data: &[u8]) -> Option<GgufInfo> {
             None
         };
 
-        match target {
-            Some(slot) => {
-                if let Some(v) = c.read_uint_as_u64(value_type) {
+        let advanced = match target {
+            Some(slot) => match c.read_uint_as_u64(value_type) {
+                Some(v) => {
                     // Clamp into u32; all of these counts are small.
                     *slot = u32::try_from(v).ok().or(Some(u32::MAX));
-                } else {
-                    // Unexpected type for a key we wanted; skip to stay aligned.
-                    c.skip_value(value_type)?;
+                    true
                 }
-            }
+                // Unexpected type for a key we wanted; skip to stay aligned.
+                None => c.skip_value(value_type).is_some(),
+            },
             // Not a key we care about (or an array) — skip its value.
-            None => c.skip_value(value_type)?,
+            None => c.skip_value(value_type).is_some(),
+        };
+        if !advanced {
+            break;
+        }
+
+        // Everything wanted is in hand — stop here instead of paying to
+        // skip through the tokenizer arrays (and instead of depending on
+        // the read budget covering them at all).
+        if n_layers.is_some()
+            && n_embd.is_some()
+            && n_head.is_some()
+            && n_head_kv.is_some()
+            && key_length.is_some()
+            && value_length.is_some()
+        {
+            break;
         }
     }
 
@@ -442,17 +471,35 @@ pub fn parse_gguf_moe_layout(data: &[u8], file_size: u64, n_layers: u32) -> Opti
     })
 }
 
-/// Read a GGUF file's leading bytes and parse its tensor layout. Mirrors
-/// [`read_gguf_info`] exactly (same 8 MiB budget, same reasoning for why a
-/// single `Read::read` isn't enough) — see there for why `take().read_to_end()`
-/// is used instead of one `read()` call.
+/// Read a GGUF file's leading bytes and parse its tensor layout.
+///
+/// Unlike [`read_gguf_info`] — whose parser can stop early because the keys
+/// it wants come first — the tensor-info table sits *after* every metadata
+/// entry, so the whole metadata block must fit in the buffer. A big-vocab
+/// model overruns the first budget with tokenizer arrays alone (Qwen3.6's
+/// 248k-token vocabulary plus merges is ~10 MiB of metadata by itself), so
+/// on a parse failure the read retries with geometrically larger budgets
+/// before giving up. The cap stays far below any real model's weights, so
+/// this never reads tensor data. Same `take().read_to_end()` pattern as
+/// `read_gguf_info` — see there for why a single `Read::read` isn't enough.
 pub fn read_gguf_moe_layout(path: &Path, file_size: u64, n_layers: u32) -> Option<MoeLayout> {
     use std::io::Read;
 
-    let file = std::fs::File::open(path).ok()?;
-    let mut buf = Vec::with_capacity(8 * 1024 * 1024);
-    file.take(8 * 1024 * 1024).read_to_end(&mut buf).ok()?;
-    parse_gguf_moe_layout(&buf, file_size, n_layers)
+    for cap in [8u64 << 20, 32 << 20, 128 << 20] {
+        let cap = cap.min(file_size);
+        let file = std::fs::File::open(path).ok()?;
+        let mut buf = Vec::with_capacity(cap as usize);
+        file.take(cap).read_to_end(&mut buf).ok()?;
+        if let Some(layout) = parse_gguf_moe_layout(&buf, file_size, n_layers) {
+            return Some(layout);
+        }
+        // The whole file is already in the buffer — a bigger budget cannot
+        // see anything more.
+        if (buf.len() as u64) >= file_size {
+            break;
+        }
+    }
+    None
 }
 
 /// Free VRAM in bytes, as reported by the active GPU backend.
@@ -835,11 +882,13 @@ pub fn run_fit(
 /// Run the MoE-aware fit flow: probe VRAM, read the GGUF header and tensor
 /// layout, and delegate to [`compute_moe_fit`].
 ///
-/// Always non-interactive — unlike [`run_fit`], this never prompts. It only
-/// runs as a refinement *after* `run_fit` already established a baseline
-/// (and, for `--fit-strict`, only after that baseline didn't abort), and a
-/// second confirmation prompt for a narrower, rarer case (MoE sizing) would
-/// duplicate the choice the user already made for the dense split.
+/// Always non-interactive — unlike [`run_fit`], this never prompts. The
+/// caller runs it *before* `run_fit`: a MoE decision here always resolves to
+/// a loadable configuration (expert offload, in the worst case combined with
+/// a reduced layer split down to fully-CPU), so there is no "doesn't fit,
+/// continue anyway?" question left to ask. Only when this returns
+/// [`MoeFitDecision::NotMoe`] does the dense `run_fit` flow — with its
+/// prompt and its `--fit-strict` handling — take over.
 pub fn run_moe_fit(
     model_path: &Path,
     ctx_size: u32,
@@ -1131,6 +1180,55 @@ mod key_length_tests {
         ]);
         let info = parse_gguf_header(&data).expect("header parses");
         assert_eq!(info.kv_elems_per_token_per_layer(), Some((1024.0, 512.0)));
+    }
+
+    /// Qwen3.6-35B-A3B's tokenizer block (248k-token vocabulary) overruns
+    /// the 8 MiB read budget on its own, so the buffer ends mid-array. The
+    /// hyperparameter keys all precede it — a truncation there must degrade
+    /// to "return what was parsed", not discard an already-read layer count
+    /// (which made `--fit` fall back to `--gpu-layers all` and OOM on real
+    /// hardware).
+    #[test]
+    fn tolerates_truncation_inside_the_tokenizer_arrays() {
+        let mut b = Vec::new();
+        b.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        b.extend_from_slice(&3u32.to_le_bytes());
+        b.extend_from_slice(&0u64.to_le_bytes());
+        b.extend_from_slice(&5u64.to_le_bytes()); // claims 5 metadata entries
+        put_u32(b"qwen35moe.block_count", 40, &mut b);
+        put_u32(b"qwen35moe.embedding_length", 2048, &mut b);
+        put_u32(b"qwen35moe.attention.head_count", 16, &mut b);
+        put_u32(b"qwen35moe.attention.head_count_kv", 2, &mut b);
+        // Fifth entry: a tokenizer array whose contents lie past the end of
+        // the buffer — only the array header made it in.
+        let key = b"tokenizer.ggml.tokens";
+        b.extend_from_slice(&(key.len() as u64).to_le_bytes());
+        b.extend_from_slice(key);
+        b.extend_from_slice(&GGUF_TYPE_ARRAY.to_le_bytes());
+        b.extend_from_slice(&GGUF_TYPE_STRING.to_le_bytes());
+        b.extend_from_slice(&248_320u64.to_le_bytes());
+
+        let info = parse_gguf_header(&b).expect("partial parse must succeed");
+        assert_eq!(info.n_layers, 40);
+        assert_eq!(info.n_head_kv, Some(2));
+    }
+
+    /// Once every wanted key is filled the parser must stop reading — a
+    /// later duplicate that would overwrite an already-parsed value proves
+    /// the stop happened by design, not because the buffer ran out.
+    #[test]
+    fn stops_reading_once_every_wanted_key_is_in_hand() {
+        let data = header(&[
+            (b"arch.block_count", 40),
+            (b"arch.embedding_length", 2048),
+            (b"arch.attention.head_count", 16),
+            (b"arch.attention.head_count_kv", 2),
+            (b"arch.attention.key_length", 256),
+            (b"arch.attention.value_length", 256),
+            (b"arch.block_count", 99),
+        ]);
+        let info = parse_gguf_header(&data).expect("parses");
+        assert_eq!(info.n_layers, 40);
     }
 
     /// The whole point: with the real head dimension the sizer charges more

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1767,48 +1767,55 @@ async fn cmd_run(
 
         // --fit: auto-size the GPU offload to free VRAM before loading. Opt-in;
         // headless-safe (never prompts unless both stdin and stdout are TTYs).
+        //
+        // MoE auto-sizing (roadmap 0.7-E) decides FIRST: a MoE decision
+        // always resolves to a loadable configuration (expert offload, in
+        // the worst case combined with a reduced layer split down to
+        // fully-CPU), so there is no "doesn't fit, continue anyway?" left to
+        // ask — and asking it with the dense whole-layer numbers, as an
+        // earlier ordering did, describes a split that MoE sizing is about
+        // to override anyway. Only when the model is not MoE (or the user
+        // already chose --cpu-moe/--n-cpu-moe themselves — explicit intent
+        // beats a guess) does the dense run_fit flow, with its prompt and
+        // its --fit-strict handling, take over.
         if fit {
             let kv_bpe_k = inference::cache_type_bytes_per_elem(&cache_type_k);
             let kv_bpe_v = inference::cache_type_bytes_per_elem(&cache_type_v);
-            match fit::run_fit(
-                &gguf_path, gpu_layers, ctx_size, fit_strict, kv_bpe_k, kv_bpe_v,
-            ) {
-                fit::FitOutcome::Proceed(n) => gpu_layers = n,
-                fit::FitOutcome::Abort => {
-                    // Clean return: don't load, don't bind a port. If we were
-                    // invoked from the picker flow, the user lands back there.
-                    return;
+            let moe_decision = if !cpu_moe && n_cpu_moe == 0 {
+                fit::run_moe_fit(&gguf_path, ctx_size, kv_bpe_k, kv_bpe_v)
+            } else {
+                fit::MoeFitDecision::NotMoe
+            };
+            match moe_decision {
+                fit::MoeFitDecision::Proceed { n_cpu_moe: computed } if computed > 0 => {
+                    println!(
+                        "[EULLM] MoE model: keeping expert tensors on CPU RAM for the \
+                         first {computed} layers so the rest fits in VRAM."
+                    );
+                    n_cpu_moe = computed;
+                    gpu_layers = -1;
                 }
-            }
-
-            // MoE auto-sizing (roadmap 0.7-E): `--fit`'s whole-layer split
-            // above has no notion of expert tensors, so a MoE model can be
-            // told "doesn't fit" (or worse, told "fits" and then OOM at
-            // load) even though `--cpu-moe`/`--n-cpu-moe` would let it run.
-            // Only when the user hasn't already chosen one of those two
-            // flags themselves — respecting explicit intent over a guess.
-            if !cpu_moe && n_cpu_moe == 0 {
-                match fit::run_moe_fit(&gguf_path, ctx_size, kv_bpe_k, kv_bpe_v) {
-                    fit::MoeFitDecision::NotMoe => {}
-                    fit::MoeFitDecision::Proceed { n_cpu_moe: computed } => {
-                        if computed > 0 {
-                            println!(
-                                "[EULLM] MoE model: keeping expert tensors on CPU RAM for the \
-                                 first {computed} layers so the rest fits in VRAM."
-                            );
-                            n_cpu_moe = computed;
-                            gpu_layers = -1;
-                        }
-                    }
-                    fit::MoeFitDecision::ProceedCpuMoeAndPartial { gpu_layers: gl } => {
-                        println!(
-                            "[EULLM] MoE model: even with every expert tensor on CPU RAM, the \
-                             rest doesn't fit fully — offloading a reduced layer split too."
-                        );
-                        cpu_moe = true;
-                        gpu_layers = gl;
-                    }
+                fit::MoeFitDecision::ProceedCpuMoeAndPartial { gpu_layers: gl } => {
+                    println!(
+                        "[EULLM] MoE model: even with every expert tensor on CPU RAM, the \
+                         rest doesn't fit fully — offloading a reduced layer split too."
+                    );
+                    cpu_moe = true;
+                    gpu_layers = gl;
                 }
+                // Dense model, a MoE that already fits fully as-is
+                // (computed == 0), or an unreadable layout.
+                _ => match fit::run_fit(
+                    &gguf_path, gpu_layers, ctx_size, fit_strict, kv_bpe_k, kv_bpe_v,
+                ) {
+                    fit::FitOutcome::Proceed(n) => gpu_layers = n,
+                    fit::FitOutcome::Abort => {
+                        // Clean return: don't load, don't bind a port. If we
+                        // were invoked from the picker flow, the user lands
+                        // back there.
+                        return;
+                    }
+                },
             }
         }
 


### PR DESCRIPTION
…ad budget

First real-hardware test of the rc14 MoE auto-sizing failed before any MoE logic ran: picking Qwen3.6-35B-A3B from the menu printed "--fit could not size the model: could not parse layer count", fell back to --gpu-layers all, and OOM'd. The layer count was present in the file (block_count=40, 20 keys in); the parser reads the first 8 MiB and discarded everything it had already parsed when the metadata ran past the buffer -- and this model's 248k-token vocabulary overruns 8 MiB with tokenizer arrays alone. A pre-existing --fit bug, surfaced by the first model tested with a vocabulary this large.

parse_gguf_header now keeps what it has already read when the buffer ends mid-metadata, and stops as soon as every wanted key is filled -- the hyperparameter keys precede the tokenizer block, so the 8 MiB budget stays sufficient by construction. read_gguf_moe_layout, whose tensor table sits after all metadata and genuinely needs it in the buffer, retries with larger read budgets (8/32/128 MiB) instead of failing.

The MoE sizing decision also moved before run_fit's continue/abort prompt: it always resolves to a loadable configuration, so there is nothing left to ask -- previously the prompt quoted a whole-layer split the MoE step was about to override.

Also logs H3-X: QwQ-32B-Preview via web chat leaks <|im_start|> into the visible text and truncates at 7 tokens -- a separate chat-template issue, not a sizing one (the model loaded fine with a 43/64 split).