### PR TITLE
fix: render the model's own chat template on the multimodal path, dro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,33 @@ something changed, less so for understanding what it means.
   was the wrong trade for its audience.
 
 ### Fixed
+- **Images sent to a non-Gemma multimodal model were refused outright, or
+  answered badly.** Two separate causes, both now fixed, found running
+  Qwen3.8-Flash-Next on 4× A100.
+
+  The first was an outright refusal: `This model requires M-RoPE positions,
+  which the current MVP does not yet plumb through the decode loop`. The
+  guard assumed a model with multi-dimensional positions needed four
+  positions per token in the decode batch. It does not — llama.cpp
+  broadcasts a text batch's single position across all RoPE sections, and
+  its own reference `mtmd-cli` generates with the same scalar position we
+  do. Every Qwen VL was refused for nothing. The guard is gone; `m_rope` is
+  now only logged at load.
+
+  The second was quieter and worse. The multimodal path built its prompt
+  with Gemma's `<start_of_turn>` turn markers, hardcoded, for every model.
+  It now renders the model's own GGUF-embedded chat template — what the
+  text path has done since 0.7.0 — with the media marker placed inside the
+  user message, so a Qwen VL gets ChatML and a Gemma still gets Gemma. A
+  wrong template does not error, it just degrades the answer, which is why
+  this survived: Gemma 4 was the only multimodal model in the catalog. The
+  `think` parameter now reaches the multimodal path too. Both the API and
+  `eullm run --image` are fixed.
+
 - **`eullm pull` could not download from HuggingFace repos that put each
   quantization in its own subdirectory.** Large models are increasingly
   published that way — `unsloth/Qwen3.8-Flash-Next-GGUF` stores its files as
-  `UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00003.gguf` — and the
+  `UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf` — and the
   repo listing dropped every file whose name contained a `/`, so the whole
   repo looked empty of weights. What the user saw was the misleading
   `this HuggingFace repo contains only a projector (mmproj), no model

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.7.5-rc5"
+version = "0.7.5-rc6"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.7.5-rc5"
+version = "0.7.5-rc6"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "AGPL-3.0-or-later"

--- a/engine/src/api/routes.rs
+++ b/engine/src/api/routes.rs
@@ -329,12 +329,47 @@ fn extract_multimodal_payload(messages: &[Value]) -> Option<(String, Vec<Vec<u8>
     Some((text, media))
 }
 
-/// Wrap a user prompt in the Gemma chat template with an mtmd media marker
-/// placed inside the user turn (matches `run_multimodal_oneshot` in main.rs).
+/// Build the prompt for a multimodal turn, preferring the model's own
+/// GGUF-embedded Jinja template — the same choice [`build_chat_prompt`] makes
+/// for text.
+///
+/// The mtmd media marker goes inside the user message's **content**, before
+/// the template renders, so the model receives the turn markers it was
+/// actually trained on: `<|im_start|>user` for a Qwen VL, `<start_of_turn>user`
+/// for Gemma. This is also how llama-server does it.
+///
+/// It was Gemma's markers in every case until now, and the reason is worth
+/// recording because it is the divergence `engine/CLAUDE.md` warns about. The
+/// multimodal branch landed two days before `build_chat_prompt` learned to
+/// render the embedded template, and it returns early — above that call — so
+/// it never picked the change up. Gemma 4 was the only multimodal model in the
+/// catalog, so nothing looked wrong until a Qwen VL arrived and was handed
+/// `<start_of_turn>` tokens it has never seen. A wrong template does not
+/// error; it degrades the answer quietly, which is the worst way to be wrong.
+///
+/// Returns the prompt together with the stop sequences that belong to it:
+/// none when the embedded template rendered (its EOG token ends generation,
+/// the contract `build_chat_prompt` already uses), Gemma's when we fell back.
+///
+/// Only the latest user turn is rendered. That predates this change — the
+/// payload extractor returns one turn's text and its images — so multi-turn
+/// image conversations still lose their history here.
 #[cfg(feature = "multimodal")]
-fn gemma_multimodal_prompt(user_text: &str) -> String {
+fn multimodal_chat_prompt(
+    engine: &InferenceEngine,
+    user_text: &str,
+    think: bool,
+) -> (String, Vec<String>) {
     let marker = llama_cpp_2::mtmd::mtmd_default_marker();
-    format!("<start_of_turn>user\n{marker}\n{user_text}<end_of_turn>\n<start_of_turn>model\n")
+    let marked = format!("{marker}\n{user_text}");
+    let pairs: [(&str, &str); 1] = [("user", marked.as_str())];
+    if let Some(dynamic) = engine.apply_jinja_chat_template(&pairs, think) {
+        return (dynamic.prompt, Vec::new());
+    }
+    (
+        format!("<start_of_turn>user\n{marked}<end_of_turn>\n<start_of_turn>model\n"),
+        crate::chat_template::ChatTemplate::Gemma.stop_sequences(),
+    )
 }
 
 /// Background mtmd-aware generation, mirroring `sequential_to_channel`.
@@ -1176,8 +1211,12 @@ async fn chat(
             }
         };
         let sp = parse_generate_params(&body);
+        // Parsed here rather than reused from the text path below: the
+        // multimodal branch returns before that code runs.
+        let mm_think = body.get("think").and_then(|v| v.as_bool()).unwrap_or(true);
+        let (mm_prompt, mm_stops) = multimodal_chat_prompt(&engine, &user_text, mm_think);
         let mm_request = GenerateRequest {
-            prompt: gemma_multimodal_prompt(&user_text),
+            prompt: mm_prompt,
             max_tokens: sp.max_tokens,
             temperature: sp.temperature,
             top_k: sp.top_k,
@@ -1187,15 +1226,15 @@ async fn chat(
             repeat_last_n: sp.repeat_last_n,
             seed: sp.seed,
             num_ctx: sp.num_ctx,
-            // Hand-built Gemma template with the mtmd marker — do NOT let
-            // generate() add its own BOS/template on top.
+            // The prompt is already templated, with the mtmd marker in place —
+            // do NOT let generate() add its own BOS/template on top.
             raw: true,
-            // The same list the text path uses. It was spelled out here, so a
-            // stop sequence added for Gemma applied everywhere except the one
-            // path that only runs with a Gemma model.
-            stop_sequences: crate::chat_template::ChatTemplate::Gemma.stop_sequences(),
-            // Gemma has no think toggle, so nothing extra to strip here.
-            filter_sequences: crate::inference::default_filters(true),
+            // Empty when the model's own template rendered: its EOG token ends
+            // generation. See `multimodal_chat_prompt`.
+            stop_sequences: mm_stops,
+            // think-aware, like the text path: a model that can be asked not to
+            // think can also emit a think tag that has to be stripped.
+            filter_sequences: crate::inference::default_filters(mm_think),
             grammar: None,
         };
         if is_streaming(&body) {

--- a/engine/src/inference/mod.rs
+++ b/engine/src/inference/mod.rs
@@ -1708,9 +1708,9 @@ impl InferenceEngine {
             .map_err(|e| format!("Failed to load mmproj: {e}"))?;
 
         // Log capability flags up front so the user (and our own logs) can
-        // see at a glance what this projector enables. M-RoPE is the load-
-        // time guard the plan called out: scalar position bookkeeping in
-        // our scheduler/generate loop is incorrect for M-RoPE models.
+        // see at a glance what this projector enables. `m_rope` was a
+        // load-time refusal until 0.7.5-rc6 and is now only a fact worth
+        // recording — see `generate_multimodal` for why the guard was wrong.
         let support_vision = ctx.support_vision();
         let support_audio = ctx.support_audio();
         let use_mrope = ctx.decode_use_mrope();
@@ -1719,14 +1719,6 @@ impl InferenceEngine {
             "mmproj loaded — vision={support_vision} audio={support_audio} \
              m_rope={use_mrope} non_causal={use_non_causal}"
         );
-        if use_mrope {
-            tracing::warn!(
-                "mmproj reports decode_use_mrope=true — this model uses \
-                 multi-dimensional positions. The current MVP only supports \
-                 scalar-position models (e.g. Gemma 4). Multimodal calls \
-                 will refuse media input on this model."
-            );
-        }
 
         Ok(Some(ctx))
     }
@@ -2183,8 +2175,8 @@ impl InferenceEngine {
     /// audio file (wav/mp3/flac) — `MtmdBitmap::from_buffer` auto-detects.
     ///
     /// Returns immediately via `StreamEvent::Error` if multimodal is not
-    /// configured for this engine, the M-RoPE guard refuses the model, or
-    /// the requested modality is not supported by the loaded projector.
+    /// configured for this engine, or the requested modality is not supported
+    /// by the loaded projector.
     #[cfg(feature = "multimodal")]
     pub fn generate_multimodal(
         &self,
@@ -2209,15 +2201,20 @@ impl InferenceEngine {
             ));
             return;
         };
-        if mtmd_ctx.decode_use_mrope() {
-            let _ = tx.blocking_send(StreamEvent::Error(
-                "This model requires M-RoPE positions, which the current MVP \
-                 does not yet plumb through the decode loop. Image/audio input \
-                 is refused; text-only requests still work via generate_streaming."
-                    .into(),
-            ));
-            return;
-        }
+        // No M-RoPE guard here any more, and the reason is in upstream's own
+        // code. The guard assumed a model with multi-dimensional positions
+        // needed four positions per token in the decode batch, and that our
+        // scalar `batch.add(token, n_cur, ..)` below would therefore be wrong.
+        // It isn't: `llama_batch_allocr` broadcasts a text batch's single
+        // position across all RoPE sections — `src_off = batch.token ? 0 : ..`
+        // in `llama-batch.cpp`, with the comment spelling it out — and
+        // llama.cpp's reference `mtmd-cli` generates with exactly the same
+        // scalar `common_batch_add(batch, token_id, n_past++, {0}, true)`.
+        // The image's real 2D positions are set inside `eval_chunks`, which
+        // returns an `n_past` already advanced past the whole grid, so the
+        // decode loop resumes at a position the M-RoPE consistency check
+        // accepts. Refusing these models cost us every Qwen VL for nothing.
+        //
         // Reject the request if the user supplied a modality the projector
         // does not support, to fail loudly rather than silently mis-decode.
         let has_audio = media.iter().any(|b| {

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -3918,9 +3918,9 @@ fn format_bytes(bytes: u64) -> String {
 }
 
 /// One-shot multimodal probe: load the file at `image_path`, read a prompt
-/// from stdin (or use a default), wrap it in the Gemma chat template with
-/// the mtmd media marker, run a single multimodal generation, stream tokens
-/// to stdout, exit.
+/// from stdin (or use a default), wrap it in the model's own chat template
+/// with the mtmd media marker, run a single multimodal generation, stream
+/// tokens to stdout, exit.
 ///
 /// This is the MVP entry point for the mtmd integration — deliberately tiny.
 /// API/UI multimodal surface is intentionally out of scope here.
@@ -3957,22 +3957,32 @@ async fn run_multimodal_oneshot(engine: Arc<InferenceEngine>, image_path: PathBu
         user_prompt
     };
 
-    // 3. Wrap in the Gemma chat template with the media marker placed inside
-    //    the user turn. Future work: detect the template from the model name
-    //    instead of hardcoding Gemma — but our only multimodal catalog entry
-    //    today is Gemma 4 12B, so this is correct for the MVP.
+    // 3. Template the turn with the media marker inside the user content,
+    //    using the model's own GGUF-embedded Jinja template — the same choice
+    //    the API path makes in `multimodal_chat_prompt`. Hardcoding Gemma here
+    //    was correct only while Gemma 4 was the sole multimodal model we
+    //    shipped; a Qwen VL fed `<start_of_turn>` answers badly and says
+    //    nothing about why.
     let marker = mtmd_default_marker();
-    let templated = format!(
-        "<start_of_turn>user\n{marker}\n{user_prompt}<end_of_turn>\n<start_of_turn>model\n"
-    );
+    let marked = format!("{marker}\n{user_prompt}");
+    let pairs: [(&str, &str); 1] = [("user", marked.as_str())];
+    let (templated, stop_sequences) = match engine.apply_jinja_chat_template(&pairs, true) {
+        // The model's own template ends generation on its EOG token, so there
+        // is no stop sequence to add on top.
+        Some(dynamic) => (dynamic.prompt, Vec::new()),
+        None => (
+            format!("<start_of_turn>user\n{marked}<end_of_turn>\n<start_of_turn>model\n"),
+            vec!["<end_of_turn>".to_string()],
+        ),
+    };
 
     // 4. Build the request and stream the answer to stdout.
     let request = inference::GenerateRequest {
         prompt: templated,
         max_tokens: 512,
         temperature: 0.7,
-        raw: true, // template is hand-built, no extra BOS / formatting
-        stop_sequences: vec!["<end_of_turn>".to_string()],
+        raw: true, // already templated, no extra BOS / formatting
+        stop_sequences,
         ..Default::default()
     };
 


### PR DESCRIPTION
…p the M-RoPE refusal

Two independent defects kept every non-Gemma multimodal model from working, both found running Qwen3.8-Flash-Next on 4x A100.

The M-RoPE guard refused any projector reporting decode_use_mrope=true, on the assumption that a model with multi-dimensional positions needs four positions per token in the decode batch and that our scalar batch.add(token, n_cur, ..) would be wrong. Upstream says otherwise: llama_batch_allocr broadcasts a text batch's single position across all RoPE sections (src_off = batch.token ? 0 : .. in llama-batch.cpp, with the comment spelling it out), and llama.cpp's reference mtmd-cli generates with the same scalar common_batch_add. The image's real 2D positions are set inside eval_chunks, which returns an n_past already advanced past the whole grid, so the decode loop resumes where the M-RoPE consistency check expects. The guard is gone; m_rope is now logged at load and nothing more.

The prompt was built with Gemma's <start_of_turn> markers, hardcoded, for every model. The multimodal branch landed two days before build_chat_prompt learned to render the GGUF-embedded Jinja template, and it returns early -- above that call -- so it never picked the change up. Gemma 4 being the only multimodal model in the catalog, nothing looked wrong. multimodal_chat_prompt now renders the model's own template with the media marker inside the user content, exactly as llama-server does, and falls back to the Gemma format only when the model ships no template. Stop sequences follow the same contract as the text path: none when the embedded template rendered, since its EOG token ends generation. `think` now reaches this path too, instead of being pinned on. run_multimodal_oneshot (eullm run --image) gets the same treatment.

Also corrects the shard count in the 0.7.5 changelog entry for the HuggingFace subdirectory fix: the UD-Q4_K_XL quantization is four shards, not three.

Bumps the version to 0.7.5-rc6.