### PR TITLE
fix(forge): repoint the Leonardo Phase 2/3 launchers and let prefetch…

### DIFF
--- a/docs/leonardo-runbook.md
+++ b/docs/leonardo-runbook.md
@@ -21,7 +21,7 @@
 | Item | Node hours |
 |------|-----------:|
 | Smoke + wiring validation | ~1 |
-| Phase 1 — continued PT 32B (ZeRO-3, ≤ 2 x 24 h chain) | ~25-50 |
+| Phase 1 — continued PT 30B-A3B (ZeRO-3, ≤ 2 x 24 h chain) | ~25-50 |
 | Phase 2 — distillation (7 x 24 h chain) | ~120-170 |
 | Phase 3 — GGUF (serial partition) | 0 |
 | Retries / headroom | ~50 |
@@ -73,7 +73,7 @@ bash "$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \
 ```
 
 Output: LoRA adapter at
-`$EULLM_RUN_DIR/checkpoints/qwen3_32b_legal_it_continued_pt/`.
+`$EULLM_RUN_DIR/checkpoints/qwen3_30b_a3b_legal_it_continued_pt/`.
 If the epoch finishes inside job 1, job 2 wakes up, finds the final
 checkpoint, re-runs the last partial step and exits quickly — a few
 wasted node-minutes, not hours.
@@ -88,7 +88,7 @@ bash "$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \
 The sbatch script refuses to start if the Phase-1 adapter is missing.
 Output: LoRA checkpoints plus — from the final save — a **merged**
 full-weights student at
-`.../checkpoints/qwen3_7b_legal_it_distilled/merged/`, which is what
+`.../checkpoints/qwen3_4b_legal_it_distilled/merged/`, which is what
 Phase 3 consumes. Watch the `kl=` term in the logs: it should fall
 steadily for the first few thousand steps.
 

--- a/forge/scripts/leonardo/prefetch_models.py
+++ b/forge/scripts/leonardo/prefetch_models.py
@@ -72,6 +72,13 @@ def main() -> int:
     # Verify the offline code path jobs will take, for what did download.
     os.environ["HF_HUB_OFFLINE"] = "1"
     os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    # Announce the import: on a cold Lustre cache `import transformers`
+    # reads thousands of small files and can take minutes with nothing on
+    # screen. Silence right after a multi-GB download reads as a hang, and
+    # the natural reaction — Ctrl-C — is the one thing that will not work
+    # here (see the os._exit note at the bottom of this file).
+    print("[..] importing transformers to verify the offline load path "
+          "(slow on a cold cache, no output until it finishes)", flush=True)
     from transformers import AutoConfig, AutoTokenizer
 
     for model_id in ok:
@@ -95,4 +102,17 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    code = main()
+    # os._exit, not sys.exit: the Xet download backend (hf_xet, the Rust
+    # engine behind the "Reconstruction complete" lines) leaves non-daemon
+    # worker threads behind, and the interpreter blocks joining them after
+    # main() has returned. The process then sits there with all the work
+    # done, printing nothing, ignoring Ctrl-C — SIGINT is only serviced
+    # between bytecodes and there are none left to run — and the only way
+    # out is SIGKILL from another shell. Observed on Leonardo after a 61 GB
+    # teacher fetch. Everything this script produces is already on disk by
+    # the time main() returns, so skipping interpreter shutdown costs
+    # nothing; flush by hand since os._exit does not.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(code)

--- a/forge/scripts/leonardo/sbatch_phase1.slurm
+++ b/forge/scripts/leonardo/sbatch_phase1.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Phase 1 — continued pre-training of the Qwen3-32B teacher on one
+# Phase 1 — continued pre-training of the Qwen3-30B-A3B teacher on one
 # Leonardo Booster node (4x A100 64 GB), DeepSpeed ZeRO-3 via
 # LLaMA-Factory. See the Leonardo YAML header for the memory budget.
 #
@@ -8,7 +8,7 @@
 #   bash "$EULLM_REPO/forge/scripts/leonardo/submit_chain.sh" \
 #       "$EULLM_REPO/forge/scripts/leonardo/sbatch_phase1.slurm" 2
 #
-#SBATCH --job-name=eullm-p1-cpt32b
+#SBATCH --job-name=eullm-p1-cpt30ba3b
 #SBATCH --partition=boost_usr_prod
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1

--- a/forge/scripts/leonardo/sbatch_phase2.slurm
+++ b/forge/scripts/leonardo/sbatch_phase2.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Phase 2 — distillation Qwen3-32B-legal-it → Qwen3-7B on one Leonardo
+# Phase 2 — distillation Qwen3-30B-A3B-legal-it → Qwen3-4B on one Leonardo
 # Booster node. Single process: the frozen BF16 teacher is sharded
 # across the 4 GPUs (accelerate device_map), the student trains on
 # cuda:0. See the Leonardo distill YAML header for the memory budget.
@@ -27,7 +27,7 @@ source "$EULLM_REPO/forge/scripts/leonardo/env.sh"
 cd "$EULLM_RUN_DIR"
 
 # Phase 1 must have produced the teacher adapter this YAML points at.
-ADAPTER="./checkpoints/qwen3_32b_legal_it_continued_pt"
+ADAPTER="./checkpoints/qwen3_30b_a3b_legal_it_continued_pt"
 [ -f "$ADAPTER/adapter_config.json" ] || {
     echo "[err] Phase-1 adapter not found at $EULLM_RUN_DIR/$ADAPTER" >&2
     echo "[err] run sbatch_phase1.slurm to completion first" >&2

--- a/forge/scripts/leonardo/sbatch_quantize.slurm
+++ b/forge/scripts/leonardo/sbatch_quantize.slurm
@@ -24,7 +24,7 @@ source "$EULLM_REPO/forge/scripts/leonardo/env.sh"
 cd "$EULLM_RUN_DIR"
 
 # The LoRA student is exported merged (full HF weights) by distill.py.
-HF_DIR="$EULLM_RUN_DIR/checkpoints/qwen3_7b_legal_it_distilled/merged"
+HF_DIR="$EULLM_RUN_DIR/checkpoints/qwen3_4b_legal_it_distilled/merged"
 [ -f "$HF_DIR/config.json" ] || {
     echo "[err] merged student not found at $HF_DIR" >&2
     echo "[err] Phase 2 must run to completion first (the merge happens" >&2


### PR DESCRIPTION
… exit

Two stale paths in the Leonardo launchers survived the model rename and would have failed a phase each, hours after submission:

- sbatch_phase2.slurm looked for the Phase-1 adapter at checkpoints/qwen3_32b_legal_it_continued_pt, while the Phase-1 config writes qwen3_30b_a3b_legal_it_continued_pt. The guard would have refused to start, burning a queue slot per attempt.
- sbatch_quantize.slurm read the merged student from qwen3_7b_legal_it_distilled/merged instead of qwen3_4b_*.

Also fixes a real hang in prefetch_models.py. After a 61 GB teacher fetch the process sat with all work done, printing nothing and ignoring Ctrl-C, and only SIGKILL from another shell cleared it. Two causes, both addressed: `import transformers` on a cold Lustre cache takes minutes in silence right after the download bars finish, which reads as a hang, so it is now announced; and the Xet download backend leaves non-daemon worker threads that the interpreter blocks on after main() returns, with no bytecode left for SIGINT to be serviced between — so the script exits via os._exit with an explicit flush, since everything it produces is on disk by then.

The single-GPU fallback path (continued_pt_qwen3_32b.yaml and friends) keeps its 32B/7B paths on purpose: a 96 GB host can afford the dense teacher, and that is the configuration the strategy document says to revisit if a larger allocation lands.