### PR TITLE
feat(forge): adapt the legal-it-7b pipeline to Leonardo Booster (Euro…

### DIFF
--- a/docs/legal-it-7b-strategy.md
+++ b/docs/legal-it-7b-strategy.md
@@ -79,9 +79,23 @@ and runs in 1-2 h on a 5070 Ti once the GGUF is validated.
 
 ## 4. Hardware budget
 
-Target: **single GPU, 96 GB class** (Blackwell-generation or equivalent
-high-bandwidth A100/H100 80 GB if 96 GB is unavailable). Multi-GPU
-shaves wall-clock but is not required for this size class.
+**Primary target (since 09/2026): EuroHPC allocation
+EHPC-AIF-2026PG01-1147 on Leonardo Booster (CINECA)** — 1,250 node
+hours, 02/09/2026 → 02/11/2026, nodes of 4x A100 64 GB. No single
+Leonardo GPU fits the single-GPU budgets below, so the Leonardo path
+uses dedicated configs (`forge/training/configs/leonardo/`): Phase 1
+shards everything with DeepSpeed ZeRO-3 across the 4 GPUs (~36 GB/GPU),
+Phase 2 shards the frozen teacher via an accelerate device map while
+the student trains on one GPU. Operational details, node-hour budget
+(~250 for the full pipeline), and the 24 h-walltime chaining protocol:
+[`leonardo-runbook.md`](leonardo-runbook.md).
+
+The rented single-GPU path below remains valid as fallback once the
+allocation ends.
+
+Fallback target: **single GPU, 96 GB class** (Blackwell-generation or
+equivalent high-bandwidth A100/H100 80 GB if 96 GB is unavailable).
+Multi-GPU shaves wall-clock but is not required for this size class.
 
 ### Phase 1 — continued pre-training (LoRA on teacher)
 

--- a/docs/leonardo-runbook.md
+++ b/docs/leonardo-runbook.md
@@ -1,0 +1,140 @@
+# Leonardo (CINECA) Runbook — legal-it-7b on EuroHPC
+
+> Allocation: **EHPC-AIF-2026PG01-1147** — 40,000 local core hours =
+> **1,250 node hours** on Leonardo Booster, 02/09/2026 → 02/11/2026.
+> Strategy background: [`legal-it-7b-strategy.md`](legal-it-7b-strategy.md).
+> All the scripts referenced here live in `forge/scripts/leonardo/`.
+
+## The machine, in the terms that matter here
+
+| Fact | Consequence |
+|------|-------------|
+| Booster node = 4x A100 **64 GB** (32 cores, ~490 GB RAM) | No single GPU fits the 78-96 GB single-GPU budgets → Phase 1 uses DeepSpeed ZeRO-3 across 4 GPUs, Phase 2 shards the frozen teacher via accelerate. Dedicated Leonardo YAMLs live in `forge/training/configs/leonardo/`. |
+| Accounting: 1 GPU-hour = ¼ node hour | Smoke tests request 1 GPU, not a node. Phase 3 runs on the serial partition and costs no GPU budget. |
+| Max walltime 24 h (`boost_usr_prod`) | Multi-day phases run as chains of jobs (`submit_chain.sh`); every launcher auto-resumes from the latest checkpoint. |
+| Compute nodes have **no internet** | Models are prefetched to `$WORK` from a login node; jobs run with `HF_HUB_OFFLINE=1` (env.sh forces it inside jobs). llama.cpp is cloned during setup. |
+| Budget linearization: ~625 node hours/month, unused budget reported to EuroHPC | Start Phase 1 immediately; keep the queue fed. Check consumption with `saldo -b`. |
+| `$HOME` 50 GB, `$WORK` 1 TB (project), `$SCRATCH` purged | Everything (venv, HF cache, dataset, checkpoints) lives on `$WORK`. env.sh encodes the layout. |
+
+## Node-hour budget
+
+| Item | Node hours |
+|------|-----------:|
+| Smoke + wiring validation | ~1 |
+| Phase 1 — continued PT 32B (ZeRO-3, ≤ 2 x 24 h chain) | ~25-50 |
+| Phase 2 — distillation (7 x 24 h chain) | ~120-170 |
+| Phase 3 — GGUF (serial partition) | 0 |
+| Retries / headroom | ~50 |
+| **Total legal-it-7b** | **~250** |
+
+Out of 1,250 available — leaves ample budget for a second epoch,
+ablations, or the medical-de / finance-fr runs if their corpora are
+ready in time.
+
+## 0. One-time setup (login node)
+
+```bash
+# In ~/.bashrc on Leonardo (account name from `saldo -b`):
+export EULLM_ACCOUNT=<project_account>
+
+git clone https://github.com/eullm/eullm.git "$WORK/eullm"
+cd "$WORK/eullm"
+
+# Downloads ~80 GB of models into $WORK/hf_home — run it in tmux.
+# For the dataset either export HF_TOKEN + HF_DATASET (private HF repo),
+# or rsync train.jsonl/val.jsonl to $WORK/datasets/legal_it/ first.
+bash forge/scripts/leonardo/setup.sh
+```
+
+The final step of setup.sh is a login-node pre-flight
+(`check_training_env.py --cpu-only --multi-gpu --offline`): it proves
+the venv, DeepSpeed, the dataset, and the offline HF cache are all in
+place *before* any node-hours are spent.
+
+## 1. Smoke test (1 GPU, debug QOS, ~15 min, ~0.1 node hours)
+
+```bash
+source "$WORK/eullm/forge/scripts/leonardo/env.sh"
+cd "$EULLM_RUN_DIR"
+bash "$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \
+    "$EULLM_REPO/forge/scripts/leonardo/sbatch_smoke.slurm"
+tail -f logs/eullm-smoke-*.out
+```
+
+Green means: offline model load, dataset registration, training steps,
+checkpoint written. Optionally re-submit once to watch it resume from
+`checkpoint-50` — that same mechanism is what the 24 h chains rely on.
+
+## 2. Phase 1 — continued pre-training (4 GPUs, chain of 2)
+
+```bash
+bash "$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \
+    "$EULLM_REPO/forge/scripts/leonardo/sbatch_phase1.slurm" 2
+```
+
+Output: LoRA adapter at
+`$EULLM_RUN_DIR/checkpoints/qwen3_32b_legal_it_continued_pt/`.
+If the epoch finishes inside job 1, job 2 wakes up, finds the final
+checkpoint, re-runs the last partial step and exits quickly — a few
+wasted node-minutes, not hours.
+
+## 3. Phase 2 — distillation (4 GPUs, chain of 7)
+
+```bash
+bash "$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \
+    "$EULLM_REPO/forge/scripts/leonardo/sbatch_phase2.slurm" 7
+```
+
+The sbatch script refuses to start if the Phase-1 adapter is missing.
+Output: LoRA checkpoints plus — from the final save — a **merged**
+full-weights student at
+`.../checkpoints/qwen3_7b_legal_it_distilled/merged/`, which is what
+Phase 3 consumes. Watch the `kl=` term in the logs: it should fall
+steadily for the first few thousand steps.
+
+## 4. Phase 3 — GGUF Q4_K_M (serial partition, no GPU budget)
+
+```bash
+bash "$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \
+    "$EULLM_REPO/forge/scripts/leonardo/sbatch_quantize.slurm"
+```
+
+Output: `$EULLM_RUN_DIR/gguf/legal-it-7b/legal-it-7b-q4_k_m.gguf`
+(~4.5 GB). Pull it home and smoke-test in the EULLM Engine:
+
+```bash
+rsync -av --progress \
+    <user>@login.leonardo.cineca.it:"$WORK/eullm_runs/legal_it/gguf/legal-it-7b/" \
+    ./gguf/
+```
+
+Move artifacts off Leonardo as they are produced — the allocation (and
+the storage) ends on 02/11/2026, and CINECA recommends not leaving data
+transfers to the last days.
+
+## Monitoring cheat-sheet
+
+```bash
+squeue --me                      # queue state of your chain
+saldo -b                         # node-hour consumption vs monthly quota
+tail -f "$EULLM_RUN_DIR"/logs/*.out
+scancel <jobid>                  # kill one job of a chain
+scancel --me                     # kill everything (chain deps die with it)
+```
+
+## Troubleshooting
+
+- **Job dies immediately, log mentions HF cache / offline** — a model
+  is missing from `$WORK/hf_home`: re-run `prefetch_models.py` on a
+  login node.
+- **`sbatch: error: Invalid account`** — `EULLM_ACCOUNT` unset or wrong;
+  the exact name is in `saldo -b`.
+- **Phase-1 OOM per GPU** — drop `cutoff_len` 2048 → 1024 in the
+  Leonardo YAML; ZeRO-3 already shards weights/optimizer, activations
+  are the only real lever.
+- **Phase-2 OOM on cuda:0** — lower `teacher_gib_on_student_gpu` to 4
+  (pushes more teacher onto GPUs 1-3), then `cutoff_len` as above.
+- **A chained job starts and exits green in minutes** — normal: the
+  previous job already finished the phase; the chain drains cheaply.
+- **Low priority / long queue waits** — monthly quota exceeded (budget
+  linearization). Check `saldo -b`; jobs still run, just deprioritized.

--- a/forge/CLAUDE.md
+++ b/forge/CLAUDE.md
@@ -49,6 +49,7 @@ reintroduce:**
 
 ## Compute Infrastructure
 
+- **EuroHPC Leonardo Booster (CINECA) — active allocation EHPC-AIF-2026PG01-1147**: 1,250 node hours, 02/09/2026 → 02/11/2026. Nodes have 4x A100 **64 GB** (not 96 GB — single-GPU memory budgets do not apply there), max walltime 24 h, no internet on compute nodes. Use the `leonardo/` training configs and `forge/scripts/leonardo/`; runbook in `docs/leonardo-runbook.md`.
 - **EU Cloud (preferred)**: Seeweb (IT), Hetzner (DE), OVH/Scaleway (FR) — GPU servers with A100/H100/RTX PRO 6000
 - **Fallback**: HuggingFace Inference Endpoints, dedicated GPU hosting (GPU-Mart and similar)
 - **Single-GPU budget**: 94-96 GB VRAM hosts (H100 NVL, RTX PRO 6000 Blackwell) — fits LoRA distillation pipeline up to 32B teacher + 7B student

--- a/forge/eullm_forge/distill.py
+++ b/forge/eullm_forge/distill.py
@@ -376,3 +376,46 @@ def distill(config: DistillConfig) -> str:
 
     logger.info("Knowledge distillation complete.")
     return str(output_dir)
+
+
+def build_teacher_max_memory(
+    num_gpus: int,
+    student_gpu_index: int = 0,
+    teacher_gib_per_gpu: int = 58,
+    teacher_gib_on_student_gpu: int = 8,
+) -> dict[int, str]:
+    """Build the accelerate ``max_memory`` map for a sharded frozen teacher.
+
+    When teacher and student run in the same process on a multi-GPU node
+    (e.g. Leonardo Booster: 4x A100 64 GB, where no single GPU fits a
+    32B BF16 teacher), the teacher is sharded with ``device_map="auto"``
+    and this map caps how much of each GPU it may occupy — leaving the
+    student's GPU almost entirely to the student, its optimizer state,
+    and activations.
+
+    Args:
+        num_gpus: Number of visible CUDA devices (must be >= 2 — on a
+            single GPU there is nothing to shard).
+        student_gpu_index: Index of the GPU that hosts the student.
+        teacher_gib_per_gpu: Teacher budget (GiB) on every other GPU.
+        teacher_gib_on_student_gpu: Teacher budget (GiB) on the
+            student's GPU.
+
+    Returns:
+        ``{gpu_index: "NGiB"}`` suitable for
+        ``AutoModelForCausalLM.from_pretrained(..., max_memory=...)``.
+    """
+    if num_gpus < 2:
+        raise ValueError(f"sharding needs >= 2 GPUs, got {num_gpus}")
+    if not 0 <= student_gpu_index < num_gpus:
+        raise ValueError(
+            f"student_gpu_index {student_gpu_index} out of range for {num_gpus} GPUs"
+        )
+    return {
+        i: (
+            f"{teacher_gib_on_student_gpu}GiB"
+            if i == student_gpu_index
+            else f"{teacher_gib_per_gpu}GiB"
+        )
+        for i in range(num_gpus)
+    }

--- a/forge/scripts/check_training_env.py
+++ b/forge/scripts/check_training_env.py
@@ -61,7 +61,7 @@ def check_module(name: str, *, min_version: str | None = None) -> bool:
     return True
 
 
-def check_cuda() -> bool:
+def check_cuda(expect_gpus: int = 1) -> bool:
     try:
         import torch
     except ImportError:
@@ -70,12 +70,17 @@ def check_cuda() -> bool:
     if not torch.cuda.is_available():
         fail("CUDA not available — torch built without CUDA?")
         return False
-    name = torch.cuda.get_device_name(0)
-    cap = torch.cuda.get_device_capability(0)
-    free, total = torch.cuda.mem_get_info()
-    ok(f"CUDA {torch.version.cuda} on {name} "
-       f"(cap {cap[0]}.{cap[1]}, {total / 1024**3:.1f} GiB total, "
-       f"{free / 1024**3:.1f} GiB free)")
+    n = torch.cuda.device_count()
+    for i in range(n):
+        name = torch.cuda.get_device_name(i)
+        cap = torch.cuda.get_device_capability(i)
+        total = torch.cuda.get_device_properties(i).total_memory
+        ok(f"cuda:{i} {name} (cap {cap[0]}.{cap[1]}, "
+           f"{total / 1024**3:.1f} GiB)")
+    if n < expect_gpus:
+        fail(f"{n} GPU(s) visible, {expect_gpus} expected "
+             f"(wrong --gres request, or not inside the job?)")
+        return False
     if torch.cuda.is_bf16_supported():
         ok("BF16 supported (Ampere+ class GPU)")
     else:
@@ -108,26 +113,35 @@ def check_dataset(data_dir: Path) -> bool:
     ok(f"dataset at {data_dir}: "
        f"train={train_size:.0f} MiB, val={val_size:.0f} MiB")
     if not info.is_file():
-        warn(f"dataset_info.json not present yet "
-             f"(train.sh will create it on launch)")
+        warn("dataset_info.json not present yet "
+             "(train.sh will create it on launch)")
     return True
 
 
-def check_tokenizer(model_id: str) -> bool:
+def check_tokenizer(model_id: str, *, offline: bool = False) -> bool:
     """Smoke-load the tokenizer for the configured model. Confirms that
     transformers + huggingface_hub auth are working without committing
-    to a full model download."""
+    to a full model download. With ``offline`` it must come from the
+    local HF cache — this is what proves prefetch_models.py ran before
+    submitting to network-less compute nodes."""
     try:
         from transformers import AutoTokenizer
     except ImportError:
         fail("transformers not importable")
         return False
     try:
-        tok = AutoTokenizer.from_pretrained(model_id, trust_remote_code=False)
+        tok = AutoTokenizer.from_pretrained(
+            model_id, trust_remote_code=False, local_files_only=offline,
+        )
     except Exception as exc:
-        fail(f"could not load tokenizer for {model_id}: {exc}")
+        if offline:
+            fail(f"tokenizer for {model_id} not in the local HF cache "
+                 f"(HF_HOME set? prefetch_models.py run?): {exc}")
+        else:
+            fail(f"could not load tokenizer for {model_id}: {exc}")
         return False
-    ok(f"tokenizer for {model_id} (vocab {len(tok)})")
+    src = "local cache" if offline else "HF Hub"
+    ok(f"tokenizer for {model_id} (vocab {len(tok)}, from {src})")
     return True
 
 
@@ -149,7 +163,35 @@ def main(argv: Iterable[str] | None = None) -> int:
         action="store_true",
         help="Skip the HF tokenizer fetch (useful offline / CI)",
     )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Assume no network (HPC compute nodes): force the HF stack "
+             "offline and require the tokenizer in the local cache",
+    )
+    parser.add_argument(
+        "--cpu-only",
+        action="store_true",
+        help="Skip the GPU/CUDA checks (login nodes have no GPU)",
+    )
+    parser.add_argument(
+        "--expect-gpus",
+        type=int,
+        default=1,
+        help="Fail if fewer CUDA devices are visible (multi-GPU jobs)",
+    )
+    parser.add_argument(
+        "--multi-gpu",
+        action="store_true",
+        help="Also check the multi-GPU stack (deepspeed) is importable",
+    )
     args = parser.parse_args(argv)
+
+    if args.offline:
+        # Must happen before transformers/huggingface_hub are imported.
+        import os
+        os.environ["HF_HUB_OFFLINE"] = "1"
+        os.environ["TRANSFORMERS_OFFLINE"] = "1"
 
     print("== Python ==")
     ok(f"Python {sys.version.split()[0]} at {sys.executable}")
@@ -165,6 +207,8 @@ def main(argv: Iterable[str] | None = None) -> int:
         ("safetensors", None),
         ("llamafactory", None),
     ]
+    if args.multi_gpu:
+        pkgs.append(("deepspeed", "0.19"))
     failed = False
     for name, min_v in pkgs:
         if not check_module(name, min_version=min_v):
@@ -177,7 +221,9 @@ def main(argv: Iterable[str] | None = None) -> int:
 
     print()
     print("== GPU / CUDA ==")
-    if not check_cuda():
+    if args.cpu_only:
+        warn("GPU checks skipped (--cpu-only)")
+    elif not check_cuda(expect_gpus=args.expect_gpus):
         failed = True
 
     print()
@@ -191,7 +237,7 @@ def main(argv: Iterable[str] | None = None) -> int:
         # smoke uses Qwen3-1.7B-Base; production uses Qwen3-32B-Base.
         # Tokenizer is the same family so the smaller download is fine
         # for both.
-        if not check_tokenizer("Qwen/Qwen3-1.7B-Base"):
+        if not check_tokenizer("Qwen/Qwen3-1.7B-Base", offline=args.offline):
             failed = True
     else:
         warn("tokenizer check skipped (--skip-tokenizer)")

--- a/forge/scripts/distill.py
+++ b/forge/scripts/distill.py
@@ -9,13 +9,22 @@ fraction of the standard cross-entropy on the ground-truth tokens
 
 Loss = α · KL(student || teacher) · T² + (1-α) · CE(student, y)
 
-Training is single-GPU (no FSDP / DeepSpeed) targeting one ~96 GB
-device. Memory layout (BF16 throughout):
+Training is single-process. Two hardware layouts are supported:
 
-    Teacher 32B (frozen, no grad):     ~64 GB
-    Student 7B + grad + 8-bit Adam:    ~28 GB
-    Activations (seq 2048, both nets): ~6 GB
-    Headroom:                          ~variable
+* ``teacher_device_map: single`` (default) — teacher and student share
+  one ~96 GB device (H100 NVL, RTX PRO 6000 Blackwell):
+
+      Teacher 32B (frozen, no grad):     ~64 GB
+      Student 7B + grad + 8-bit Adam:    ~28 GB
+      Activations (seq 2048, both nets): ~6 GB
+      Headroom:                          ~variable
+
+* ``teacher_device_map: auto`` — multi-GPU nodes where no single GPU
+  fits the BF16 teacher (Leonardo Booster: 4x A100 64 GB). The frozen
+  teacher is sharded across every visible GPU via accelerate, capped by
+  a max_memory map that reserves the student's GPU (default cuda:0)
+  for the student + optimizer + activations. The teacher forward is
+  pipelined across GPUs; the student trains entirely on its own GPU.
 
 If the 32B teacher does not fit, pass --teacher-load-in-8bit (bitsandbytes
 NF4/INT8) to drop the teacher to ~16 GB at the cost of slightly noisier
@@ -46,7 +55,7 @@ import json
 import os
 import sys
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -63,6 +72,10 @@ from transformers import (
     get_cosine_schedule_with_warmup,
 )
 
+# The script runs from a repo checkout, not necessarily with eullm_forge
+# pip-installed — make the package importable from its source tree.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from eullm_forge.distill import build_teacher_max_memory  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Config
@@ -77,6 +90,17 @@ class DistillConfig:
     student_model: str = "Qwen/Qwen3-7B-Base"
     teacher_load_in_8bit: bool = False     # bitsandbytes 8-bit teacher
     teacher_load_in_4bit: bool = False     # bitsandbytes 4-bit teacher (NF4)
+
+    # Teacher placement:
+    #   "single" — teacher lives on student_device (one 96 GB-class GPU).
+    #   "auto"   — teacher sharded across all visible GPUs (accelerate
+    #              device_map) with a max_memory cap that keeps the
+    #              student's GPU free. Required on nodes where no single
+    #              GPU fits the BF16 teacher (Leonardo: 4x A100 64 GB).
+    teacher_device_map: str = "single"
+    teacher_gib_per_gpu: int = 58          # teacher budget on non-student GPUs
+    teacher_gib_on_student_gpu: int = 8    # teacher budget on the student GPU
+    student_device: str = "cuda:0"
 
     # Student fine-tuning method:
     #   "lora" (default) — wrap student in PEFT LoRA, only LoRA params
@@ -195,14 +219,39 @@ def _quantization_config(load_in_8bit: bool, load_in_4bit: bool):
 
 def load_teacher(cfg: DistillConfig, dtype: torch.dtype, device: str):
     print(f"[teacher] loading {cfg.teacher_model} "
-          f"(8bit={cfg.teacher_load_in_8bit}, 4bit={cfg.teacher_load_in_4bit})",
+          f"(8bit={cfg.teacher_load_in_8bit}, 4bit={cfg.teacher_load_in_4bit}, "
+          f"device_map={cfg.teacher_device_map})",
           file=sys.stderr)
     quant = _quantization_config(cfg.teacher_load_in_8bit,
                                  cfg.teacher_load_in_4bit)
+    device_map = {"": device} if quant is None else "auto"
+    max_memory = None
+    if cfg.teacher_device_map == "auto":
+        n_gpus = torch.cuda.device_count()
+        if n_gpus > 1:
+            student_idx = torch.device(cfg.student_device).index or 0
+            device_map = "auto"
+            max_memory = build_teacher_max_memory(
+                n_gpus,
+                student_gpu_index=student_idx,
+                teacher_gib_per_gpu=cfg.teacher_gib_per_gpu,
+                teacher_gib_on_student_gpu=cfg.teacher_gib_on_student_gpu,
+            )
+            print(f"[teacher] sharding across {n_gpus} GPUs, "
+                  f"max_memory={max_memory}", file=sys.stderr)
+        else:
+            print("[teacher] teacher_device_map=auto but only 1 GPU visible "
+                  "— falling back to single-device placement", file=sys.stderr)
+    elif cfg.teacher_device_map != "single":
+        raise ValueError(
+            f"teacher_device_map must be 'single' or 'auto', "
+            f"got {cfg.teacher_device_map!r}"
+        )
     model = AutoModelForCausalLM.from_pretrained(
         cfg.teacher_model,
         torch_dtype=dtype,
-        device_map={"": device} if quant is None else "auto",
+        device_map=device_map,
+        max_memory=max_memory,
         quantization_config=quant,
     )
     if cfg.teacher_adapter:
@@ -410,11 +459,37 @@ def load_checkpoint(ckpt_dir: Path, optimizer, scheduler, scaler) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _reload_student_from_checkpoint(
+    ckpt_dir: Path, cfg: DistillConfig, dtype: torch.dtype, device: str,
+):
+    """Rebuild the student from a checkpoint directory.
+
+    A LoRA checkpoint contains only the adapter (adapter_config.json +
+    adapter weights), so the base student must be re-instantiated first
+    and the adapter attached trainable on top. A full-FT checkpoint is a
+    complete HF model directory and loads directly.
+    """
+    if (ckpt_dir / "adapter_config.json").is_file():
+        base = AutoModelForCausalLM.from_pretrained(
+            cfg.student_model, torch_dtype=dtype, device_map={"": device},
+        )
+        model = PeftModel.from_pretrained(base, str(ckpt_dir), is_trainable=True)
+    else:
+        model = AutoModelForCausalLM.from_pretrained(
+            str(ckpt_dir), torch_dtype=dtype,
+        ).to(device)
+    if cfg.gradient_checkpointing:
+        model.gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs={"use_reentrant": False},
+        )
+    return model
+
+
 def train(cfg: DistillConfig) -> None:
     torch.manual_seed(cfg.seed)
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA required.")
-    device = "cuda:0"
+    device = cfg.student_device
     dtype = torch.bfloat16 if cfg.bf16 else torch.float16
 
     output_dir = Path(cfg.output_dir)
@@ -438,8 +513,19 @@ def train(cfg: DistillConfig) -> None:
     teacher = load_teacher(cfg, dtype, device)
     student = load_student(cfg, dtype, device)
 
+    # --- resume: replace the student BEFORE building the optimizer, so
+    # the optimizer binds to the parameters that will actually train
+    # (binding it to a model that is then swapped out silently trains
+    # nothing) ---
+    resume_dir = (
+        Path(cfg.resume_from) if cfg.resume_from
+        else latest_checkpoint(output_dir)
+    )
+    if resume_dir:
+        student = _reload_student_from_checkpoint(resume_dir, cfg, dtype, device)
+
     optimizer = torch.optim.AdamW(
-        student.parameters(),
+        (p for p in student.parameters() if p.requires_grad),
         lr=cfg.learning_rate,
         weight_decay=cfg.weight_decay,
     )
@@ -450,21 +536,8 @@ def train(cfg: DistillConfig) -> None:
     )
     scaler = None  # bf16 needs no scaler
 
-    # --- resume ---
-    resume_dir = (
-        Path(cfg.resume_from) if cfg.resume_from
-        else latest_checkpoint(output_dir)
-    )
     start_step = 0
     if resume_dir:
-        # Re-load student weights from the checkpoint (overrides base init).
-        student = AutoModelForCausalLM.from_pretrained(
-            resume_dir, torch_dtype=dtype,
-        ).to(device)
-        if cfg.gradient_checkpointing:
-            student.gradient_checkpointing_enable(
-                gradient_checkpointing_kwargs={"use_reentrant": False},
-            )
         start_step = load_checkpoint(resume_dir, optimizer, scheduler, scaler)
         print(f"[resume] continuing from step {start_step}", file=sys.stderr)
 
@@ -489,7 +562,9 @@ def train(cfg: DistillConfig) -> None:
             batch = {k: v.to(device, non_blocking=True) for k, v in batch.items()}
             with torch.no_grad():
                 t_out = teacher(**batch)
-                t_logits = t_out.logits.detach()
+                # With a sharded teacher the logits land on the GPU of the
+                # last pipeline stage — bring them to the student's device.
+                t_logits = t_out.logits.detach().to(device)
             s_out = student(**batch)
             loss, parts = distill_loss(
                 s_out.logits, t_logits, batch["labels"],
@@ -540,6 +615,20 @@ def train(cfg: DistillConfig) -> None:
                     output_dir, cfg)
     # Save tokenizer too — needed for inference / GGUF export later.
     tokenizer.save_pretrained(output_dir)
+
+    # Phase 3 (quantize_to_gguf.sh) needs a full HF model directory, but a
+    # LoRA student's checkpoints contain only the adapter — merge it into
+    # the base weights and export the result alongside the checkpoints.
+    if isinstance(student, PeftModel):
+        merged_dir = output_dir / "merged"
+        print(f"[merge] merging LoRA adapter into base → {merged_dir}",
+              file=sys.stderr)
+        merged = student.merge_and_unload()
+        merged.save_pretrained(merged_dir, safe_serialization=True)
+        tokenizer.save_pretrained(merged_dir)
+        print(f"[merge] GGUF-exportable model at {merged_dir}",
+              file=sys.stderr)
+
     print(f"[done] final student saved at {output_dir}", file=sys.stderr)
 
 

--- a/forge/scripts/leonardo/env.sh
+++ b/forge/scripts/leonardo/env.sh
@@ -1,0 +1,54 @@
+# Shared environment for EULLM work on Leonardo (CINECA) — EuroHPC
+# allocation EHPC-AIF-2026PG01-1147 (Leonardo Booster, 4x A100 64 GB
+# per node).
+#
+# Source this from login shells AND from sbatch scripts:
+#
+#   EULLM_REPO="${EULLM_REPO:-$WORK/eullm}"
+#   source "$EULLM_REPO/forge/scripts/leonardo/env.sh"
+#
+# Everything lives on $WORK (project storage, 1 TB default quota):
+# $HOME is only 50 GB and $SCRATCH is purged periodically. Override any
+# EULLM_* variable before sourcing to relocate.
+#
+# Set once in ~/.bashrc on Leonardo (value from `saldo -b`):
+#   export EULLM_ACCOUNT=<your_project_account>
+
+: "${WORK:?WORK is not set — this file is meant to be sourced on a Leonardo node}"
+
+export EULLM_REPO="${EULLM_REPO:-$WORK/eullm}"
+export EULLM_VENV="${EULLM_VENV:-$WORK/eullm_venv}"
+export EULLM_RUN_DIR="${EULLM_RUN_DIR:-$WORK/eullm_runs/legal_it}"
+export EULLM_DATA_DIR="${EULLM_DATA_DIR:-$WORK/datasets/legal_it}"
+
+# HF model cache on project storage — prefetch_models.py fills it from a
+# login node; jobs read it offline.
+export HF_HOME="${HF_HOME:-$WORK/hf_home}"
+
+# llama.cpp checkout for Phase 3 (cloned/built on a login node).
+export LCPP_DIR="${LCPP_DIR:-$WORK/llama.cpp}"
+
+# Compute nodes have no outbound network: force the HF stack offline
+# inside jobs so a cache miss fails fast instead of hanging on retries.
+if [ -n "${SLURM_JOB_ID:-}" ]; then
+    export HF_HUB_OFFLINE=1
+    export TRANSFORMERS_OFFLINE=1
+fi
+
+# sbatch reads SBATCH_ACCOUNT, so no per-submission -A flag is needed.
+if [ -n "${EULLM_ACCOUNT:-}" ]; then
+    export SBATCH_ACCOUNT="$EULLM_ACCOUNT"
+fi
+
+# Lmod: newest python module for the venv's interpreter (best effort —
+# adjust after checking `module avail python` if the default is too old).
+if command -v module >/dev/null 2>&1; then
+    module try-load python 2>/dev/null || true
+fi
+
+if [ -f "$EULLM_VENV/bin/activate" ]; then
+    # shellcheck disable=SC1091
+    source "$EULLM_VENV/bin/activate"
+fi
+
+mkdir -p "$EULLM_RUN_DIR/logs"

--- a/forge/scripts/leonardo/prefetch_models.py
+++ b/forge/scripts/leonardo/prefetch_models.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Pre-download the training models into the HF cache on $WORK.
+
+Leonardo compute nodes have no outbound network, so every model a job
+needs must already sit in the local HF cache ($HF_HOME, set by env.sh)
+before submission. Run this ON A LOGIN NODE (which has internet):
+
+    source forge/scripts/leonardo/env.sh
+    python forge/scripts/leonardo/prefetch_models.py
+
+After downloading, each model is re-opened with local_files_only=True —
+the same code path the jobs will use — so a green run here means the
+offline loads inside sbatch jobs will find everything.
+
+The default set covers the legal-it-7b pipeline: smoke proxy, student,
+teacher (~65 GB — make sure `saldo` shows quota headroom on $WORK).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+DEFAULT_MODELS = [
+    "Qwen/Qwen3-1.7B-Base",   # smoke test
+    "Qwen/Qwen3-7B-Base",     # Phase-2 student
+    "Qwen/Qwen3-32B-Base",    # Phase-1/2 teacher (~65 GB)
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--models", nargs="+", default=DEFAULT_MODELS,
+        help="HF model ids to prefetch (default: the legal-it-7b set)",
+    )
+    args = parser.parse_args()
+
+    if not os.environ.get("HF_HOME"):
+        print("[warn] HF_HOME not set — models would land in ~/.cache on "
+              "the 50 GB $HOME. Source forge/scripts/leonardo/env.sh first.",
+              file=sys.stderr)
+        return 1
+
+    from huggingface_hub import snapshot_download
+
+    for model_id in args.models:
+        print(f"[..] fetching {model_id} → $HF_HOME")
+        path = snapshot_download(model_id)
+        print(f"[ok] {model_id} at {path}")
+
+    # Verify the offline code path jobs will take.
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    from transformers import AutoConfig, AutoTokenizer
+
+    for model_id in args.models:
+        AutoConfig.from_pretrained(model_id, local_files_only=True)
+        AutoTokenizer.from_pretrained(model_id, local_files_only=True)
+        print(f"[ok] {model_id} loads offline")
+
+    print("[done] cache ready for offline compute jobs")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/forge/scripts/leonardo/sbatch_phase1.slurm
+++ b/forge/scripts/leonardo/sbatch_phase1.slurm
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Phase 1 — continued pre-training of the Qwen3-32B teacher on one
+# Leonardo Booster node (4x A100 64 GB), DeepSpeed ZeRO-3 via
+# LLaMA-Factory. See the Leonardo YAML header for the memory budget.
+#
+# The 24 h walltime cap makes preemption certain for a full epoch —
+# submit a chain; every job resumes from the latest checkpoint:
+#   bash "$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \
+#       "$EULLM_REPO/forge/scripts/leonardo/sbatch_phase1.slurm" 2
+#
+#SBATCH --job-name=eullm-p1-cpt32b
+#SBATCH --partition=boost_usr_prod
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=32
+#SBATCH --gres=gpu:4
+#SBATCH --mem=450G
+#SBATCH --time=24:00:00
+#SBATCH --output=logs/%x-%j.out
+
+set -euo pipefail
+
+EULLM_REPO="${EULLM_REPO:-$WORK/eullm}"
+# shellcheck disable=SC1091
+source "$EULLM_REPO/forge/scripts/leonardo/env.sh"
+cd "$EULLM_RUN_DIR"
+
+python "$EULLM_REPO/forge/scripts/check_training_env.py" \
+    --offline --multi-gpu --expect-gpus 4 --data-dir "$EULLM_DATA_DIR"
+
+# LLaMA-Factory launches through torchrun with one rank per GPU.
+export FORCE_TORCHRUN=1
+export NPROC_PER_NODE=4
+export OMP_NUM_THREADS=8
+
+bash "$EULLM_REPO/forge/scripts/train.sh" \
+    "$EULLM_REPO/forge/training/configs/leonardo/continued_pt_qwen3_32b_leonardo.yaml" \
+    "$EULLM_DATA_DIR"

--- a/forge/scripts/leonardo/sbatch_phase2.slurm
+++ b/forge/scripts/leonardo/sbatch_phase2.slurm
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Phase 2 — distillation Qwen3-32B-legal-it → Qwen3-7B on one Leonardo
+# Booster node. Single process: the frozen BF16 teacher is sharded
+# across the 4 GPUs (accelerate device_map), the student trains on
+# cuda:0. See the Leonardo distill YAML header for the memory budget.
+#
+# Expect 5-7 days of wall time — submit a chain of 24 h jobs; each one
+# resumes from the latest checkpoint:
+#   bash "$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \
+#       "$EULLM_REPO/forge/scripts/leonardo/sbatch_phase2.slurm" 7
+#
+#SBATCH --job-name=eullm-p2-distill
+#SBATCH --partition=boost_usr_prod
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=32
+#SBATCH --gres=gpu:4
+#SBATCH --mem=450G
+#SBATCH --time=24:00:00
+#SBATCH --output=logs/%x-%j.out
+
+set -euo pipefail
+
+EULLM_REPO="${EULLM_REPO:-$WORK/eullm}"
+# shellcheck disable=SC1091
+source "$EULLM_REPO/forge/scripts/leonardo/env.sh"
+cd "$EULLM_RUN_DIR"
+
+# Phase 1 must have produced the teacher adapter this YAML points at.
+ADAPTER="./checkpoints/qwen3_32b_legal_it_continued_pt"
+[ -f "$ADAPTER/adapter_config.json" ] || {
+    echo "[err] Phase-1 adapter not found at $EULLM_RUN_DIR/$ADAPTER" >&2
+    echo "[err] run sbatch_phase1.slurm to completion first" >&2
+    exit 1
+}
+
+python "$EULLM_REPO/forge/scripts/check_training_env.py" \
+    --offline --expect-gpus 4 --data-dir "$EULLM_DATA_DIR"
+
+bash "$EULLM_REPO/forge/scripts/distill.sh" \
+    "$EULLM_REPO/forge/training/configs/leonardo/distill_qwen3_32b_to_7b_leonardo.yaml" \
+    "$EULLM_DATA_DIR"

--- a/forge/scripts/leonardo/sbatch_quantize.slurm
+++ b/forge/scripts/leonardo/sbatch_quantize.slurm
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Phase 3 — quantize the distilled student to GGUF Q4_K_M. CPU-only, so
+# it runs on the serial partition and costs no GPU budget. llama.cpp
+# must already be cloned at $LCPP_DIR (setup.sh does it — this node has
+# no outbound network, hence LCPP_SKIP_UPDATE=1).
+#
+#   bash "$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \
+#       "$EULLM_REPO/forge/scripts/leonardo/sbatch_quantize.slurm"
+#
+#SBATCH --job-name=eullm-p3-gguf
+#SBATCH --partition=lrd_all_serial
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=30G
+#SBATCH --time=04:00:00
+#SBATCH --output=logs/%x-%j.out
+
+set -euo pipefail
+
+EULLM_REPO="${EULLM_REPO:-$WORK/eullm}"
+# shellcheck disable=SC1091
+source "$EULLM_REPO/forge/scripts/leonardo/env.sh"
+cd "$EULLM_RUN_DIR"
+
+# The LoRA student is exported merged (full HF weights) by distill.py.
+HF_DIR="$EULLM_RUN_DIR/checkpoints/qwen3_7b_legal_it_distilled/merged"
+[ -f "$HF_DIR/config.json" ] || {
+    echo "[err] merged student not found at $HF_DIR" >&2
+    echo "[err] Phase 2 must run to completion first (the merge happens" >&2
+    echo "[err] in its final save)" >&2
+    exit 1
+}
+
+LCPP_SKIP_UPDATE=1 bash "$EULLM_REPO/forge/scripts/quantize_to_gguf.sh" \
+    "$HF_DIR" \
+    "$EULLM_RUN_DIR/gguf/legal-it-7b"

--- a/forge/scripts/leonardo/sbatch_smoke.slurm
+++ b/forge/scripts/leonardo/sbatch_smoke.slurm
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Smoke test on Leonardo Booster: 1 GPU (= 1/4 node of budget), debug
+# QOS for fast scheduling. Validates the whole offline wiring — venv,
+# HF cache, dataset, LLaMA-Factory, checkpoint write — before any
+# node-hours go to the production phases.
+#
+# Submit from $EULLM_RUN_DIR (submit_chain.sh does the right thing):
+#   bash "$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \
+#       "$EULLM_REPO/forge/scripts/leonardo/sbatch_smoke.slurm"
+#
+# The account comes from SBATCH_ACCOUNT (exported by env.sh from
+# EULLM_ACCOUNT), so no -A flag is needed.
+#
+#SBATCH --job-name=eullm-smoke
+#SBATCH --partition=boost_usr_prod
+#SBATCH --qos=boost_qos_dbg
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=8
+#SBATCH --gres=gpu:1
+#SBATCH --mem=110G
+#SBATCH --time=00:30:00
+#SBATCH --output=logs/%x-%j.out
+
+set -euo pipefail
+
+EULLM_REPO="${EULLM_REPO:-$WORK/eullm}"
+# shellcheck disable=SC1091
+source "$EULLM_REPO/forge/scripts/leonardo/env.sh"
+cd "$EULLM_RUN_DIR"
+
+python "$EULLM_REPO/forge/scripts/check_training_env.py" \
+    --offline --data-dir "$EULLM_DATA_DIR"
+
+bash "$EULLM_REPO/forge/scripts/train.sh" \
+    "$EULLM_REPO/forge/training/configs/smoke_qwen3_1.7b.yaml" \
+    "$EULLM_DATA_DIR"

--- a/forge/scripts/leonardo/setup.sh
+++ b/forge/scripts/leonardo/setup.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# One-time setup for the legal-it-7b pipeline on Leonardo (CINECA).
+# Run ON A LOGIN NODE (internet access) after cloning the repo to $WORK:
+#
+#   git clone https://github.com/eullm/eullm.git "$WORK/eullm"
+#   cd "$WORK/eullm"
+#   bash forge/scripts/leonardo/setup.sh
+#
+# For the dataset download step, export first (skipped when the corpus
+# is already at $EULLM_DATA_DIR, e.g. rsync'ed from the workstation):
+#   HF_TOKEN    — HF token with read access to the private dataset repo
+#   HF_DATASET  — e.g. primoco/legal_it_pretraining
+#
+# Idempotent: re-running skips whatever is already in place.
+
+set -euo pipefail
+
+err() { printf '\033[31m[err]\033[0m %s\n' "$*" >&2; exit 1; }
+ok()  { printf '\033[32m[ok]\033[0m  %s\n' "$*"; }
+log() { printf '\033[34m[..]\033[0m  %s\n' "$*"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/env.sh"
+
+# -----------------------------------------------------------------------------
+# 1. Python venv on $WORK
+# -----------------------------------------------------------------------------
+
+if [ ! -f "$EULLM_VENV/bin/activate" ]; then
+    log "creating venv at $EULLM_VENV"
+    PYBIN="$(command -v python3.11 || command -v python3.10 || command -v python3)"
+    "$PYBIN" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' \
+        || err "need Python >= 3.10 — try 'module avail python' and load one"
+    "$PYBIN" -m venv "$EULLM_VENV"
+    # shellcheck disable=SC1091
+    source "$EULLM_VENV/bin/activate"
+else
+    ok "venv already at $EULLM_VENV"
+fi
+log "using $(python --version) at $(command -v python)"
+
+# -----------------------------------------------------------------------------
+# 2. Training stack: LLaMA-Factory + deps (into the venv, LF on $WORK)
+# -----------------------------------------------------------------------------
+
+LF_DIR="${LF_DIR:-$WORK/LLaMA-Factory}" PYTHON=python \
+    bash "$EULLM_REPO/forge/scripts/install_training_deps.sh"
+
+# Multi-GPU stack for the ZeRO-3 Phase-1 config + distill extras.
+log "installing multi-GPU / distillation deps"
+python -m pip install --quiet --upgrade \
+    "deepspeed>=0.19.6" \
+    "peft>=0.12" \
+    "bitsandbytes>=0.43"
+ok "deepspeed + peft + bitsandbytes installed"
+
+# -----------------------------------------------------------------------------
+# 3. Prefetch models into $HF_HOME (compute nodes are offline)
+# -----------------------------------------------------------------------------
+
+python "$EULLM_REPO/forge/scripts/leonardo/prefetch_models.py"
+
+# -----------------------------------------------------------------------------
+# 4. Dataset onto $WORK
+# -----------------------------------------------------------------------------
+
+if [ -f "$EULLM_DATA_DIR/train.jsonl" ] && [ -f "$EULLM_DATA_DIR/val.jsonl" ]; then
+    ok "dataset already at $EULLM_DATA_DIR"
+elif [ -n "${HF_TOKEN:-}" ] && [ -n "${HF_DATASET:-}" ]; then
+    log "downloading $HF_DATASET → $EULLM_DATA_DIR"
+    mkdir -p "$EULLM_DATA_DIR"
+    export TARBALL_NAME="${TARBALL_NAME:-legal_it_pretraining.tar.gz}"
+    python - <<PY
+import os
+from huggingface_hub import hf_hub_download
+path = hf_hub_download(
+    repo_id=os.environ["HF_DATASET"],
+    filename=os.environ.get("TARBALL_NAME", "legal_it_pretraining.tar.gz"),
+    repo_type="dataset",
+    local_dir=os.environ["EULLM_DATA_DIR"],
+)
+print(f"   downloaded {path}")
+PY
+    tar -xzf "$EULLM_DATA_DIR/$TARBALL_NAME" -C "$EULLM_DATA_DIR"
+    rm -f "$EULLM_DATA_DIR/$TARBALL_NAME"
+    ok "dataset extracted to $EULLM_DATA_DIR"
+else
+    err "no dataset at $EULLM_DATA_DIR and HF_TOKEN/HF_DATASET not set —
+     either export them and re-run, or copy the corpus manually:
+       rsync -av --progress train.jsonl val.jsonl \\
+           <user>@login.leonardo.cineca.it:$EULLM_DATA_DIR/"
+fi
+
+# -----------------------------------------------------------------------------
+# 5. llama.cpp for Phase 3 (clone + CPU build now; jobs run it offline)
+# -----------------------------------------------------------------------------
+
+if [ ! -d "$LCPP_DIR/.git" ]; then
+    log "cloning llama.cpp into $LCPP_DIR (Phase 3 uses it offline)"
+    git clone --depth 1 https://github.com/ggerganov/llama.cpp.git "$LCPP_DIR"
+else
+    ok "llama.cpp already at $LCPP_DIR"
+fi
+
+# -----------------------------------------------------------------------------
+# 6. Login-node pre-flight (no GPU here — jobs re-check with GPUs)
+# -----------------------------------------------------------------------------
+
+python "$EULLM_REPO/forge/scripts/check_training_env.py" \
+    --cpu-only --multi-gpu --offline --data-dir "$EULLM_DATA_DIR"
+
+cat <<EOF
+
+================================================================================
+ Leonardo setup complete. Next (see docs/leonardo-runbook.md):
+
+   export EULLM_ACCOUNT=<project account from 'saldo -b'>
+   cd "\$EULLM_RUN_DIR"
+
+   # 1. Smoke test (1 GPU, debug QOS, ~15 min):
+   bash "\$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \\
+       "\$EULLM_REPO/forge/scripts/leonardo/sbatch_smoke.slurm"
+
+   # 2. Phase 1 (1 node / 4 GPUs, chained over the 24 h walltime cap):
+   bash "\$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \\
+       "\$EULLM_REPO/forge/scripts/leonardo/sbatch_phase1.slurm" 2
+================================================================================
+EOF

--- a/forge/scripts/leonardo/submit_chain.sh
+++ b/forge/scripts/leonardo/submit_chain.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Submit N chained copies of an sbatch script (afterany dependencies).
+#
+# Leonardo's boost_usr_prod partition caps jobs at 24 h, so a multi-day
+# phase is a chain: when job k dies (walltime or otherwise), job k+1
+# starts and the launchers (train.sh / distill.sh) resume from the
+# latest checkpoint. A count of 1 is a plain submission with the logs
+# dir prepared.
+#
+# Usage:
+#   bash submit_chain.sh <script.slurm> [count] [extra sbatch args...]
+#
+# Examples:
+#   bash submit_chain.sh sbatch_smoke.slurm
+#   bash submit_chain.sh sbatch_phase2.slurm 7
+#
+# Run from $EULLM_RUN_DIR (the scripts' #SBATCH --output is relative to
+# the submission directory). The account is picked up from
+# SBATCH_ACCOUNT — export EULLM_ACCOUNT and source env.sh first.
+
+set -euo pipefail
+
+SCRIPT="${1:?Usage: $0 <script.slurm> [count] [extra sbatch args...]}"
+COUNT="${2:-1}"
+shift
+if [ $# -gt 0 ]; then shift; fi
+
+[ -f "$SCRIPT" ] || { echo "[err] sbatch script not found: $SCRIPT" >&2; exit 1; }
+case "$COUNT" in
+    ''|*[!0-9]*) echo "[err] count must be a positive integer, got '$COUNT'" >&2; exit 1;;
+esac
+
+if [ -z "${SBATCH_ACCOUNT:-}" ]; then
+    echo "[warn] SBATCH_ACCOUNT not set — export EULLM_ACCOUNT and source" >&2
+    echo "[warn] forge/scripts/leonardo/env.sh, or pass -A <account>" >&2
+fi
+
+mkdir -p logs
+
+prev=""
+for i in $(seq 1 "$COUNT"); do
+    if [ -z "$prev" ]; then
+        jid=$(sbatch --parsable "$@" "$SCRIPT")
+    else
+        jid=$(sbatch --parsable --dependency=afterany:"$prev" "$@" "$SCRIPT")
+    fi
+    jid="${jid%%;*}"   # --parsable may append ';cluster'
+    echo "[ok] submitted $jid ($i/$COUNT)${prev:+ — after $prev}"
+    prev="$jid"
+done
+
+echo "[ok] monitor with: squeue --me   |   logs in $(pwd)/logs/"

--- a/forge/scripts/quantize_to_gguf.sh
+++ b/forge/scripts/quantize_to_gguf.sh
@@ -52,9 +52,17 @@ mkdir -p "$OUT_DIR"
 # ---------------------------------------------------------------------------
 
 if [ -d "$LCPP_DIR/.git" ]; then
-    log "llama.cpp already at $LCPP_DIR — pulling latest"
-    git -C "$LCPP_DIR" pull --quiet --ff-only
+    if [ "${LCPP_SKIP_UPDATE:-0}" = "1" ]; then
+        # Offline mode (e.g. HPC compute nodes without outbound network):
+        # use the checkout as-is. Clone/update it on a login node first.
+        log "llama.cpp at $LCPP_DIR — LCPP_SKIP_UPDATE=1, using as-is"
+    else
+        log "llama.cpp already at $LCPP_DIR — pulling latest"
+        git -C "$LCPP_DIR" pull --quiet --ff-only
+    fi
 else
+    [ "${LCPP_SKIP_UPDATE:-0}" != "1" ] || \
+        err "LCPP_SKIP_UPDATE=1 but no checkout at $LCPP_DIR — clone it on a login node first"
     log "cloning llama.cpp into $LCPP_DIR"
     git clone --depth 1 "$LCPP_REPO" "$LCPP_DIR"
 fi

--- a/forge/scripts/train.sh
+++ b/forge/scripts/train.sh
@@ -65,9 +65,12 @@ TMP_YAML=$(mktemp --suffix=.yaml)
 trap 'rm -f "$TMP_YAML"' EXIT
 
 # Use a delimiter that can't appear in a Unix path (|) and an absolute
-# DATA_DIR so the substitution is unambiguous.
+# DATA_DIR so the substitution is unambiguous. __REPO_ROOT__ lets a YAML
+# reference files in the repo (e.g. the DeepSpeed config) regardless of
+# the directory the job runs from.
 ABS_DATA_DIR="$(cd "$DATA_DIR" && pwd)"
-sed "s|__DATASET_DIR__|$ABS_DATA_DIR|g" "$CONFIG" > "$TMP_YAML"
+sed -e "s|__DATASET_DIR__|$ABS_DATA_DIR|g" \
+    -e "s|__REPO_ROOT__|$REPO_ROOT|g" "$CONFIG" > "$TMP_YAML"
 
 # Extract output_dir from the resolved YAML to look for an existing
 # checkpoint.

--- a/forge/tests/test_distill.py
+++ b/forge/tests/test_distill.py
@@ -1,6 +1,8 @@
-"""Tests for the distillation cost estimator."""
+"""Tests for the distillation cost estimator and teacher-sharding helper."""
 
-from eullm_forge.distill import estimate_distillation_cost
+import pytest
+
+from eullm_forge.distill import build_teacher_max_memory, estimate_distillation_cost
 
 
 def test_estimate_14b_to_7b():
@@ -29,3 +31,29 @@ def test_estimate_custom_gpu_cost():
     cost_cheap = estimate_distillation_cost(14.0, 7.0, 50.0, gpu_cost_per_hour=1.0)
     cost_expensive = estimate_distillation_cost(14.0, 7.0, 50.0, gpu_cost_per_hour=5.0)
     assert cost_expensive["estimated_cost"] > cost_cheap["estimated_cost"]
+
+
+def test_teacher_max_memory_leonardo_node():
+    # Leonardo Booster node: 4x A100 64 GB, student on GPU 0.
+    mm = build_teacher_max_memory(4)
+    assert mm == {0: "8GiB", 1: "58GiB", 2: "58GiB", 3: "58GiB"}
+    # The teacher budget must fit a 32B BF16 teacher (~64 GiB).
+    total = sum(int(v.removesuffix("GiB")) for v in mm.values())
+    assert total >= 64
+
+
+def test_teacher_max_memory_custom_student_gpu():
+    mm = build_teacher_max_memory(
+        4, student_gpu_index=2, teacher_gib_per_gpu=50, teacher_gib_on_student_gpu=4
+    )
+    assert mm == {0: "50GiB", 1: "50GiB", 2: "4GiB", 3: "50GiB"}
+
+
+def test_teacher_max_memory_rejects_single_gpu():
+    with pytest.raises(ValueError):
+        build_teacher_max_memory(1)
+
+
+def test_teacher_max_memory_rejects_bad_student_index():
+    with pytest.raises(ValueError):
+        build_teacher_max_memory(4, student_gpu_index=4)

--- a/forge/training/README.md
+++ b/forge/training/README.md
@@ -18,6 +18,14 @@ The end-to-end strategy lives in
 | `smoke_qwen3_1.7b.yaml` | smoke | `Qwen/Qwen3-1.7B-Base` + LoRA r=8 | RTX 5070 Ti 16 GB | ~5-15 min |
 | `continued_pt_qwen3_32b.yaml` | Phase 1 | `Qwen/Qwen3-32B-Base` + LoRA r=128 | 96 GB GPU | 2.5-3.5 days |
 | `distill_qwen3_32b_to_7b.yaml` | Phase 2 | `Qwen/Qwen3-32B` (frozen) + `Qwen/Qwen3-7B-Base` (trainable) | 96 GB GPU | 5-7 days |
+| `leonardo/continued_pt_qwen3_32b_leonardo.yaml` | Phase 1 | same, DeepSpeed ZeRO-3 | Leonardo node (4x A100 64 GB) | < 1 day |
+| `leonardo/distill_qwen3_32b_to_7b_leonardo.yaml` | Phase 2 | same, teacher sharded on 4 GPUs | Leonardo node (4x A100 64 GB) | 5-7 days |
+
+The `leonardo/` variants target the EuroHPC allocation on Leonardo
+Booster (CINECA), where no single GPU fits the single-GPU memory
+budgets. SLURM launchers, offline-cache setup, and the full runbook
+live in `forge/scripts/leonardo/` and
+[`docs/leonardo-runbook.md`](../../docs/leonardo-runbook.md).
 
 The smoke config exists only to validate the wiring (dataset registration,
 checkpoint write, resume-from-checkpoint). Train it once, kill it

--- a/forge/training/configs/ds_zero3.json
+++ b/forge/training/configs/ds_zero3.json
@@ -1,0 +1,30 @@
+{
+  "train_batch_size": "auto",
+  "train_micro_batch_size_per_gpu": "auto",
+  "gradient_accumulation_steps": "auto",
+  "gradient_clipping": "auto",
+  "zero_allow_untested_optimizer": true,
+  "bf16": {
+    "enabled": "auto"
+  },
+  "fp16": {
+    "enabled": "auto",
+    "loss_scale": 0,
+    "loss_scale_window": 1000,
+    "initial_scale_power": 16,
+    "hysteresis": 2,
+    "min_loss_scale": 1
+  },
+  "zero_optimization": {
+    "stage": 3,
+    "overlap_comm": true,
+    "contiguous_gradients": true,
+    "sub_group_size": 1000000000,
+    "reduce_bucket_size": "auto",
+    "stage3_prefetch_bucket_size": "auto",
+    "stage3_param_persistence_threshold": "auto",
+    "stage3_max_live_parameters": 1000000000,
+    "stage3_max_reuse_distance": 1000000000,
+    "stage3_gather_16bit_weights_on_model_save": true
+  }
+}

--- a/forge/training/configs/leonardo/continued_pt_qwen3_32b_leonardo.yaml
+++ b/forge/training/configs/leonardo/continued_pt_qwen3_32b_leonardo.yaml
@@ -1,0 +1,85 @@
+# Phase 1 — Continued pre-training of the teacher, Leonardo Booster edition.
+#
+# Target: Qwen3-32B-Base + LoRA r=128 on the full 700M-token Italian
+# legal corpus, on ONE Leonardo Booster node (4x NVIDIA A100 64 GB).
+# No single 64 GB GPU fits the 78 GB single-GPU budget of
+# continued_pt_qwen3_32b.yaml, so this variant shards everything with
+# DeepSpeed ZeRO-3 across the 4 GPUs:
+#
+#   frozen 32B BF16 weights, sharded 4-way      ~16 GB / GPU
+#   LoRA r=128 params + grads + Adam, sharded    ~2 GB / GPU
+#   activations (grad ckpt, seq len 2048)        ~8 GB / GPU
+#   ZeRO-3 gather buffers + headroom            ~10 GB / GPU
+#   ────────                                    ─────
+#   total                                       ~36 GB / 64 GB per GPU ✅
+#
+# Launch (inside an sbatch job — see forge/scripts/leonardo/):
+#   export FORCE_TORCHRUN=1 NPROC_PER_NODE=4
+#   bash forge/scripts/train.sh \
+#       forge/training/configs/leonardo/continued_pt_qwen3_32b_leonardo.yaml \
+#       "$EULLM_DATA_DIR"
+#
+# Data parallelism is 4-way, so gradient_accumulation_steps drops from
+# 16 to 4 to keep the effective batch at 16 (1 x 4 GPUs x 4 accum) —
+# same optimization trajectory as the single-GPU config, ~4x the
+# throughput. Expected wall time: well under 24 h for one epoch, but
+# submit via submit_chain.sh with count=2 anyway — the launcher resumes
+# from the latest checkpoint if the first job hits the walltime cap.
+
+### model
+model_name_or_path: Qwen/Qwen3-32B-Base
+trust_remote_code: false
+
+### distributed (DeepSpeed ZeRO-3 across the node's 4 GPUs)
+# __REPO_ROOT__ is replaced by forge/scripts/train.sh at launch time.
+deepspeed: __REPO_ROOT__/forge/training/configs/ds_zero3.json
+
+### method (continued pre-training with LoRA)
+stage: pt
+do_train: true
+finetuning_type: lora
+lora_target: q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj
+lora_rank: 128
+lora_alpha: 256
+lora_dropout: 0.05
+
+### dataset
+# __DATASET_DIR__ is replaced by forge/scripts/train.sh at launch time.
+dataset_dir: __DATASET_DIR__
+dataset: legal_it_train
+eval_dataset: legal_it_val
+cutoff_len: 2048
+preprocessing_num_workers: 8
+overwrite_cache: false
+
+### training
+# Relative to the job's working directory — the sbatch scripts cd into
+# $EULLM_RUN_DIR on $WORK, so checkpoints land on the project storage.
+output_dir: ./checkpoints/qwen3_32b_legal_it_continued_pt
+overwrite_output_dir: false
+per_device_train_batch_size: 1
+gradient_accumulation_steps: 4         # effective batch = 1 x 4 GPUs x 4 = 16
+learning_rate: 1.0e-5
+num_train_epochs: 1
+lr_scheduler_type: cosine
+warmup_steps: 2000         # same optim-step count as the single-GPU
+                           # config (effective batch unchanged)
+weight_decay: 0.01
+max_grad_norm: 1.0
+bf16: true
+gradient_checkpointing: true
+optim: adamw_torch         # ZeRO-3 shards the optimizer state, so
+                           # plain AdamW costs ~0.5 GB/GPU here
+
+### checkpointing (every 500 steps as per strategy doc §6)
+logging_steps: 10
+save_steps: 500
+save_total_limit: 2
+save_strategy: steps
+plot_loss: true
+
+### eval (perplexity on val every 500 steps)
+per_device_eval_batch_size: 1
+eval_strategy: steps
+eval_steps: 500
+val_size: 0

--- a/forge/training/configs/leonardo/distill_qwen3_32b_to_7b_leonardo.yaml
+++ b/forge/training/configs/leonardo/distill_qwen3_32b_to_7b_leonardo.yaml
@@ -1,0 +1,87 @@
+# Phase 2 — Knowledge distillation Qwen3-32B-legal-it → Qwen3-7B-Base,
+# Leonardo Booster edition (one node, 4x NVIDIA A100 64 GB).
+#
+# The 64 GB BF16 teacher does not fit any single Leonardo GPU, so it is
+# sharded across all 4 GPUs (teacher_device_map: auto) while the student
+# trains entirely on cuda:0. The max_memory caps below reserve cuda:0
+# for the student:
+#
+#   cuda:0  teacher shard ≤ 8 GB + student 14 GB + LoRA/Adam 6 GB
+#           + activations ~10 GB                        ≈ 38 / 64 GB ✅
+#   cuda:1-3  teacher shards, ≤ 58 GB each (64 GB weights total
+#             spread over ~3.4 GPUs of budget)          ≈ 19 / 64 GB each ✅
+#
+# The teacher forward is pipelined across the GPUs; the student's
+# forward/backward stays on cuda:0. Wall time is teacher-forward-bound,
+# comparable to the single-96GB estimate (5-7 days) — submit with
+# submit_chain.sh count=7: each 24 h job resumes from the latest
+# checkpoint automatically.
+#
+# Launch (inside an sbatch job — see forge/scripts/leonardo/):
+#   bash forge/scripts/distill.sh \
+#       forge/training/configs/leonardo/distill_qwen3_32b_to_7b_leonardo.yaml \
+#       "$EULLM_DATA_DIR"
+
+### models
+teacher_model: Qwen/Qwen3-32B-Base
+# Phase-1 LoRA adapter, relative to the job's working directory
+# ($EULLM_RUN_DIR) — i.e. the output_dir of the Phase-1 Leonardo config.
+teacher_adapter: ./checkpoints/qwen3_32b_legal_it_continued_pt
+student_model: Qwen/Qwen3-7B-Base
+teacher_load_in_8bit: false
+teacher_load_in_4bit: false
+
+### teacher placement (Leonardo: shard across the node's 4 GPUs)
+teacher_device_map: auto
+teacher_gib_per_gpu: 58
+teacher_gib_on_student_gpu: 8
+student_device: cuda:0
+
+### student fine-tuning method
+# LoRA student, as in the single-GPU config. With 256 GB of node VRAM a
+# full fine-tune becomes thinkable, but it needs FSDP on the student —
+# out of scope for v0.1 (see docs/legal-it-7b-strategy.md §4).
+student_finetune: lora
+student_lora_rank: 128
+student_lora_alpha: 256
+student_lora_dropout: 0.0
+student_lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - gate_proj
+  - up_proj
+  - down_proj
+
+### data
+# Overridden by the data-dir argument distill.sh passes on the CLI.
+dataset_dir: ~/datasets/legal_it
+train_file: train.jsonl
+val_file: val.jsonl
+cutoff_len: 2048
+max_train_samples: null
+
+### training
+# Relative to the job's working directory ($EULLM_RUN_DIR on $WORK).
+output_dir: ./checkpoints/qwen3_7b_legal_it_distilled
+per_device_train_batch_size: 1
+gradient_accumulation_steps: 16
+learning_rate: 5.0e-5
+weight_decay: 0.01
+max_grad_norm: 1.0
+num_train_epochs: 1
+max_steps: -1
+warmup_steps: 1000
+save_steps: 1000
+eval_steps: 1000
+logging_steps: 20
+
+### distillation
+kl_temperature: 2.0
+kl_alpha: 0.7
+
+### hardware
+bf16: true
+gradient_checkpointing: true
+seed: 42


### PR DESCRIPTION
…HPC)

The EHPC-AIF-2026PG01-1147 allocation (1,250 node hours on Leonardo Booster, 02/09-02/11/2026) replaces the rented 96 GB single-GPU plan. Leonardo nodes are 4x A100 64 GB, 24 h max walltime, no network on compute nodes — none of which the pipeline supported.

- Phase 1: Leonardo YAML variant with DeepSpeed ZeRO-3 across the node's 4 GPUs (~36 GB/GPU vs the 78 GB single-GPU budget); train.sh gains a __REPO_ROOT__ substitution so YAMLs can reference the DeepSpeed config from any run directory.
- Phase 2: distill.py learns teacher_device_map=auto — the frozen BF16 teacher shards across all visible GPUs via an accelerate max_memory map (build_teacher_max_memory, unit-tested) while the student trains on its own GPU; teacher logits are moved to the student device.
- Resume correctness (critical under the 24 h walltime cap): the optimizer is now created after the student is reloaded from a checkpoint (it previously bound to the discarded model, silently training nothing after a resume), and LoRA checkpoints resume via PeftModel on a rebuilt base instead of failing in AutoModelForCausalLM.
- Phase 2 -> 3 handoff: after the final save the LoRA student is merged into full HF weights (output_dir/merged), which is what quantize_to_gguf.sh requires; the quantize script gains LCPP_SKIP_UPDATE=1 for offline compute nodes.
- New forge/scripts/leonardo/: shared env (paths on $WORK, offline HF flags inside jobs, SBATCH_ACCOUNT), login-node setup, model prefetcher, sbatch scripts for smoke/phase1/phase2/quantize, and submit_chain.sh to chain 24 h jobs with afterany dependencies.
- check_training_env.py: --offline (require the HF cache), --cpu-only (login nodes), --expect-gpus/--multi-gpu (deepspeed) checks.
- Docs: leonardo-runbook.md (budget, walltime chaining, monitoring, troubleshooting); strategy doc and training README updated to point at the Leonardo path.