### PR TITLE
fix: download every shard of a split GGUF on pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,25 @@ something changed, less so for understanding what it means.
   was the wrong trade for its audience.
 
 ### Fixed
+- **`eullm pull` now downloads split GGUFs, so large quantizations can be
+  pulled at all.** A model published as `…-00001-of-00004.gguf` is four
+  files, and llama.cpp opens the rest from the first only once they are all
+  on disk — but the pull resolved to a single filename and downloaded one.
+  With four shards matching the requested quantization, none of the
+  single-file branches applied and the pull ended on `multiple .gguf files
+  match quant 'UD-Q4_K_XL'`. Every shard is now fetched, in order, and the
+  recorded size is the sum rather than the first shard's.
+
+  This completes the previous entry, which did not go as far as it read: it
+  made the files in a per-quantization subdirectory *visible*, which changed
+  the failure from `contains only a projector` to the ambiguity error above,
+  but left `unsloth/Qwen3.8-Flash-Next-GGUF` — and every repo like it —
+  still impossible to pull. A repo whose only model is one split is also no
+  longer refused with `pass an explicit :<quant>`, which was advice that led
+  straight into the same wall. An incomplete split is refused up front,
+  naming the missing shards, rather than downloading most of a model and
+  failing at load.
+
 - **Images sent to a non-Gemma multimodal model were refused outright, or
   answered badly.** Two separate causes, both now fixed, found running
   Qwen3.8-Flash-Next on 4× A100.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.7.5-rc6"
+version = "0.7.5-rc7"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.7.5-rc6"
+version = "0.7.5-rc7"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "AGPL-3.0-or-later"

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1082,7 +1082,7 @@ async fn cmd_pull_hf(store: &ModelStore, hf: &registry::HfRef) {
     }
 
     println!("Resolving HuggingFace repo: {}", hf.repo);
-    let filename = match registry::resolve_hf_gguf(hf).await {
+    let filenames = match registry::resolve_hf_gguf(hf).await {
         Ok(f) => f,
         Err(e) => {
             eprintln!("Could not resolve a GGUF to download: {e}");
@@ -1090,37 +1090,59 @@ async fn cmd_pull_hf(store: &ModelStore, hf: &registry::HfRef) {
         }
     };
 
-    println!("Pulling from HuggingFace: {} ({})", hf.repo, filename);
+    if filenames.len() > 1 {
+        println!(
+            "Pulling from HuggingFace: {} ({} shards)",
+            hf.repo,
+            filenames.len()
+        );
+        for f in &filenames {
+            println!("    {f}");
+        }
+    } else {
+        println!("Pulling from HuggingFace: {} ({})", hf.repo, filenames[0]);
+    }
     println!("  Storing as: {id}");
     println!("  (off-catalog model — no license/VRAM metadata available)");
     println!();
 
     let model_dir = store.model_path(&id);
-    // `filename` is the repo-relative path and can carry a subdirectory when
+    // Each name is the repo-relative path and can carry a subdirectory when
     // the repo groups quantizations (`UD-Q4_K_XL/Model-…-00001-of-00004.gguf`).
     // The remote path is what the download needs; locally the model already
     // has its own directory, so that prefix is redundant and the file is
     // stored under its bare name — the same flattening the projector branch
-    // below has always done.
-    let leaf = filename
-        .rsplit('/')
-        .next()
-        .unwrap_or(&filename)
-        .to_string();
-    let gguf_dest = model_dir.join(&leaf);
+    // below has always done. Shards must keep their `-NNNNN-of-TOTAL` suffix,
+    // which they do: only the directory prefix is dropped.
+    let leaves: Vec<String> = filenames
+        .iter()
+        .map(|f| f.rsplit('/').next().unwrap_or(f).to_string())
+        .collect();
+    // The manifest names the first shard. llama.cpp reads the split count from
+    // its header and opens the siblings itself, which is why they all have to
+    // land in the same directory.
+    let leaf = leaves[0].clone();
 
-    let result = {
-        use crate::registry::download_from_huggingface;
-        download_from_huggingface(
+    let mut result = Ok(());
+    for (i, (remote, local)) in filenames.iter().zip(leaves.iter()).enumerate() {
+        if filenames.len() > 1 {
+            println!("  [{}/{}] {local}", i + 1, filenames.len());
+        }
+        result = registry::download_from_huggingface(
             &hf.repo,
-            &filename,
-            &gguf_dest,
+            remote,
+            &model_dir.join(local),
             None,
             Some(download_progress()),
         )
-        .await
-    };
-    eprintln!();
+        .await;
+        eprintln!();
+        // Stop at the first failure: a partial split cannot be loaded, and the
+        // error handling below deletes the whole model directory anyway.
+        if result.is_err() {
+            break;
+        }
+    }
 
     // A vision repo ships the projector beside the weights, and without it the
     // model loads but cannot see. llama.cpp's own `-hf` fetches both, and a
@@ -1161,9 +1183,17 @@ async fn cmd_pull_hf(store: &ModelStore, hf: &registry::HfRef) {
 
     match result {
         Ok(()) => {
-            let size = std::fs::metadata(&gguf_dest).map(|m| m.len()).unwrap_or(0);
-            // `leaf`, not `filename`: the manifest names a file inside this
-            // model's directory, and that is where the flattened basename is.
+            // Every shard, not just the first: the recorded size is what the
+            // model costs on disk, and `eullm list` showing 30 GB for a 111 GB
+            // split would be worse than showing nothing.
+            let size: u64 = leaves
+                .iter()
+                .filter_map(|l| std::fs::metadata(model_dir.join(l)).ok())
+                .map(|m| m.len())
+                .sum();
+            // `leaf`, not the repo-relative name: the manifest names a file
+            // inside this model's directory, and that is where the flattened
+            // basename is.
             match store.write_external_manifest(
                 &id,
                 &leaf,

--- a/engine/src/registry/mod.rs
+++ b/engine/src/registry/mod.rs
@@ -449,17 +449,92 @@ pub fn is_mmproj(name: &str) -> bool {
         .starts_with("mmproj")
 }
 
-fn select_gguf(ggufs: &[String], requested_quant: Option<&str>) -> Result<String, String> {
+/// One split GGUF: every shard of `stem-NNNNN-of-TOTAL.gguf`, in order.
+#[derive(Debug)]
+struct ShardSet {
+    /// Everything before `-NNNNN-of-TOTAL.gguf`, which identifies the split.
+    stem: String,
+    /// How many shards the filenames themselves claim exist.
+    total: u32,
+    /// The shards present in the repo listing, ordered by index.
+    files: Vec<String>,
+}
+
+impl ShardSet {
+    fn is_complete(&self) -> bool {
+        self.files.len() as u32 == self.total
+    }
+}
+
+/// Decompose `…/Model-Q4_K_XL-00002-of-00004.gguf` into its stem, index and
+/// total. `None` for anything that is not a split shard.
+fn parse_shard(name: &str) -> Option<(&str, u32, u32)> {
+    let base = name.get(..name.len().checked_sub(5)?)?;
+    if !name[name.len() - 5..].eq_ignore_ascii_case(".gguf") {
+        return None;
+    }
+    let (rest, total) = base.rsplit_once("-of-")?;
+    let (stem, index) = rest.rsplit_once('-')?;
+    let total: u32 = total.parse().ok()?;
+    let index: u32 = index.parse().ok()?;
+    // A zero index or a shard numbered past the total is not a split we
+    // understand; treat the name as an ordinary file rather than guess.
+    if index == 0 || total == 0 || index > total {
+        return None;
+    }
+    Some((stem, index, total))
+}
+
+/// Split a candidate list into standalone files and the split GGUFs they
+/// belong to. Shard order follows the index in the filename, not the order
+/// the API happened to list them in.
+fn group_shards(files: &[&String]) -> (Vec<String>, Vec<ShardSet>) {
+    let mut singles = Vec::new();
+    // Insertion-ordered so the result does not depend on hash iteration order,
+    // which would make an ambiguity error vary between runs.
+    let mut sets: Vec<(ShardSet, Vec<(u32, String)>)> = Vec::new();
+    for f in files {
+        let Some((stem, index, total)) = parse_shard(f) else {
+            singles.push((*f).clone());
+            continue;
+        };
+        match sets.iter_mut().find(|(s, _)| s.stem == stem) {
+            Some((_, indexed)) => indexed.push((index, (*f).clone())),
+            None => sets.push((
+                ShardSet {
+                    stem: stem.to_string(),
+                    total,
+                    files: Vec::new(),
+                },
+                vec![(index, (*f).clone())],
+            )),
+        }
+    }
+    let sets = sets
+        .into_iter()
+        .map(|(mut set, mut indexed)| {
+            indexed.sort_by_key(|(i, _)| *i);
+            indexed.dedup_by_key(|(i, _)| *i);
+            set.files = indexed.into_iter().map(|(_, f)| f).collect();
+            set
+        })
+        .collect();
+    (singles, sets)
+}
+
+/// Every file that has to be downloaded for one model, in the order to
+/// fetch them.
+///
+/// A split GGUF is `N` files and llama.cpp opens the rest from the first, but
+/// only once they are all on disk — so returning one name was never enough.
+/// Until 0.7.5-rc7 this returned a single `String`, which is why pulling a
+/// large quantization from a repo that ships it split failed: with four
+/// shards matching the requested quant, none of the single-file branches
+/// applied and the pull ended on `multiple .gguf files match quant`.
+fn select_gguf(ggufs: &[String], requested_quant: Option<&str>) -> Result<Vec<String>, String> {
     if ggufs.is_empty() {
         return Err("no .gguf files found in this HuggingFace repo".to_string());
     }
-
-    // Sharded multi-file ggufs (e.g. `model-00001-of-00003.gguf`) cannot be
-    // loaded from a single file — refuse to guess and let the user pick.
-    let is_shard = |name: &str| {
-        let lower = name.to_lowercase();
-        lower.contains("-of-") && lower.contains(".gguf")
-    };
 
     // A projector is a `.gguf` in the same repo but never the model, and it
     // has to come out of the candidate set before anything else looks at it.
@@ -496,19 +571,35 @@ fn select_gguf(ggufs: &[String], requested_quant: Option<&str>) -> Result<String
         ));
     }
 
-    // If a quant was requested and it disambiguates to a single file, use it
-    // even if other (non-matching) shards exist.
+    let (singles, sets) = group_shards(&candidates);
+
+    // Refusing to download a split we know to be incomplete beats downloading
+    // three quarters of a model and failing at load with an error about the
+    // file rather than about the repo.
+    let take = |set: ShardSet| -> Result<Vec<String>, String> {
+        if set.is_complete() {
+            return Ok(set.files);
+        }
+        Err(format!(
+            "'{}' is split into {} shards but the repo lists only {}. \
+             The upload looks incomplete; nothing was downloaded.",
+            set.stem,
+            set.total,
+            set.files.len(),
+        ))
+    };
+
     if requested_quant.is_some() {
-        let non_shard: Vec<&&String> = candidates
-            .iter()
-            .filter(|f| !is_shard(f.as_str()))
-            .collect();
-        if non_shard.len() == 1 {
-            return Ok(non_shard[0].to_string());
+        // A quant that disambiguates to a single standalone file wins even
+        // when other (non-matching) shards are present in the repo.
+        if singles.len() == 1 {
+            return Ok(vec![singles.into_iter().next().unwrap()]);
+        }
+        if singles.is_empty() && sets.len() == 1 {
+            return take(sets.into_iter().next().unwrap());
         }
         if candidates.len() == 1 {
-            // Single match, even if it looks like a shard — let llama.cpp try.
-            return Ok(candidates[0].to_string());
+            return Ok(vec![candidates[0].to_string()]);
         }
         return Err(format!(
             "multiple .gguf files match quant '{}'. Re-run with a more specific :<quant>. Available files:\n{}",
@@ -517,25 +608,29 @@ fn select_gguf(ggufs: &[String], requested_quant: Option<&str>) -> Result<String
         ));
     }
 
-    // No quant requested: refuse if the repo only contains shards (we'd have
-    // to guess across them), otherwise prefer the standard quants.
-    let single_file: Vec<&String> = ggufs.iter().filter(|f| !is_shard(f.as_str())).collect();
-    if single_file.is_empty() {
-        return Err(format!(
-            "this repo only contains sharded .gguf files; pass an explicit :<quant>. Available files:\n{}",
-            list_for_error(ggufs),
-        ));
-    }
-
+    // No quant requested: prefer a standalone file, and fall back to a split
+    // when it is the only thing the repo offers. Guessing across *several*
+    // splits is still refused — that is a real choice for the user to make.
     let prefer = |needle: &str| {
-        single_file
+        singles
             .iter()
             .find(|f| f.to_lowercase().contains(needle))
-            .map(|f| f.to_string())
+            .cloned()
     };
-    Ok(prefer("q4_k_m")
-        .or_else(|| prefer("q4_0"))
-        .unwrap_or_else(|| single_file[0].to_string()))
+    if !singles.is_empty() {
+        return Ok(vec![
+            prefer("q4_k_m")
+                .or_else(|| prefer("q4_0"))
+                .unwrap_or_else(|| singles[0].clone()),
+        ]);
+    }
+    if sets.len() == 1 {
+        return take(sets.into_iter().next().unwrap());
+    }
+    Err(format!(
+        "this repo contains several sharded .gguf models; pass an explicit :<quant>. Available files:\n{}",
+        list_for_error(ggufs),
+    ))
 }
 
 /// Render a bullet list of filenames for an error message.
@@ -605,11 +700,15 @@ pub async fn list_hf_ggufs(
 
 /// Resolve a HuggingFace ref to a single GGUF filename to download.
 ///
-/// Combines [`list_hf_ggufs`] and [`select_gguf`]. The returned string is the
+/// Combines [`list_hf_ggufs`] and [`select_gguf`]. Each returned string is an
 /// `rfilename` to fetch from `{repo}/resolve/main/{filename}`.
+///
+/// More than one file comes back when the model is a split GGUF: all of its
+/// shards, in order, all of which have to be on disk before llama.cpp can
+/// open the first.
 pub async fn resolve_hf_gguf(
     hf: &HfRef,
-) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
     let ggufs = list_hf_ggufs(&hf.repo).await?;
     select_gguf(&ggufs, hf.quant.as_deref()).map_err(|e| e.into())
 }
@@ -754,7 +853,7 @@ mod tests {
             "model-Q4_K_M.gguf".to_string(),
             "model-Q4_0.gguf".to_string(),
         ];
-        assert_eq!(select_gguf(&files, None).unwrap(), "model-Q4_K_M.gguf");
+        assert_eq!(select_gguf(&files, None).unwrap(), ["model-Q4_K_M.gguf"]);
     }
 
     #[test]
@@ -763,20 +862,91 @@ mod tests {
             "model-Q8_0.gguf".to_string(),
             "model-Q4_K_M.gguf".to_string(),
         ];
+        assert_eq!(select_gguf(&files, Some("q8_0")).unwrap(), ["model-Q8_0.gguf"]);
+    }
+
+    // A repo whose only model is one split GGUF used to be refused with
+    // "pass an explicit :<quant>" -- and passing one refused again, because
+    // several files matched it. Both halves failed, so the repo could not be
+    // pulled at all. The whole split now comes back, in shard order.
+    #[test]
+    fn select_returns_a_whole_split_without_quant() {
+        let files = vec![
+            "model-00002-of-00003.gguf".to_string(),
+            "model-00003-of-00003.gguf".to_string(),
+            "model-00001-of-00003.gguf".to_string(),
+        ];
         assert_eq!(
-            select_gguf(&files, Some("q8_0")).unwrap(),
-            "model-Q8_0.gguf"
+            select_gguf(&files, None).unwrap(),
+            [
+                "model-00001-of-00003.gguf",
+                "model-00002-of-00003.gguf",
+                "model-00003-of-00003.gguf",
+            ]
         );
     }
 
+    // The real layout that started this: unsloth/Qwen3.8-Flash-Next-GGUF, one
+    // subdirectory per quantization and every large quant split. rc5 made the
+    // files visible; the pull still ended on "multiple .gguf files match
+    // quant" because four shards matched and none of the single-file branches
+    // applied.
     #[test]
-    fn select_refuses_shards_without_quant() {
+    fn select_returns_every_shard_of_the_requested_quant() {
+        let files: Vec<String> = (1..=4)
+            .map(|i| format!("UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-0000{i}-of-00004.gguf"))
+            .chain(std::iter::once("mmproj-F16.gguf".to_string()))
+            .chain((1..=2).map(|i| {
+                format!("UD-Q2_K_XL/Qwen3.8-Flash-Next-UD-Q2_K_XL-0000{i}-of-00002.gguf")
+            }))
+            .collect();
+        let picked = select_gguf(&files, Some("UD-Q4_K_XL")).unwrap();
+        assert_eq!(picked.len(), 4);
+        assert!(picked[0].ends_with("00001-of-00004.gguf"));
+        assert!(picked[3].ends_with("00004-of-00004.gguf"));
+        // The other quantization's shards, and the projector, stay out of it.
+        assert!(picked.iter().all(|f| f.contains("UD-Q4_K_XL")));
+    }
+
+    // Downloading three quarters of a model and failing at load with an error
+    // about the file is worse than refusing up front.
+    #[test]
+    fn select_refuses_an_incomplete_split() {
         let files = vec![
             "model-00001-of-00003.gguf".to_string(),
-            "model-00002-of-00003.gguf".to_string(),
             "model-00003-of-00003.gguf".to_string(),
         ];
+        let err = select_gguf(&files, None).expect_err("shard 2 is missing");
+        assert!(err.contains("3 shards"), "{err}");
+        assert!(err.contains("only 2"), "{err}");
+    }
+
+    // Two splits and no way to tell which is wanted is still the user's
+    // choice to make, not ours to guess.
+    #[test]
+    fn select_refuses_to_guess_between_two_splits() {
+        let files = vec![
+            "model-Q4_K_M-00001-of-00002.gguf".to_string(),
+            "model-Q4_K_M-00002-of-00002.gguf".to_string(),
+            "model-Q8_0-00001-of-00002.gguf".to_string(),
+            "model-Q8_0-00002-of-00002.gguf".to_string(),
+        ];
         assert!(select_gguf(&files, None).is_err());
+        // Naming one of them resolves it.
+        assert_eq!(select_gguf(&files, Some("q8_0")).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn a_name_that_only_looks_sharded_is_an_ordinary_file() {
+        // No `-of-` at all, and a `-of-` that is not a shard counter.
+        assert_eq!(parse_shard("model-Q4_K_M.gguf"), None);
+        assert_eq!(parse_shard("best-of-breed.gguf"), None);
+        assert_eq!(parse_shard("model-00000-of-00003.gguf"), None);
+        assert_eq!(parse_shard("model-00004-of-00003.gguf"), None);
+        assert_eq!(
+            parse_shard("dir/model-00002-of-00003.gguf"),
+            Some(("dir/model", 2, 3))
+        );
     }
 
     // A vision repo carries the projector next to the weights. It is a .gguf
@@ -794,7 +964,7 @@ mod tests {
         // could land on the projector.
         assert_eq!(
             select_gguf(&files, None).expect("one model, one projector"),
-            "gemma-4-12b-it-Q4_K_M.gguf"
+            ["gemma-4-12b-it-Q4_K_M.gguf"]
         );
         // `:F16` used to match `mmproj-F16.gguf` and download it as the
         // weights, which then failed to load with an error about the file


### PR DESCRIPTION
A model published as `...-00001-of-00004.gguf` is four files, and llama.cpp opens the siblings from the first only once they are all on disk. select_gguf resolved to a single filename, so the pull fetched one shard of four. With four shards matching the requested quantization neither single-file branch applied and it ended on "multiple .gguf files match quant 'UD-Q4_K_XL'" -- which is where the previous fix left unsloth/Qwen3.8-Flash-Next-GGUF: the files were visible, the model still could not be pulled.

select_gguf returns Vec<String> now: the standalone file, or every shard of one split in index order. parse_shard decomposes `stem-NNNNN-of-TOTAL.gguf` and rejects what only looks like one (`best-of-breed.gguf`, a zero index, an index past the total), and group_shards keeps insertion order so an ambiguity error does not vary between runs. A repo whose only model is one split is no longer refused with "pass an explicit :<quant>" -- advice that led into the same wall, since naming the quant matched every shard. Two or more splits with no quant given is still refused: that is a real choice for the user.

An incomplete split is refused before anything is downloaded, naming how many shards are missing, rather than fetching three quarters of a model and failing at load with an error about the file.

cmd_pull_hf loops over the resolved files, stops at the first failure (the existing handler deletes the model directory), and records the sum of the shard sizes in the manifest instead of the first shard's. The manifest still names the first shard, which is what llama.cpp is given.

Bumps the version to 0.7.5-rc7.