### PR TITLE
fix: accept per-quantization subdirectories when pulling from Hugging…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ something changed, less so for understanding what it means.
   was the wrong trade for its audience.
 
 ### Fixed
+- **`eullm pull` could not download from HuggingFace repos that put each
+  quantization in its own subdirectory.** Large models are increasingly
+  published that way — `unsloth/Qwen3.8-Flash-Next-GGUF` stores its files as
+  `UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00003.gguf` — and the
+  repo listing dropped every file whose name contained a `/`, so the whole
+  repo looked empty of weights. What the user saw was the misleading
+  `this HuggingFace repo contains only a projector (mmproj), no model
+  weights`. Subdirectories are now accepted, each path segment still
+  validated exactly as a bare filename was, and the file is saved under its
+  own name rather than the full repo path.
+
 - **The Linux CUDA binaries (`eullm-linux-x64-cuda-13.1` and the new
   `-datacenter` variant) didn't run on RHEL, CentOS, Rocky Linux, AlmaLinux,
   or Oracle Linux — any RHEL 8-family distro.** They were built against

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.7.5-rc4"
+version = "0.7.5-rc5"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.7.5-rc4"
+version = "0.7.5-rc5"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "AGPL-3.0-or-later"

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1096,7 +1096,18 @@ async fn cmd_pull_hf(store: &ModelStore, hf: &registry::HfRef) {
     println!();
 
     let model_dir = store.model_path(&id);
-    let gguf_dest = model_dir.join(&filename);
+    // `filename` is the repo-relative path and can carry a subdirectory when
+    // the repo groups quantizations (`UD-Q4_K_XL/Model-…-00001-of-00004.gguf`).
+    // The remote path is what the download needs; locally the model already
+    // has its own directory, so that prefix is redundant and the file is
+    // stored under its bare name — the same flattening the projector branch
+    // below has always done.
+    let leaf = filename
+        .rsplit('/')
+        .next()
+        .unwrap_or(&filename)
+        .to_string();
+    let gguf_dest = model_dir.join(&leaf);
 
     let result = {
         use crate::registry::download_from_huggingface;
@@ -1151,9 +1162,11 @@ async fn cmd_pull_hf(store: &ModelStore, hf: &registry::HfRef) {
     match result {
         Ok(()) => {
             let size = std::fs::metadata(&gguf_dest).map(|m| m.len()).unwrap_or(0);
+            // `leaf`, not `filename`: the manifest names a file inside this
+            // model's directory, and that is where the flattened basename is.
             match store.write_external_manifest(
                 &id,
-                &filename,
+                &leaf,
                 &hf.original,
                 size,
                 mmproj_stored.as_deref(),

--- a/engine/src/models/store.rs
+++ b/engine/src/models/store.rs
@@ -67,6 +67,27 @@ pub fn is_safe_filename(name: &str) -> bool {
         && Path::new(name).components().count() == 1
 }
 
+/// Whether `path` is safe as a *remote* HuggingFace reference: one or more
+/// components, each one safe by `is_safe_filename`.
+///
+/// Repos that publish many quantizations give each its own subdirectory —
+/// `UD-Q4_K_XL/Model-UD-Q4_K_XL-00001-of-00004.gguf` — so `siblings[].rfilename`
+/// is a path, not a bare name. Judging those with `is_safe_filename` dropped
+/// every weight file in such a repo and left only the projector sitting at the
+/// repo root, which surfaced as the nonsensical "this HuggingFace repo contains
+/// only a projector (mmproj), no model weights". Found live pulling
+/// `unsloth/Qwen3.8-Flash-Next-GGUF`, whose weights are *all* in subdirectories.
+///
+/// The traversal guarantee is unchanged, because every component still goes
+/// through the same rules: `..`, absolute prefixes, backslashes, drive letters
+/// and NUL are all rejected per component, and an absolute path fails outright
+/// (its leading `/` splits to an empty first component). Callers still reduce
+/// this to a basename before touching the filesystem — this validates the value
+/// on the way *out* to the network, which is a use of its own.
+pub fn is_safe_relative_path(path: &str) -> bool {
+    !path.is_empty() && path.len() <= 4096 && path.split('/').all(is_safe_filename)
+}
+
 /// Manages the local model directory (`~/.eullm/models/`).
 pub struct ModelStore {
     root: PathBuf,
@@ -773,6 +794,76 @@ mod tests {
         let listed = store.list().unwrap();
         assert_eq!(listed[0].id, "my-model");
         fs::remove_dir_all(&root).ok();
+    }
+}
+
+#[cfg(test)]
+mod safe_relative_path_tests {
+    use super::{is_safe_filename, is_safe_relative_path};
+
+    /// The case that motivated this: `unsloth/Qwen3.8-Flash-Next-GGUF` keeps
+    /// every quantization in its own subdirectory, so judging the HF API's
+    /// `rfilename` values as single filenames dropped all the weights and left
+    /// only the repo-root projector — reported to the user as "this repo
+    /// contains only a projector, no model weights".
+    #[test]
+    fn accepts_the_per_quant_subdirectory_layout() {
+        for path in [
+            "UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf",
+            "Q8_0/Qwen3.8-Flash-Next-Q8_0-00006-of-00006.gguf",
+            "BF16/Qwen3.8-Flash-Next-BF16-00001-of-00008.gguf",
+            "MTP/mtp-Qwen3.8-Flash-Next-Q4_K_M.gguf",
+        ] {
+            assert!(is_safe_relative_path(path), "should accept {path:?}");
+            assert!(
+                !is_safe_filename(path),
+                "{path:?} is exactly the shape the old check rejected"
+            );
+        }
+    }
+
+    /// Widening to paths must not widen what escapes: every component is still
+    /// judged by the same rules.
+    #[test]
+    fn still_rejects_anything_that_escapes() {
+        for path in [
+            "../../../../etc/cron.d/payload.gguf",
+            "UD-Q4_K_XL/../../../etc/shadow.gguf",
+            "/etc/shadow.gguf",
+            "UD-Q4_K_XL//model.gguf", // empty component
+            "UD-Q4_K_XL/",
+            "sub\\dir/model.gguf",
+            "C:\\Windows\\model.gguf",
+            "UD-Q4_K_XL/.hidden.gguf",
+            "UD-Q4_K_XL/model\0.gguf",
+            "",
+        ] {
+            assert!(!is_safe_relative_path(path), "should reject {path:?}");
+        }
+    }
+
+    /// A bare filename is still a valid relative path — the single-component
+    /// case must keep working, since most repos are laid out flat.
+    #[test]
+    fn a_bare_filename_is_still_accepted() {
+        for name in ["qwen3-8b-Q4_K_M.gguf", "mmproj-F16.gguf"] {
+            assert!(is_safe_relative_path(name));
+        }
+    }
+
+    /// The property callers rely on: taking the last component of any accepted
+    /// path yields a name that is itself safe to join onto the model directory.
+    #[test]
+    fn the_basename_of_an_accepted_path_is_always_a_safe_filename() {
+        for path in [
+            "UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf",
+            "a/b/c/model.gguf",
+            "model.gguf",
+        ] {
+            assert!(is_safe_relative_path(path));
+            let leaf = path.rsplit('/').next().unwrap();
+            assert!(is_safe_filename(leaf), "basename of {path:?} must be safe");
+        }
     }
 }
 

--- a/engine/src/registry/mod.rs
+++ b/engine/src/registry/mod.rs
@@ -580,12 +580,17 @@ pub async fn list_hf_ggufs(
             if !name.to_lowercase().ends_with(".gguf") {
                 continue;
             }
-            // The suffix used to be the only check, and this value becomes a
-            // path component in `cmd_pull_hf` (`model_dir.join(&filename)`).
-            // A repo is free to declare whatever `rfilename` it likes, so
-            // anything that isn't a single safe filename is dropped here, at
-            // the boundary, rather than being validated at each use site.
-            if !crate::models::store::is_safe_filename(name) {
+            // The suffix used to be the only check. A repo is free to declare
+            // whatever `rfilename` it likes, so anything unsafe is dropped
+            // here, at the boundary, rather than being validated at each use
+            // site.
+            //
+            // A *relative path* is allowed, not just a bare filename: repos
+            // with many quantizations put each in its own subdirectory, and
+            // requiring a single component rejected every weight file in such
+            // a repo. Callers store the basename, so nothing joins this onto a
+            // local directory as-is.
+            if !crate::models::store::is_safe_relative_path(name) {
                 tracing::warn!(
                     "Ignoring unsafe filename from the HuggingFace API for {repo}: {}",
                     crate::audit::sanitize_for_log(name),


### PR DESCRIPTION
…Face

Repos that organise each quantization into its own directory -- unsloth/Qwen3.8-Flash-Next-GGUF publishes
UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00003.gguf -- were unusable: the listing filter rejected every name containing a slash, so the repo appeared to hold no weights at all and pull failed with the misleading "contains only a projector (mmproj), no model weights".

is_safe_relative_path validates each path segment with the same is_safe_filename check the bare-name filter used, so the traversal guarantee is unchanged: no empty segment, no "." or "..", no absolute path, no backslash. cmd_pull_hf now saves the file under its leaf name rather than the full repo path, and records that leaf in the external manifest.

Bumps the version to 0.7.5-rc5.