### PR TITLE
chore(release): bump version to 0.7.5-rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.7.5-rc1"
+version = "0.7.5-rc2"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.7.5-rc1"
+version = "0.7.5-rc2"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Retag after the PIE link fix and fail-fast matrix fix (#384) landed — 0.7.5-rc1's CI run published with both Linux CUDA assets missing.