### PR TITLE
feat(engine): log llama.cpp's own memory breakdown after context crea…

### DIFF
--- a/engine/src/inference/scheduler.rs
+++ b/engine/src/inference/scheduler.rs
@@ -874,6 +874,14 @@ fn run_scheduler_loop(
     // and this backend is now shared (`Arc`) across every model in the
     // process.
 
+    // The same per-device memory breakdown table stock llama-cli/llama-server
+    // print at load time (`total | free | self = model + context + compute`),
+    // straight from llama.cpp's own accounting rather than our own estimate —
+    // logged here so a real allocation can be compared apples-to-apples
+    // against a stock binary's, instead of guessing from two processes' free
+    // VRAM numbers.
+    ctx.memory_breakdown_print();
+
     let mut active: Vec<ActiveSequence> = Vec::with_capacity(sched_config.max_batch_size);
     // Pool of idle sequence slots in range [0, max_batch_size), each carrying
     // the token history currently resident in its KV cache so a later

--- a/engine/vendor/llama-cpp-rs/llama-cpp-2/Cargo.toml
+++ b/engine/vendor/llama-cpp-rs/llama-cpp-2/Cargo.toml
@@ -19,6 +19,10 @@
 #   - `llama-cpp-sys-2/wrapper_common.h` + `.cpp`: the C wrapper functions
 #     backing the three above — `llama_rs_apply_chat_template`,
 #     `llama_rs_apply_chat_template_oai`, `llama_rs_chat_parse`.
+#   - `context.rs`: `LlamaContext::memory_breakdown_print`, wrapping the
+#     already-upstream `llama_rs_memory_breakdown_print` (declared in
+#     `wrapper_common.h`, not itself an EuLLM addition) in a safe method —
+#     only the Rust-side wrapper is ours.
 [package]
 name = "llama-cpp-2"
 description = "llama.cpp bindings for Rust"

--- a/engine/vendor/llama-cpp-rs/llama-cpp-2/src/context.rs
+++ b/engine/vendor/llama-cpp-rs/llama-cpp-2/src/context.rs
@@ -89,6 +89,18 @@ impl<'model> LlamaContext<'model> {
         unsafe { llama_cpp_sys_2::llama_n_ctx(self.context.as_ptr()) }
     }
 
+    /// EuLLM addition: prints llama.cpp's own per-device memory breakdown
+    /// table (`total | free | self = model + (context = kv + compute +
+    /// output) + unaccounted`) for this context to stderr via llama.cpp's
+    /// logger — the same table stock `llama-cli`/`llama-server` print at
+    /// load time. Wraps `common_memory_breakdown_print`, the exact function
+    /// those binaries call, so a comparison against them is apples-to-apples
+    /// instead of a guess from two different processes' free-VRAM numbers.
+    #[cfg(feature = "common")]
+    pub fn memory_breakdown_print(&self) {
+        unsafe { llama_cpp_sys_2::llama_rs_memory_breakdown_print(self.context.as_ptr()) }
+    }
+
     /// Decodes the batch.
     ///
     /// # Errors


### PR DESCRIPTION
…tion

Wraps the already-vendored llama_rs_memory_breakdown_print (wired for the in-progress MTP speculative decoding support, unused by eullm until now) in a safe LlamaContext::memory_breakdown_print method, and calls it once after the scheduler's context allocation succeeds. Prints the same per-device table stock llama-cli/llama-server show at load time (total | free | self = model + context + compute), straight from llama.cpp's own accounting — gives a real, apples-to-apples number to compare against a stock binary's own breakdown instead of guessing from two different processes' free-VRAM readings.