### PR TITLE
feat(engine): embed the build's git commit hash in -V and the ready b…

### DIFF
--- a/engine/build.rs
+++ b/engine/build.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+
+/// Embeds the short git commit hash this binary was built from, so `-V`/`--version`
+/// can answer "which exact commit is this" without trusting whoever tells you the
+/// crate version number — the crate version only bumps on a release, but a build
+/// from an unreleased branch (like this one) can be anywhere on that branch's
+/// history. Falls back to "unknown" rather than failing the build: a source
+/// tarball or a shallow clone with no `.git` directory must still build.
+fn main() {
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let dirty = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false);
+
+    let suffix = if dirty { "-dirty" } else { "" };
+    println!("cargo:rustc-env=EULLM_GIT_HASH={hash}{suffix}");
+
+    // Re-run only when HEAD or the index actually changes, not on every build.
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/index");
+}

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -38,21 +38,50 @@ const DEFAULT_PIDFILE: &str = "eullm.pid";
 //   eullm 0.5.8 (CPU)
 // Only one branch matches per build because feature flags are mutually
 // exclusive (set by the release matrix).
+// The git commit this binary was built from (see build.rs) — the crate
+// version alone doesn't say which commit on an unreleased branch a build
+// came from, and "did you actually rebuild with the fix" was costing real
+// back-and-forth during hands-on debugging on real hardware.
 #[cfg(feature = "cuda")]
-const VERSION_STRING: &str = concat!(env!("CARGO_PKG_VERSION"), " (CUDA)");
+const VERSION_STRING: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (CUDA) [",
+    env!("EULLM_GIT_HASH"),
+    "]"
+);
 #[cfg(feature = "metal")]
-const VERSION_STRING: &str = concat!(env!("CARGO_PKG_VERSION"), " (Metal)");
+const VERSION_STRING: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (Metal) [",
+    env!("EULLM_GIT_HASH"),
+    "]"
+);
 #[cfg(feature = "rocm")]
-const VERSION_STRING: &str = concat!(env!("CARGO_PKG_VERSION"), " (ROCm)");
+const VERSION_STRING: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (ROCm) [",
+    env!("EULLM_GIT_HASH"),
+    "]"
+);
 #[cfg(feature = "vulkan")]
-const VERSION_STRING: &str = concat!(env!("CARGO_PKG_VERSION"), " (Vulkan)");
+const VERSION_STRING: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (Vulkan) [",
+    env!("EULLM_GIT_HASH"),
+    "]"
+);
 #[cfg(not(any(
     feature = "cuda",
     feature = "metal",
     feature = "rocm",
     feature = "vulkan"
 )))]
-const VERSION_STRING: &str = concat!(env!("CARGO_PKG_VERSION"), " (CPU)");
+const VERSION_STRING: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (CPU) [",
+    env!("EULLM_GIT_HASH"),
+    "]"
+);
 
 /// Build the `run` command implied by a choice made in the interactive picker.
 ///
@@ -2307,7 +2336,11 @@ async fn cmd_run(
     let short = model_name.strip_prefix("eullm/").unwrap_or(&model_name);
 
     println!();
-    println!("eullm ready.  [v{}]", env!("CARGO_PKG_VERSION"));
+    println!(
+        "eullm ready.  [v{} {}]",
+        env!("CARGO_PKG_VERSION"),
+        env!("EULLM_GIT_HASH")
+    );
     println!("  API (EULLM):   http://localhost:{port}/api");
     println!("  API (OpenAI):  http://localhost:{port}/v1");
     if let Some(p) = ui_port {


### PR DESCRIPTION
…anner

Crate version alone doesn't say which commit on an unreleased branch a build came from. Cost real back-and-forth during hands-on debugging: "did you rebuild with the fix" had no answer short of asking. Now -V and the startup banner both show e.g. "[a271901a74a7]", or "-dirty" appended when the working tree has uncommitted changes at build time.