### PR TITLE
fix: salvage tool calls when the strict output parse rejects a comple…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,12 @@ something changed, less so for understanding what it means.
   before. One knowing limit: tool requests are parsed whole, so a
   streaming request gets its answer as a single delta rather than
   token-by-token — incremental tool-call streaming is separate future
-  work.
+  work. From rc6, a strict parse failure no longer leaks the raw call
+  markup into the reply: the parser retries in salvage mode, which
+  extracts the tool calls it recognized even when surrounding text
+  confused the strict grammar (reported live in #334 on a second-round
+  call, "unparsed peg-native output"); only a truly unparseable output
+  falls back to plain text.
 
 ### Fixed
 - **`--fit` no longer overcharges KV on hybrid-SSM models, so far more

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.80-rc5"
+version = "0.6.80-rc6"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.80-rc5"
+version = "0.6.80-rc6"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/vendor/llama-cpp-rs/llama-cpp-2/src/lib.rs
+++ b/engine/vendor/llama-cpp-rs/llama-cpp-2/src/lib.rs
@@ -427,8 +427,9 @@ pub enum JinjaChatTemplateError {
     /// the C++ side failed to allocate the returned string.
     #[error("allocation failed")]
     AllocationFailed,
-    /// llama.cpp's Jinja engine (minja) threw while parsing or rendering the template.
-    #[error("llama.cpp raised an exception while rendering the chat template")]
+    /// llama.cpp's chat machinery threw — while rendering a template or
+    /// while parsing model output with the format-aware parser.
+    #[error("llama.cpp raised an exception in the chat template engine")]
     Exception,
     /// llama.cpp returned a status code this wrapper does not recognize.
     #[error("unrecognized status code {0}")]

--- a/engine/vendor/llama-cpp-rs/llama-cpp-sys-2/wrapper_common.cpp
+++ b/engine/vendor/llama-cpp-rs/llama-cpp-sys-2/wrapper_common.cpp
@@ -145,7 +145,27 @@ extern "C" llama_rs_status llama_rs_chat_parse(
             params.parser.load(parser);
         }
 
-        const auto msg = common_chat_parse(input, is_partial, params);
+        common_chat_msg msg;
+        try {
+            msg = common_chat_parse(input, is_partial, params);
+        } catch (const std::exception &) {
+            if (is_partial) {
+                return LLAMA_RS_STATUS_EXCEPTION;
+            }
+            // The strict parse of a complete output throws on any unparsed
+            // remainder ("unparsed peg-native output: ..."), even when the
+            // tool calls themselves were captured fine — seen in the wild on
+            // a second-round tool call whose surrounding text the grammar
+            // did not expect. The partial path extracts whatever AST nodes
+            // were recognized instead of throwing, which salvages the calls;
+            // only if that also fails is the output truly unparseable.
+            msg = common_chat_parse(input, /* is_partial */ true, params);
+            if (msg.empty()) {
+                // The salvage captured nothing; let the caller fall back to
+                // the raw text rather than returning an empty message.
+                return LLAMA_RS_STATUS_EXCEPTION;
+            }
+        }
         *out_json = llama_rs_dup_string(msg.to_json_oaicompat().dump());
         return *out_json ? LLAMA_RS_STATUS_OK : LLAMA_RS_STATUS_ALLOCATION_FAILED;
     } catch (const std::exception &) {


### PR DESCRIPTION
…te reply

Reported in #334 after rc2: the first tool round worked end to end, the second round's output failed the strict parse with "unparsed peg-native output" even though the tool_call block in it was well formed, and the raw markup leaked into content. The strict parse of a complete output throws on any unparsed remainder, discarding calls it had already recognized.

llama_rs_chat_parse now retries a failed strict parse in partial mode, which extracts whatever the grammar did recognize instead of throwing; an empty salvage still reports the exception so the caller's plain-text fallback applies. Also rewords the shared exception message, which claimed "while rendering the chat template" in parse contexts.