### PR TITLE
fix: explain a download onto a dangling store symlink instead of repo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ something changed, less so for understanding what it means.
   back to plain text.
 
 ### Fixed
+- **A download onto an unmounted volume says so, instead of "File
+  exists".** When the model store lives behind a symlink to a volume that
+  is not mounted, creating the destination directory fails with EEXIST —
+  the link is there, it just leads nowhere — and the pull reported
+  `Download failed: File exists (os error 17)`, which reads as "you
+  already have this model". The download path now uses the same
+  diagnostic the rest of the store already had: it names the dangling
+  symlink and says to mount the volume or set `EULLM_MODELS_DIR`.
+
 - **Different quants of the same model are different models again**
   (#345). Switching between `repo:UD-Q5_K_XL` and `repo:UD-Q4_K_M` did
   nothing: the server compared names with a file-stem rule that cuts at

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.80-rc9"
+version = "0.6.80-rc10"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.80-rc9"
+version = "0.6.80-rc10"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/models/store.rs
+++ b/engine/src/models/store.rs
@@ -162,7 +162,7 @@ impl ModelStore {
         mmproj_file: Option<&str>,
     ) -> Result<PathBuf, Box<dyn std::error::Error>> {
         let model_dir = self.root.join(&entry.id);
-        create_model_dir(&model_dir)?;
+        create_model_dir(&model_dir).map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
 
         let manifest = ModelManifest {
             id: entry.id.clone(),
@@ -204,7 +204,7 @@ impl ModelStore {
         mmproj_file: Option<&str>,
     ) -> Result<PathBuf, Box<dyn std::error::Error>> {
         let model_dir = self.root.join(id);
-        create_model_dir(&model_dir)?;
+        create_model_dir(&model_dir).map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
 
         let manifest = ModelManifest {
             id: id.to_string(),
@@ -481,7 +481,7 @@ impl ModelStore {
     /// problem is a local message and nothing is downloaded.
     pub fn ensure_model_dir(&self, id: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
         let dir = self.model_path(id);
-        create_model_dir(&dir)?;
+        create_model_dir(&dir).map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
         Ok(dir)
     }
 
@@ -511,7 +511,9 @@ impl ModelStore {
 /// reasons this fails on a real machine: the path is occupied by a regular
 /// file, or it is a symlink whose target is gone. Neither is a plausible
 /// guess from that message alone, so both are named here.
-fn create_model_dir(dir: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn create_model_dir(
+    dir: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     fs::create_dir_all(dir).map_err(|e| {
         let occupant = match fs::symlink_metadata(dir) {
             Ok(md) if md.file_type().is_symlink() => {
@@ -675,6 +677,30 @@ mod tests {
         let root = std::env::temp_dir().join(format!("eullm-test-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&root).unwrap();
         (ModelStore { root: root.clone() }, root)
+    }
+
+    /// A store path that is a symlink to an unmounted volume must explain
+    /// itself. `create_dir_all` answers EEXIST there — the symlink exists,
+    /// it just does not lead anywhere — and reporting that raw reads as
+    /// "File exists (os error 17)" in the middle of a download, which sounds
+    /// like the model is already present. Reported on a real setup where the
+    /// store lived on a volume that was not mounted yet.
+    #[cfg(unix)]
+    #[test]
+    fn a_dangling_store_symlink_explains_itself() {
+        let base = std::env::temp_dir().join(format!("eullm-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&base).unwrap();
+        let link = base.join("models");
+        std::os::unix::fs::symlink(base.join("not-mounted"), &link).unwrap();
+
+        let err = create_model_dir(&link.join("some-model"))
+            .expect_err("a dangling symlink cannot be created into")
+            .to_string();
+        assert!(
+            err.contains("mount it first") || err.contains("symlink"),
+            "error must point at the unmounted volume, got: {err}"
+        );
+        let _ = fs::remove_dir_all(&base);
     }
 
     /// A manifest written before the `id` field existed must still resolve to

--- a/engine/src/registry/mod.rs
+++ b/engine/src/registry/mod.rs
@@ -71,8 +71,12 @@ pub async fn download_file(
     on_progress: Option<ProgressCallback>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Ensure parent directory exists up-front so we can put the .part there.
+    // Through the store's helper, for its diagnosis: a bare `create_dir_all`
+    // reports EEXIST ("File exists (os error 17)") when a path component is
+    // a symlink to an unmounted volume, which reads as "already downloaded"
+    // and sent a user hunting for a file that was never there.
     if let Some(parent) = dest.parent() {
-        fs::create_dir_all(parent)?;
+        crate::models::store::create_model_dir(parent)?;
     }
     let tmp_path = dest.with_extension("gguf.part");
 


### PR DESCRIPTION
…rting EEXIST

Hit while testing the quant fix: with the model store on a volume that was not mounted yet, the pull failed with "Download failed: File exists (os error 17)". create_dir_all answers EEXIST on a symlink whose target is absent -- the link exists, it just leads nowhere -- and raw, that message reads as "the model is already downloaded", which is the opposite of what happened.

The download path now creates its parent through the store's create_model_dir, which already diagnoses this exact case (names the dangling symlink, suggests mounting the volume or setting EULLM_MODELS_DIR). Covered by a unix test that builds a dangling symlink and asserts the message points at the mount.