### PR TITLE
fix(release): install findutils in the Linux CPU build container

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -343,10 +343,14 @@ jobs:
       # — same fix as build-cuda: gcc-toolset-13 for a current compiler
       # while the produced object code still links against this image's own
       # glibc 2.28. clang-devel is bindgen's libclang for the Rust FFI
-      # bindings (needed regardless of the cuda feature).
+      # bindings (needed regardless of the cuda feature). findutils is NOT
+      # in the bare `rockylinux:8` image the way it is in build-cuda's
+      # `nvidia/cuda:*-devel-rockylinux8` (a fuller devel image) — without
+      # it, the sccache install step's `find` call fails with "command not
+      # found" (exit 127), found live on this job's first real CI run.
       - name: Install a modern GCC, build dependencies and bindgen's libclang
         run: |
-          dnf install -y gcc-toolset-13 cmake make pkgconf-pkg-config openssl-devel clang-devel curl
+          dnf install -y gcc-toolset-13 cmake make pkgconf-pkg-config openssl-devel clang-devel findutils curl
           echo "/opt/rh/gcc-toolset-13/root/usr/bin" >> $GITHUB_PATH
 
       - name: Install Rust toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.7.5-rc2"
+version = "0.7.5-rc3"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.7.5-rc2"
+version = "0.7.5-rc3"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
The bare rockylinux:8 image doesn't ship findutils the way build-cuda's fuller nvidia/cuda:*-devel-rockylinux8 image does — the sccache install step's `find` call failed with "command not found" (exit 127) on build-linux-cpu's first real CI run (EuLLM-v0.7.5-rc3).

Also bumps the version to 0.7.5-rc3: the rc3 tag was pushed pointing at a commit that never had this fix, and engine/Cargo.toml was still on rc2, so require_version_match failed too. Retag after this merges.