### PR TITLE
fix: drop blank source lines next to block elements in the chat UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ something changed, less so for understanding what it means.
   work.
 
 ### Fixed
+- **Normal vertical spacing between blocks in the chat UI.** Headings,
+  lists, tables and code blocks were surrounded by roughly twice the
+  intended air, and a blank line between numbered list items visibly
+  restarted the numbering. The message body preserves the source's blank
+  lines (that is what separates plain-text paragraphs), but block elements
+  bring their own margins, so the two spacings stacked. Blank lines
+  touching a block element are now dropped; blank lines between plain
+  paragraphs still render as before.
+
 - **Markdown tables render as tables in the chat UI** (#335). They used to
   come out as plain text with visible pipes. GFM syntax — a header row, a
   `|---|` separator, optional `:` alignment markers — now produces a real

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.80-rc2"
+version = "0.6.80-rc3"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -2184,8 +2184,12 @@ diligenza manuale.
   modello senza template tool per il fallback pulito (campo assente,
   niente errori).
 
-- [ ] **H4-B · Chat web: troppo spazio verticale tra i blocchi renderizzati**
-  *(P3 — cosmetico, richiesto il 9 agosto validando le tabelle di rc1)*
+- [x] **H4-B · Chat web: troppo spazio verticale tra i blocchi renderizzati**
+  *(P3 — cosmetico, richiesto il 9 agosto validando le tabelle di rc1;
+  corretto in 0.6.80-rc3 esattamente come diagnosticato sotto: righe vuote
+  adiacenti a un blocco inghiottite nel renderer, CSS lasciato com'era
+  perché i margini erano già giusti. Bonus: una riga vuota tra elementi di
+  una lista numerata non spezza più la numerazione.)*
   Tra titoli, liste e tabelle c'è circa il doppio dell'aria voluta. Causa
   già individuata, non è questione di ritoccare un margine: `.msg-content`
   è `white-space: pre-wrap`, quindi le righe vuote del markdown sorgente

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.80-rc2"
+version = "0.6.80-rc3"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/ui/app.js
+++ b/engine/src/ui/app.js
@@ -496,7 +496,30 @@
       out.push(renderInline(line));
     }
     closeList();
-    return out.join("\n");
+
+    // The message body is white-space: pre-wrap, so blank SOURCE lines
+    // render as visible gaps — and block elements bring their own CSS
+    // margins, so a blank line next to a heading, list, table or code block
+    // doubles the spacing (H4-B: roughly twice the intended air between
+    // blocks). Swallow blank lines that touch block-level output; blank
+    // lines between plain-text paragraphs stay, because there pre-wrap is
+    // exactly what separates the paragraphs.
+    const blockish = (s) =>
+      /^<(?:h[1-6]|ul|ol|\/ul|\/ol|li|hr|table|blockquote)\b/.test(s) ||
+      /^CODE\d+$/.test(s.trim());
+    const compact = [];
+    for (let k = 0; k < out.length; k++) {
+      if (!out[k].trim()) {
+        const prev = compact.length ? compact[compact.length - 1] : null;
+        let next = null;
+        for (let j = k + 1; j < out.length; j++) {
+          if (out[j].trim()) { next = out[j]; break; }
+        }
+        if ((prev && blockish(prev)) || (next && blockish(next))) continue;
+      }
+      compact.push(out[k]);
+    }
+    return compact.join("\n");
   }
 
   function renderContent(text) {


### PR DESCRIPTION
H4-B: headings, lists, tables and code blocks showed roughly double the intended vertical spacing, and a blank line between numbered list items visibly restarted the numbering. The message body is white-space: pre-wrap, so the source's blank lines render as gaps, and block elements bring their own CSS margins on top.

renderMarkdownBlocks now swallows blank lines that touch block-level output (the block's margin already provides the separation) and keeps blank lines between plain-text paragraphs, where pre-wrap is exactly what separates them. CSS margins were already right and are untouched.