### PR TITLE
chore(release): bump version to 0.7.5-rc8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries for **0.6.36 and later** are written by hand. Everything below that is
 derived from the commit history and reads like it: useful for tracing when
 something changed, less so for understanding what it means.
 
-## 0.7.5-rc1 — 2026-09-05
+## 0.7.5-rc8 — 2026-09-07
 
 ### Added
 - **A model browser in the web UI.** The download icon in the top bar opens a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.7.5-rc7"
+version = "0.7.5-rc8"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.7.5-rc7"
+version = "0.7.5-rc8"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Renames the accumulating changelog heading from 0.7.5-rc1, which it had kept since the series began, to the version actually being cut.