### PR TITLE
feat: run --fit sizing on serve and on every model swap, never prompting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ something changed, less so for understanding what it means.
 
 ## 0.6.70 — 2026-08-05
 
-*Published so far only as the pre-release `EuLLM-v0.6.70-rc20`. The dynamic
+*Published so far only as the pre-release `EuLLM-v0.6.70-rc21`. The dynamic
 chat template further up has not been re-validated across every known model
 family yet — that is what this pre-release is for. More may accumulate
 under this version before the final release.*
@@ -49,6 +49,25 @@ under this version before the final release.*
   Reasoning stays ON by default — suppressing it on models that need it
   degrades answers, and unchecking is one click for the models where it
   works.
+
+### Added
+- **`--fit` now works on `serve`, and on every model swap — without ever
+  prompting.** Found live: `run --fit` sized a dense 27B at 43/64 layers,
+  then switching to the 22 GB MoE from the web UI loaded it with those
+  same launch settings — no expert offload, wrong split — and OOM'd
+  ("Failed to load model: null result from llama cpp"). The `--fit`/
+  `--fit-strict` flags moved into the shared `RuntimeOpts` (so `serve` has
+  them too), and `api::swap_model` now runs the same sizing before every
+  load — the initial lazy load on `serve` and every API-triggered swap on
+  both commands — after the old model is unloaded, so the measured free
+  VRAM is real. MoE auto-sizing resolves silently as always; a dense
+  partial split is applied and logged instead of asked about (a daemon has
+  nobody at the keyboard — `serve` started from a shell is still a TTY, so
+  the interactive gate alone would have blocked it); `--fit-strict`
+  surfaces as an error to the API caller instead of a question. The server
+  also now inherits the user's original `--gpu-layers`/`--cpu-moe`/
+  `--n-cpu-moe` flags rather than the values a launch-time fit computed
+  for the first model.
 
 ### Fixed
 - **Reasoning models no longer get truncated mid-think by the default

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.70-rc20"
+version = "0.6.70-rc21"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -57,10 +57,19 @@ Two things the struct does **not** do, and they are where the remaining care
 is needed:
 
 - **A flag deliberately kept out needs its reason written next to it**, and
-  both paths wired by hand. Today that is `--fit`/`--fit-strict` alone: they
-  size the offload against measured free VRAM *before* the load, and `serve`
-  loads inside `api::swap_model`, which has no such step. Offering them there
-  would parse them and do nothing, which is worse than not offering them.
+  both paths wired by hand. `--fit`/`--fit-strict` were that flag until
+  0.6.70-rc21: `serve` loads inside `api::swap_model`, which had no sizing
+  step, so offering them there would have parsed them and done nothing.
+  They now live in `RuntimeOpts` and `swap_model` runs the same sizing
+  before every load (after the old model is unloaded, so the measured free
+  VRAM is real) — but *never prompts*: a daemon, or a swap serving an API
+  request, has nobody at the keyboard, so a partial split is applied and
+  logged (`fit::run_fit_headless`) and `--fit-strict` surfaces as an API
+  error instead of a question. Two rules survive that work: `ServeConfig`
+  must receive the user's ORIGINAL `--gpu-layers`/`--cpu-moe`/`--n-cpu-moe`
+  flags, never values a launch-time fit computed (a dense 27B's 43/64
+  split reused to load a 22 GB MoE via web-UI swap OOM'd — found live);
+  and anything that can block on stdin must stay out of the swap path.
 - **A shared flag still has to reach the model `serve` loads**, through
   `ServeConfig` and into `api::swap_model`. Parsing it is not honouring it.
   Where a per-request override exists (`ctx_size`, `batch_size` via

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.70-rc20"
+version = "0.6.70-rc21"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -57,6 +57,19 @@ pub struct AppState {
 
     // ── Immutable inference settings (from CLI flags) ────────────────
     pub gpu_layers: i32,
+    /// `--fit`: size the GPU offload against measured free VRAM before
+    /// every load this server performs — the initial lazy load and every
+    /// API-triggered swap. Never prompts (a daemon cannot ask questions):
+    /// the MoE path always resolves to a loadable configuration, and the
+    /// dense path proceeds with the computed split, or refuses the load
+    /// when `fit_strict` is set. Without this, a swap reused the *launch*
+    /// model's layer split for whatever model came next — observed live:
+    /// `run --fit` sized a dense 27B at 43/64 layers, then a web-UI switch
+    /// to a 22 GB MoE loaded with those same settings and OOM'd.
+    pub fit: bool,
+    /// `--fit-strict`: with `fit`, a model that does not fully fit is not
+    /// loaded; the API caller gets the error instead of a partial split.
+    pub fit_strict: bool,
     pub ctx_size: u32,
     pub threads: u32,
     pub flash_attn: bool,
@@ -277,10 +290,66 @@ impl AppState {
                 crate::audit::sanitize_for_log(&normalized)
             );
         }
+        // ── 2a. Size the offload for THIS model (--fit) ─────────────
+        // The launch flags describe the launch model; whatever is being
+        // swapped in has its own size, layer count, and (possibly) expert
+        // layout. Runs after the unload above so the measured free VRAM is
+        // real. Never prompts — same decision order as the `run` startup
+        // flow: MoE auto-sizing first (always resolves), then the dense
+        // split, headless.
+        let effective_ctx = override_ctx_size.unwrap_or(self.ctx_size);
+        let mut gpu_layers = self.gpu_layers;
+        let mut cpu_moe = self.cpu_moe;
+        let mut n_cpu_moe = self.n_cpu_moe;
+        if self.fit {
+            let kv_bpe_k = crate::inference::cache_type_bytes_per_elem(&cache_type_k);
+            let kv_bpe_v = crate::inference::cache_type_bytes_per_elem(&cache_type_v);
+            let moe_decision = if !cpu_moe && n_cpu_moe == 0 {
+                crate::fit::run_moe_fit(&gguf_path, effective_ctx, kv_bpe_k, kv_bpe_v)
+            } else {
+                crate::fit::MoeFitDecision::NotMoe
+            };
+            match moe_decision {
+                crate::fit::MoeFitDecision::Proceed { n_cpu_moe: computed } if computed > 0 => {
+                    tracing::info!(
+                        "--fit: MoE model — keeping expert tensors on CPU RAM for the \
+                         first {computed} layers so the rest fits in VRAM"
+                    );
+                    n_cpu_moe = computed;
+                    gpu_layers = -1;
+                }
+                crate::fit::MoeFitDecision::ProceedCpuMoeAndPartial { gpu_layers: gl } => {
+                    tracing::info!(
+                        "--fit: MoE model — even with every expert tensor on CPU RAM the \
+                         rest doesn't fit fully; offloading a reduced layer split ({gl})"
+                    );
+                    cpu_moe = true;
+                    gpu_layers = gl;
+                }
+                _ => match crate::fit::run_fit_headless(
+                    &gguf_path,
+                    self.gpu_layers,
+                    effective_ctx,
+                    self.fit_strict,
+                    kv_bpe_k,
+                    kv_bpe_v,
+                ) {
+                    crate::fit::FitOutcome::Proceed(n) => gpu_layers = n,
+                    crate::fit::FitOutcome::Abort => {
+                        return Err(ModelError::LoadFailed(format!(
+                            "--fit-strict: model '{normalized}' does not fully fit in the \
+                             currently free VRAM; not loading. Retry without --fit-strict \
+                             to allow a partial CPU/GPU split."
+                        )));
+                    }
+                },
+            }
+        }
+
         let config = InferenceConfig {
             model_path: gguf_path,
-            gpu_layers: self.gpu_layers,
-            context_size: override_ctx_size.unwrap_or(self.ctx_size),
+            gpu_layers,
+            context_size: effective_ctx,
             threads: self.threads,
             flash_attn: self.flash_attn,
             n_batch: self.n_batch,
@@ -291,8 +360,8 @@ impl AppState {
             // `engine.generate_multimodal()`. Models without an mmproj keep
             // the text-only fast path (None → no extra VRAM, no init cost).
             mmproj_path: mmproj_path.clone(),
-            cpu_moe: self.cpu_moe,
-            n_cpu_moe: self.n_cpu_moe,
+            cpu_moe,
+            n_cpu_moe,
             rs_seq: self.rs_seq,
         };
 
@@ -582,6 +651,13 @@ pub struct ServeConfig {
     pub engine: Option<Arc<InferenceEngine>>,
     pub scheduler: Option<SchedulerHandle>,
     pub gpu_layers: i32,
+    /// Auto-size the GPU offload before every model load (see
+    /// `AppState::fit`). Pass the user's `--fit` flag, never a value a
+    /// previous fit computed.
+    pub fit: bool,
+    /// With `fit`, refuse a load that does not fully fit instead of
+    /// offloading a partial split (see `AppState::fit_strict`).
+    pub fit_strict: bool,
     pub ctx_size: u32,
     pub threads: u32,
     pub flash_attn: bool,
@@ -731,6 +807,8 @@ pub async fn serve(cfg: ServeConfig) -> Result<(), Box<dyn std::error::Error>> {
         }),
         swap_lock: tokio::sync::Mutex::new(()),
         gpu_layers: cfg.gpu_layers,
+        fit: cfg.fit,
+        fit_strict: cfg.fit_strict,
         ctx_size: cfg.ctx_size,
         threads: cfg.threads,
         flash_attn: cfg.flash_attn,
@@ -1185,6 +1263,8 @@ mod http_tests {
             }),
             swap_lock: tokio::sync::Mutex::new(()),
             gpu_layers: 0,
+            fit: false,
+            fit_strict: false,
             ctx_size: 4096,
             threads: 1,
             flash_attn: false,

--- a/engine/src/fit.rs
+++ b/engine/src/fit.rs
@@ -788,6 +788,52 @@ pub fn run_fit(
     kv_bytes_per_elem_k: f64,
     kv_bytes_per_elem_v: f64,
 ) -> FitOutcome {
+    run_fit_impl(
+        model_path,
+        fallback_gpu_layers,
+        ctx_size,
+        strict,
+        kv_bytes_per_elem_k,
+        kv_bytes_per_elem_v,
+        /* allow_prompt */ true,
+    )
+}
+
+/// [`run_fit`] for server contexts: never prompts, even on an interactive
+/// terminal. A daemon (or a model swap serving an API request) has nobody
+/// at the keyboard on the other end of stdin — `serve` started from a shell
+/// IS a TTY, so the [`run_fit`] gate alone would block it on the first
+/// partial-fit load. A partial split proceeds with a logged one-liner;
+/// `strict` still refuses, and the caller turns that into an API error.
+pub fn run_fit_headless(
+    model_path: &Path,
+    fallback_gpu_layers: i32,
+    ctx_size: u32,
+    strict: bool,
+    kv_bytes_per_elem_k: f64,
+    kv_bytes_per_elem_v: f64,
+) -> FitOutcome {
+    run_fit_impl(
+        model_path,
+        fallback_gpu_layers,
+        ctx_size,
+        strict,
+        kv_bytes_per_elem_k,
+        kv_bytes_per_elem_v,
+        /* allow_prompt */ false,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_fit_impl(
+    model_path: &Path,
+    fallback_gpu_layers: i32,
+    ctx_size: u32,
+    strict: bool,
+    kv_bytes_per_elem_k: f64,
+    kv_bytes_per_elem_v: f64,
+    allow_prompt: bool,
+) -> FitOutcome {
     let free_vram = free_vram_bytes();
     let info = read_gguf_info(model_path);
     let file_size = std::fs::metadata(model_path).map(|m| m.len()).unwrap_or(0);
@@ -844,7 +890,7 @@ pub fn run_fit(
                 return FitOutcome::Abort;
             }
 
-            if interactive() {
+            if allow_prompt && interactive() {
                 println!("[EULLM] --fit: model does not fit fully on the GPU.");
                 println!("  Free VRAM:  {}", gib(free));
                 println!("  Model size: {}", gib(file_size));

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -73,8 +73,8 @@ fn picker_run(model: &str) -> Commands {
     let mut cmd = Cli::parse_from(["eullm", "run", "--", model])
         .command
         .expect("`eullm run <model>` always parses to a subcommand");
-    if let Commands::Run { fit, .. } = &mut cmd {
-        *fit = true;
+    if let Commands::Run { opts, .. } = &mut cmd {
+        opts.fit = true;
     }
     cmd
 }
@@ -130,6 +130,22 @@ struct RuntimeOpts {
     /// Number of GPU layers to offload (-1 = all, 0 = CPU only)
     #[arg(long, default_value_t = -1, allow_hyphen_values = true)]
     gpu_layers: i32,
+
+    /// Auto-fit GPU layers to available VRAM (CUDA builds only). Probes
+    /// free VRAM and the model's layer count, then offloads as many layers
+    /// as fit. Opt-in: without it, --gpu-layers is used as-is. If VRAM
+    /// can't be probed it falls back to --gpu-layers. On `run` a partial
+    /// split asks for confirmation when the terminal is interactive; on
+    /// `serve` (and on model swaps requested through the API) it never
+    /// prompts — the computed split is applied and logged.
+    #[arg(long)]
+    fit: bool,
+
+    /// With --fit, refuse to load (instead of offloading a partial split
+    /// or falling back) when the model does not fully fit on the GPU. On
+    /// `serve`, a refused load surfaces as an error to the API caller.
+    #[arg(long)]
+    fit_strict: bool,
 
     /// For MoE models (e.g. Qwen3-30B-A3B): keep expert tensors
     /// (`*.ffn_(up|down|gate)_exps`) on CPU RAM while attention,
@@ -296,18 +312,6 @@ enum Commands {
 
         #[command(flatten)]
         opts: RuntimeOpts,
-
-        /// Auto-fit GPU layers to available VRAM (CUDA builds only). Probes
-        /// free VRAM and the model's layer count, then offloads as many layers
-        /// as fit. Opt-in: without it, --gpu-layers is used as-is. If VRAM
-        /// can't be probed it falls back to --gpu-layers.
-        #[arg(long)]
-        fit: bool,
-
-        /// With --fit, refuse to load (instead of offloading a partial split
-        /// or falling back) when the model does not fully fit on the GPU.
-        #[arg(long)]
-        fit_strict: bool,
 
         /// Disable the embedded chat UI (otherwise served on --ui-port).
         /// Use this for headless / backend / RAG deployments where you only
@@ -540,8 +544,6 @@ async fn main() {
         Commands::Pull { model } => cmd_pull_maybe(&store, model.as_deref()).await,
         Commands::Run {
             model,
-            fit,
-            fit_strict,
             no_ui,
             cli,
             image,
@@ -555,6 +557,8 @@ async fn main() {
                 batch_size,
                 replace,
                 gpu_layers,
+                fit,
+                fit_strict,
                 cpu_moe,
                 n_cpu_moe,
                 rs_seq,
@@ -676,6 +680,8 @@ async fn main() {
                 batch_size,
                 replace,
                 gpu_layers,
+                fit,
+                fit_strict,
                 cpu_moe,
                 n_cpu_moe,
                 rs_seq,
@@ -725,6 +731,8 @@ async fn main() {
                 ui_port_opt,
                 batch_size,
                 gpu_layers,
+                fit,
+                fit_strict,
                 ctx_size,
                 threads,
                 !no_flash_attn,
@@ -1663,6 +1671,15 @@ async fn cmd_run(
     // too — only when the user hasn't already chosen one explicitly.
     let mut cpu_moe = cpu_moe;
     let mut n_cpu_moe = n_cpu_moe;
+    // What the user actually asked for, before --fit specializes the mut
+    // bindings above to the LAUNCH model. The API server must inherit these
+    // originals: with --fit it re-sizes each model it loads against them,
+    // and handing it the launch model's computed split instead is exactly
+    // the bug where a dense 27B's 43/64 split was reused to load a 22 GB
+    // MoE and OOM'd.
+    let flag_gpu_layers = gpu_layers;
+    let flag_cpu_moe = cpu_moe;
+    let flag_n_cpu_moe = n_cpu_moe;
 
     if !multimodal_oneshot {
         ensure_port_available(port, replace).await;
@@ -2057,7 +2074,9 @@ async fn cmd_run(
             model_name: Some(api_model_name),
             engine,
             scheduler,
-            gpu_layers,
+            gpu_layers: flag_gpu_layers,
+            fit,
+            fit_strict,
             ctx_size,
             threads: resolved_threads,
             flash_attn,
@@ -2065,8 +2084,8 @@ async fn cmd_run(
             cache_type_k,
             cache_type_v,
             batch_size,
-            cpu_moe,
-            n_cpu_moe,
+            cpu_moe: flag_cpu_moe,
+            n_cpu_moe: flag_n_cpu_moe,
             rs_seq,
             ctx_checkpoints,
             checkpoint_min_step,
@@ -2120,6 +2139,8 @@ async fn cmd_serve(
     ui_port: Option<u16>,
     batch_size: usize,
     gpu_layers: i32,
+    fit: bool,
+    fit_strict: bool,
     ctx_size: u32,
     threads: Option<u32>,
     flash_attn: bool,
@@ -2162,6 +2183,8 @@ async fn cmd_serve(
         engine: None,
         scheduler: None,
         gpu_layers,
+        fit,
+        fit_strict,
         ctx_size,
         threads,
         flash_attn,


### PR DESCRIPTION
Found live: run --fit sized a dense 27B at 43/64 layers, then a web-UI switch to a 22 GB MoE loaded it with those same launch settings -- no expert offload, wrong split -- and OOM'd with "Failed to load model: null result from llama cpp". serve had no --fit at all (deliberately, since api::swap_model had no sizing step), and run's swaps reused whatever the launch fit had computed for a different model.

--fit/--fit-strict move into the shared RuntimeOpts so both commands carry them, and api::swap_model now runs the same sizing before every load -- serve's initial lazy load and every API-triggered swap on either command -- after the old model is fully unloaded, so the measured free VRAM is real. The decision order matches the run startup flow: MoE auto-sizing first (always resolves to a loadable configuration), then the dense split via the new fit::run_fit_headless, which never prompts even on a TTY -- a daemon, or a swap serving an HTTP request, has nobody at the keyboard. --fit-strict surfaces as a ModelError to the API caller instead of a question.

ServeConfig now receives the user's original --gpu-layers/--cpu-moe/ --n-cpu-moe flags, never values a launch-time fit computed: fit re-sizes each model against the real flags, per load.

Updates the engine CLAUDE.md rule that documented --fit as the one flag deliberately kept out of serve.