### PR TITLE
chore(release): 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ Entries for **0.6.36 and later** are written by hand. Everything below that is
 derived from the commit history and reads like it: useful for tracing when
 something changed, less so for understanding what it means.
 
+## 0.7.4 — 2026-08-28
+
+### Fixed
+- **Loading a model with `--n-cpu-moe N` for `N` greater than 1 crashed
+  instead of loading**, panicking with `last buft_override was not empty`.
+  Every MoE-to-CPU layer override after the first was written into the same
+  slot instead of the next free one, so the crash was guaranteed as soon as
+  more than one layer needed offloading — in practice, any large MoE model
+  that `--fit` or a manual `--n-cpu-moe` chose to partially offload, such as
+  Qwen3-Next-80B-A3B on a single consumer GPU. `--cpu-moe` (offload every MoE
+  layer in one call) and single-layer `--n-cpu-moe 1` were unaffected; this
+  is what broke everything above that.
+- **`--fit`'s automatic GPU-layer sizing reserved more headroom for the
+  compute buffer than modern loads actually use**, so it sometimes left a
+  layer or two on CPU that would have fit on GPU. The reserve was set years
+  ago and had already been flagged as outdated; a real measurement on
+  today's loader (27B model, 16384 context) now backs the new, smaller
+  figure. This only affects the automatic split `--fit` picks when no
+  `--gpu-layers` is given — `--gpu-layers` still overrides it, and
+  `--no-fit` skips it entirely.
+
 ## 0.7.3 — 2026-08-23
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "Apache-2.0"

--- a/engine/src/fit.rs
+++ b/engine/src/fit.rs
@@ -653,21 +653,28 @@ pub(crate) const MIN_FREE_TOTAL_RATIO: f64 = 0.12;
 const VRAM_SAFETY_FRACTION: f64 = 0.97;
 
 /// Flat reserve for the CUDA context + the prefill/decode compute buffer,
-/// which does not scale per offloaded layer. The original 320 MiB was
-/// calibrated against an observed ~307 MiB CUDA0 compute buffer; it was then
-/// doubled to 640 on the theory that `n_ubatch` had been bumped to 1024. That
-/// theory is now stale twice over: `build_ctx_params_with_cache` sets
-/// `n_ubatch = n_batch.min(512)` (llama.cpp's real default — the 1024 bump was
-/// reverted), and the compute buffer has since been measured directly via the
-/// memory-breakdown table (`LlamaContext::memory_breakdown_print`) at ~507 MiB
-/// on a 27B before the `n_outputs_max` cap and expected far lower after it.
-/// So 640 is almost certainly oversized now — but lowering it is a real-fit
-/// change that must be validated on hardware before it lands (an under-reserve
-/// OOMs at load), which is why the number is left alone here and the
-/// recalibration tracked as H2-H in docs/backlog-fix-e-hardening.md. Re-measure
-/// the actual CUDA0 compute buffer with the breakdown table at the new
-/// n_ubatch and n_outputs_max before trusting this at a tight fit.
-const COMPUTE_BUFFER_RESERVE_BYTES: f64 = 640.0 * 1024.0 * 1024.0;
+/// which does not scale per offloaded layer. H2-H (docs/backlog-fix-e-hardening.md)
+/// tracked this as "almost certainly oversized" since the `n_outputs_max` cap
+/// landed, but left at 640 pending an on-hardware re-measurement — this is
+/// that re-measurement. `LlamaContext::memory_breakdown_print` on a 27B
+/// (RTX 5070 Ti, 16384 ctx, `n_ubatch` at its real default of 512, the
+/// `n_outputs_max` cap in effect) reported the actual CUDA0 compute buffer at
+/// **164 MiB**. 320 keeps roughly 2× that measurement as margin for
+/// architectures not yet re-measured (wider intermediate tensors, more attention
+/// heads) rather than pinning the reserve to one data point from one model.
+///
+/// Getting this wrong in the low direction OOMs at load, which is why it isn't
+/// pinned to the bare 164 — but this constant only feeds `--fit`'s *automatic*
+/// sizing, the guardrail for someone who launched with no `--gpu-layers` at
+/// all. Anyone who wants to steer past what it picks still can, with
+/// `--gpu-layers` (a ceiling on top of fit) or `--no-fit` (fit out of the
+/// loop entirely) — so a split that turns out mildly optimistic on some other
+/// architecture costs that person a manual `--gpu-layers` step down, not a
+/// silent failure with no recourse.
+///
+/// Re-measure via the breakdown table before lowering further; 320 is this
+/// session's floor, not a ceiling nothing will ever beat.
+const COMPUTE_BUFFER_RESERVE_BYTES: f64 = 320.0 * 1024.0 * 1024.0;
 
 /// The same kind of flat reserve as `COMPUTE_BUFFER_RESERVE_BYTES`, but for
 /// an embedding model's own compute buffer rather than a generation model's

--- a/engine/vendor/llama-cpp-rs/llama-cpp-2/src/model/params.rs
+++ b/engine/vendor/llama-cpp-rs/llama-cpp-2/src/model/params.rs
@@ -225,7 +225,7 @@ impl LlamaModelParams {
     ) {
         let kv_override = self
             .kv_overrides
-            .get_mut(0)
+            .last_mut()
             .expect("kv_overrides did not have a next allocated");
 
         assert_eq!(kv_override.key[0], 0, "last kv_override was not empty");
@@ -269,7 +269,7 @@ impl LlamaModelParams {
     pub fn add_cpu_buft_override(mut self: Pin<&mut Self>, key: &CStr) {
         let buft_override = self
             .buft_overrides
-            .get_mut(0)
+            .last_mut()
             .expect("buft_overrides did not have a next allocated");
 
         assert!(
@@ -693,6 +693,33 @@ mod tests {
         assert_eq!(
             params.tensor_buft_override_patterns(),
             vec!["\\.ffn_(up|down|gate)_(ch|)exps".to_owned()],
+        );
+    }
+
+    #[test]
+    fn tensor_buft_override_patterns_reads_back_multiple_added_overrides() {
+        // Regression test: --n-cpu-moe N>1 calls add_cpu_buft_override once per
+        // layer on the same params. A prior re-vendor swapped `.last_mut()` for
+        // `.get_mut(0)` here, which panicked on the second call ("last
+        // buft_override was not empty") because it kept re-reading the already
+        // filled first slot instead of the newest empty one.
+        let mut params = pin!(LlamaModelParams::default());
+        params
+            .as_mut()
+            .add_cpu_buft_override(c"blk\\.0\\.ffn_(up|down|gate)_(ch|)exps");
+        params
+            .as_mut()
+            .add_cpu_buft_override(c"blk\\.1\\.ffn_(up|down|gate)_(ch|)exps");
+        params
+            .as_mut()
+            .add_cpu_buft_override(c"blk\\.2\\.ffn_(up|down|gate)_(ch|)exps");
+        assert_eq!(
+            params.tensor_buft_override_patterns(),
+            vec![
+                "blk\\.0\\.ffn_(up|down|gate)_(ch|)exps".to_owned(),
+                "blk\\.1\\.ffn_(up|down|gate)_(ch|)exps".to_owned(),
+                "blk\\.2\\.ffn_(up|down|gate)_(ch|)exps".to_owned(),
+            ],
         );
     }
 


### PR DESCRIPTION
## Summary
- Fix `--n-cpu-moe N` (N>1) crashing with `last buft_override was not empty` — a re-vendor swapped `.last_mut()` for `.get_mut(0)` in `add_cpu_buft_override`/`append_kv_override`, so every override after the first overwrote the wrong slot instead of the next free one. Hit loading Qwen3-Next-80B-A3B with `--n-cpu-moe 38`.
- Recalibrate `--fit`'s compute-buffer reserve (640 → 320 MiB) from a real memory-breakdown measurement (27B model, RTX 5070 Ti, 16384 ctx), closing backlog item H2-H.
- Bump version to 0.7.4 and update `CHANGELOG.md`.

## Test plan
- [x] `cargo test -p llama-cpp-2 --lib` — 20 passed, including a new regression test that calls `add_cpu_buft_override` three times on one `LlamaModelParams`
- [x] `cargo test -p llama-cpp-2 --doc` — doctest for `append_kv_override` passes
- [x] `cargo test -p eullm-engine --bin eullm fit::` — all 31 `fit::` tests pass against the recalibrated reserve
- [x] `cargo build -p eullm-engine --bin eullm` — builds clean