### PR TITLE
chore: bump to 0.6.80-rc11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.6.80-rc10"
+version = "0.6.80-rc11"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.6.80-rc10"
+version = "0.6.80-rc11"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"


### PR DESCRIPTION
rc10 is tagged; the projector-leak fix ships as rc11.