### PR TITLE
fix: read VRAM on every GPU backend, not only CUDA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ Entries for **0.6.36 and later** are written by hand. Everything below that is
 derived from the commit history and reads like it: useful for tracing when
 something changed, less so for understanding what it means.
 
+## 0.7.5-rc9 — 2026-09-07
+
+### Fixed
+- **The model browser said "no GPU detected" on every build except CUDA, and
+  judged downloads against system RAM alone.** VRAM was read with
+  `cudaMemGetInfo`, compiled in only for the CUDA binaries, so the Vulkan,
+  Metal, ROCm and CPU builds all reported no GPU — a Vulkan machine with a
+  16 GB card was told it had none, and a 21 GB model was coloured against its
+  64 GB of RAM instead. It is now asked through ggml's device registry, which
+  every backend populates, and several GPUs are summed because that is what a
+  layer split can use. This also gives `--fit` a real VRAM figure on those
+  builds for the first time, where it previously fell back to whatever
+  `--gpu-layers` the user passed.
+
+- **Opening a repo in the model browser showed the bottom of its
+  quantization list**, so a repo with twenty of them opened on the largest
+  and hid the line saying what the traffic lights were judged against. The
+  repo name and that line now stay put while only the list scrolls, and the
+  list starts at the smallest.
+
 ## 0.7.5-rc8 — 2026-09-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eullm-engine"
-version = "0.7.5-rc8"
+version = "0.7.5-rc9"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eullm-engine"
-version = "0.7.5-rc8"
+version = "0.7.5-rc9"
 edition = "2024"
 description = "eullm — sovereign LLM runtime for Europe"
 license = "AGPL-3.0-or-later"

--- a/engine/src/fit.rs
+++ b/engine/src/fit.rs
@@ -587,33 +587,59 @@ pub fn read_gguf_moe_layout(path: &Path, file_size: u64, n_layers: u32) -> Optio
 
 /// Free VRAM in bytes, as reported by the active GPU backend.
 ///
-/// `(free, total)` VRAM in bytes. The total matters because the loader's
-/// context probe requires a fraction of the card's TOTAL memory to remain
-/// free after allocation (`inference::MIN_FREE_VRAM_RATIO`), a floor the
-/// sizer has to respect or it produces splits the loader then refuses.
-#[cfg(feature = "cuda")]
+/// `(free, total)` in bytes, or `None` when there is no GPU or nothing can be
+/// read from it. The total matters because the loader's context probe requires
+/// a fraction of the card's TOTAL memory to remain free after allocation
+/// (`inference::MIN_FREE_VRAM_RATIO`), a floor the sizer has to respect or it
+/// produces splits the loader then refuses.
+///
+/// Asked through ggml's device registry rather than `cudaMemGetInfo`, so it
+/// answers on **every** GPU backend we ship — Vulkan, Metal and ROCm as well
+/// as CUDA — instead of only the CUDA builds. The old probe was
+/// `#[cfg(feature = "cuda")]` and returned `None` everywhere else, which was
+/// invisible while VRAM only fed `--fit` (falling back to the user's own
+/// `--gpu-layers` is a reasonable non-answer) and became wrong the moment the
+/// model catalog started colouring downloads by it: a Vulkan build on a 16 GB
+/// card was told "no GPU detected" and judged every model against system RAM
+/// alone. Reported from the field.
+///
+/// Multiple GPUs are summed, because that is what a layer split can use.
+///
+/// Returns `None` before `llama_backend_init` has run: the device registry is
+/// empty until then, and reporting zero VRAM would read as "a GPU with no
+/// memory" rather than "not asked yet".
 pub fn vram_bytes() -> Option<(u64, u64)> {
-    // cudart is linked by the CUDA build of llama.cpp. We bind only the one
-    // symbol we need rather than pulling in a CUDA crate.
-    unsafe extern "C" {
-        fn cudaMemGetInfo(free: *mut usize, total: *mut usize) -> i32;
+    use llama_cpp_sys_2::{
+        GGML_BACKEND_DEVICE_TYPE_GPU, ggml_backend_dev_count, ggml_backend_dev_get,
+        ggml_backend_dev_memory, ggml_backend_dev_type,
+    };
+
+    let mut free_total: u64 = 0;
+    let mut total_total: u64 = 0;
+    // SAFETY: the registry is a process-global initialised by the ggml
+    // backends when they load. `ggml_backend_dev_get` is valid for any index
+    // below the count, and `ggml_backend_dev_memory` writes two usize
+    // out-params through pointers we own. Nothing here mutates backend state.
+    unsafe {
+        for i in 0..ggml_backend_dev_count() {
+            let dev = ggml_backend_dev_get(i);
+            if dev.is_null() || ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU {
+                continue;
+            }
+            let mut free: usize = 0;
+            let mut total: usize = 0;
+            ggml_backend_dev_memory(dev, &mut free as *mut usize, &mut total as *mut usize);
+            free_total += free as u64;
+            total_total += total as u64;
+        }
     }
-    let mut free: usize = 0;
-    let mut total: usize = 0;
-    // SAFETY: cudaMemGetInfo writes two usize out-params and returns a status
-    // code. We pass valid, initialized pointers and read the values only on
-    // success. No CUDA context state is mutated.
-    let rc = unsafe { cudaMemGetInfo(&mut free as *mut usize, &mut total as *mut usize) };
-    if rc != 0 || free == 0 {
+
+    // A device that reports nothing is a device we cannot size against, and
+    // saying so beats sizing a model to zero bytes of VRAM.
+    if total_total == 0 || free_total == 0 {
         return None;
     }
-    Some((free as u64, total as u64))
-}
-
-/// Non-CUDA builds cannot probe VRAM: always "unknown".
-#[cfg(not(feature = "cuda"))]
-pub fn vram_bytes() -> Option<(u64, u64)> {
-    None
+    Some((free_total, total_total))
 }
 
 /// The outcome of a fit computation.

--- a/engine/src/ui/app.js
+++ b/engine/src/ui/app.js
@@ -1339,6 +1339,15 @@
     }
 
     catalogEls.detail.innerHTML = "";
+    // The head does not scroll: the repo name and, above all, what the traffic
+    // lights were judged against have to be visible without hunting for them.
+    // They were inside the scrolling list, and a repo with twenty
+    // quantizations opened showing the largest ones and none of the context —
+    // which reads as the colours having no basis at all.
+    const head = document.createElement("div");
+    head.className = "catalog-detail-head";
+    const list = document.createElement("div");
+    list.className = "quant-list";
     const back = document.createElement("button");
     back.type = "button";
     back.className = "catalog-back";
@@ -1349,7 +1358,7 @@
     });
     const title = document.createElement("h3");
     title.textContent = id;
-    catalogEls.detail.append(back, title);
+    head.append(back, title);
 
     // Say what the traffic light was judged against, rather than showing a
     // colour with no stated basis.
@@ -1363,18 +1372,22 @@
     }
     if (data.ram_total_bytes) parts.push(`${humanBytes(data.ram_total_bytes)} RAM`);
     basis.textContent = `Judged against: ${parts.join(", ")}. An estimate from the download size — the exact layer split is computed after the model is on disk.`;
-    catalogEls.detail.appendChild(basis);
+    head.appendChild(basis);
 
     if (data.mmproj) {
       const mm = document.createElement("p");
       mm.className = "catalog-note";
       mm.textContent = `Ships a multimodal projector (${humanBytes(data.mmproj_bytes)}); it is downloaded with whichever quantization you pick.`;
-      catalogEls.detail.appendChild(mm);
+      head.appendChild(mm);
     }
 
     for (const q of data.quants) {
-      catalogEls.detail.appendChild(quantRow(q));
+      list.appendChild(quantRow(q));
     }
+    catalogEls.detail.append(head, list);
+    // Smallest first is the useful end of the list, so start there rather than
+    // wherever the previous view happened to leave the scroll position.
+    list.scrollTop = 0;
   }
 
   function quantRow(q) {

--- a/engine/src/ui/style.css
+++ b/engine/src/ui/style.css
@@ -750,3 +750,10 @@ dialog#catalog-modal::backdrop { background: rgba(0, 0, 0, 0.6); }
 .quant-row progress { width: 100%; grid-column: 1 / -1; height: 4px; }
 .quant-row .pull-state { font-size: 0.78rem; color: var(--text-dim); grid-column: 1 / -1; }
 .catalog-error { color: var(--danger); font-size: 0.85rem; }
+
+/* The detail panel scrolls its quantization list only: the repo name and the
+   line saying what the traffic lights were judged against stay put. */
+.catalog-detail { overflow: hidden; display: flex; flex-direction: column; gap: 0.5rem; }
+.catalog-detail-head { display: flex; flex-direction: column; gap: 0.35rem; }
+.catalog-detail-head h3 { margin: 0; font-size: 0.95rem; }
+.quant-list { overflow-y: auto; max-height: 42vh; }


### PR DESCRIPTION
vram_bytes() was #[cfg(feature = "cuda")] and bound cudaMemGetInfo, so the Vulkan, Metal, ROCm and CPU builds all returned None. That was invisible while VRAM only fed --fit, where falling back to the user's own --gpu-layers is a reasonable non-answer. It stopped being invisible when the model catalog started colouring downloads by it: a Vulkan build on a 16 GB card was told "no GPU detected" and judged a 21 GB model against 64 GB of system RAM. Reported from the field.

It now goes through ggml's device registry -- ggml_backend_dev_count / _get / _type / _memory, all already in the generated bindings -- which every backend populates, so one implementation answers for all of them instead of one answering and four staying silent. Multiple GPUs are summed, because that is what a layer split can use. The registry is populated by init_shared_backend at process startup, before anything loads, so it is ready by the time a request arrives; None still means "no GPU or nothing readable", never "a GPU with no memory".

Also fixes the catalog panel opening scrolled to the bottom of the quantization list, which hid both the smallest quantizations and the line stating what the traffic lights were judged against -- and a colour whose basis is off-screen reads as having none. The repo name and that line no longer scroll; only the list does, from the top.

Bumps the version to 0.7.5-rc9.