### PR TITLE
fix: don't reuse the launch model's projector for every later swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,15 @@ something changed, less so for understanding what it means.
   back to plain text.
 
 ### Fixed
+- **Switching away from a vision model no longer breaks the next load.**
+  Launching a multimodal model (Gemma 3/4 and friends) and then switching
+  to any other model from the chat UI failed with `mismatch between text
+  model (n_embd = 2048) and mmproj (n_embd = 2560)`: the projector found
+  for the launch model was handed to the server as a fallback and applied
+  to every model swapped in afterwards. Only an explicit `--mmproj` is a
+  fallback now. Models with a projector of their own still find it, from
+  the store entry or from the file beside their weights.
+
 - **A download onto an unmounted volume says so, instead of "File
   exists".** When the model store lives behind a symlink to a volume that
   is not mounted, creating the destination directory fails with EEXIST —

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -135,7 +135,12 @@ pub struct AppState {
     pub web_policy: crate::tools::guard::WebPolicy,
 
     /// Projector to fall back on when the model being loaded declares none
-    /// of its own, from `serve --mmproj`. Normally `None`.
+    /// of its own. Only ever an explicit `--mmproj`, never a projector that
+    /// was discovered for some other model: pairing a projector with weights
+    /// it was not trained on fails the load outright (`mismatch between text
+    /// model and mmproj`), which is what happened when `run`'s auto-detected
+    /// projector was passed here and then applied to every later swap.
+    /// Normally `None`.
     pub fallback_mmproj: Option<PathBuf>,
 
     /// Whether a request's `model` field may name an arbitrary filesystem

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1989,7 +1989,15 @@ async fn cmd_run(
         if let Some(ref p) = mmproj_for_config {
             println!("Found mmproj: {}", p.display());
         }
-        api_mmproj = mmproj_for_config.clone();
+        // Only an explicit `--mmproj` becomes the server's fallback for
+        // later swaps. A projector discovered for THIS model belongs to
+        // this model: handing it to the next one produced
+        // "mismatch between text model (n_embd = 2048) and mmproj
+        // (n_embd = 2560)" and a failed load, after launching a vision
+        // model and switching to anything else from the chat UI. Every
+        // model that has its own projector still finds it in swap_model,
+        // by store entry or by the file sitting beside its weights.
+        api_mmproj = mmproj.clone();
 
         let config = InferenceConfig {
             model_path: gguf_path,


### PR DESCRIPTION
Found on real hardware: launch a vision model (gemma-3-4b), switch to anything else from the chat UI, and the load dies with "mtmd_init_from_file: error: mismatch between text model (n_embd = 2048) and mmproj (n_embd = 2560)". cmd_run resolved the launch model's projector -- from the store entry or from the file beside its weights -- and passed it to the API server as its fallback projector, which swap_model then applied to every model that had none of its own.

A projector discovered for one model is a fact about that model. Only an explicit --mmproj is a legitimate fallback, and that is what the server now receives. Models with their own projector are unaffected: swap_model still resolves them by store entry and by mmproj_beside.