### PR TITLE
fix(forge): drop ZeRO-3 for the frozen teacher, quantize and replicat…

### DIFF
--- a/forge/scripts/leonardo/memprobe/sitecustomize.py
+++ b/forge/scripts/leonardo/memprobe/sitecustomize.py
@@ -1,0 +1,115 @@
+"""CUDA memory probe, installed by putting this directory on PYTHONPATH.
+
+Python imports `sitecustomize` automatically at interpreter startup, which
+makes this the one place we can instrument LLaMA-Factory's worker processes
+without forking it: the training entry point is theirs, not ours, and by the
+time an OOM propagates the allocator state that caused it is gone.
+
+Three OOMs on the Qwen3-30B-A3B teacher were diagnosed by inference — the
+exception says how much was free and how much was requested, and nothing
+about *what* had taken the rest. This prints, for every rank:
+
+  * on a CUDA OOM: `torch.cuda.memory_summary()`, which breaks the reserved
+    pool down by allocation size and shows fragmentation;
+  * at exit, whatever the outcome: peak allocated and peak reserved per
+    device, which are the numbers a run log needs and which cannot be
+    recovered afterwards.
+
+Deliberately defensive throughout. A probe that raises inside an excepthook
+or an atexit handler would turn a diagnosable failure into an undiagnosable
+one, so every path is wrapped and failure is silent.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import sys
+
+_TAG = f"[memprobe rank {os.environ.get('RANK', os.environ.get('LOCAL_RANK', '?'))}]"
+
+
+def _torch():
+    """Return torch if it is already imported and CUDA is usable, else None.
+
+    Never imports torch itself: sitecustomize runs before anything else, and
+    importing a multi-second dependency at startup in every subprocess — pip,
+    the shell's python, LLaMA-Factory's own helpers — would be a real cost for
+    no benefit. If the process never loaded torch, there is nothing to report.
+    """
+    mod = sys.modules.get("torch")
+    try:
+        if mod is None or not mod.cuda.is_available():
+            return None
+    except Exception:
+        return None
+    return mod
+
+
+def _emit(line: str) -> None:
+    try:
+        print(f"{_TAG} {line}", file=sys.stderr, flush=True)
+    except Exception:
+        pass
+
+
+def _dump_totals(when: str) -> None:
+    torch = _torch()
+    if torch is None:
+        return
+    try:
+        gib = 1024 ** 3
+        for i in range(torch.cuda.device_count()):
+            # Skip devices this process never allocated on. Dataloader and
+            # preprocessing workers import torch without touching CUDA, and
+            # four zero lines each would bury the ranks that matter.
+            if torch.cuda.max_memory_allocated(i) == 0:
+                continue
+            _emit(
+                f"{when} dev{i}: "
+                f"peak_allocated={torch.cuda.max_memory_allocated(i) / gib:.2f} GiB  "
+                f"peak_reserved={torch.cuda.max_memory_reserved(i) / gib:.2f} GiB  "
+                f"now_allocated={torch.cuda.memory_allocated(i) / gib:.2f} GiB  "
+                f"now_reserved={torch.cuda.memory_reserved(i) / gib:.2f} GiB"
+            )
+    except Exception as exc:
+        _emit(f"{when}: could not read memory stats ({type(exc).__name__})")
+
+
+def _dump_summary() -> None:
+    torch = _torch()
+    if torch is None:
+        return
+    try:
+        _emit("OOM — allocator summary for the current device follows")
+        print(torch.cuda.memory_summary(), file=sys.stderr, flush=True)
+    except Exception as exc:
+        _emit(f"could not produce memory_summary ({type(exc).__name__})")
+
+
+_previous_excepthook = sys.excepthook
+
+
+def _excepthook(exc_type, exc, tb):  # noqa: ANN001 - signature is fixed
+    try:
+        name = getattr(exc_type, "__name__", "")
+        if "OutOfMemory" in name or "out of memory" in str(exc):
+            _dump_totals("at OOM")
+            _dump_summary()
+    except Exception:
+        pass
+    _previous_excepthook(exc_type, exc, tb)
+
+
+sys.excepthook = _excepthook
+
+# The exception may never reach the excepthook — torch.distributed.elastic and
+# the Trainer both catch and re-raise through their own machinery — so the
+# peak numbers are also emitted unconditionally at interpreter shutdown.
+atexit.register(_dump_totals, "at exit")
+
+# Announce once, from the first rank only: every child process imports
+# sitecustomize too, and eight preprocessing workers saying "installed" is
+# noise in a log whose whole purpose is to be readable.
+if os.environ.get("RANK", "0") == "0" and os.environ.get("LOCAL_RANK", "0") == "0":
+    _emit("installed (peaks at exit, allocator summary on CUDA OOM)")

--- a/forge/scripts/leonardo/sbatch_phase1.slurm
+++ b/forge/scripts/leonardo/sbatch_phase1.slurm
@@ -38,10 +38,38 @@ python "$EULLM_REPO/forge/scripts/check_training_env.py" \
     --offline --multi-gpu --expect-gpus 4 --data-dir "$EULLM_DATA_DIR" \
     --tokenizer-model Qwen/Qwen3-30B-A3B-Base
 
-# LLaMA-Factory launches through torchrun with one rank per GPU.
+# LLaMA-Factory launches through torchrun with one rank per GPU. No
+# DeepSpeed config is passed, so this is plain DDP and every rank holds the
+# whole quantized base — see the training YAML header for why.
 export FORCE_TORCHRUN=1
 export NPROC_PER_NODE=4
 export OMP_NUM_THREADS=8
+
+# Let the caching allocator grow segments instead of pre-carving fixed ones.
+# Three OOMs on this model asked for a few hundred MiB while the allocator
+# held gigabytes it could not hand back because of fragmentation.
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+# Python auto-imports `sitecustomize` from PYTHONPATH, which is the only
+# hook into LLaMA-Factory's worker processes we get without forking it. The
+# probe prints peak allocated/reserved per GPU at exit and the allocator
+# summary on a CUDA OOM — the breakdown the exception itself never carries.
+export PYTHONPATH="$EULLM_REPO/forge/scripts/leonardo/memprobe${PYTHONPATH:+:$PYTHONPATH}"
+
+# Run identity, in the log rather than in someone's memory. Comparing two
+# runs a week apart is impossible without knowing which commit and which
+# quantization produced each.
+CFG="$EULLM_REPO/forge/training/configs/leonardo/continued_pt_qwen3_30b_a3b_leonardo.yaml"
+echo "=================== RUN ==================="
+echo "  job          : ${SLURM_JOB_ID:-?} on ${SLURMD_NODENAME:-?}"
+echo "  commit       : $(git -C "$EULLM_REPO" rev-parse --short HEAD 2>/dev/null || echo '?')"
+echo "  config       : $(basename "$CFG")"
+for k in quantization_bit cutoff_len per_device_train_batch_size \
+         gradient_accumulation_steps lora_rank lora_target num_train_epochs; do
+    printf '  %-13s: %s\n' "$k" "$(grep -E "^${k}:" "$CFG" | head -1 | cut -d: -f2- | xargs)"
+done
+echo "  deepspeed    : $(grep -qE '^deepspeed:' "$CFG" && echo yes || echo 'no (plain DDP)')"
+echo "==========================================="
 
 bash "$EULLM_REPO/forge/scripts/train.sh" \
     "$EULLM_REPO/forge/training/configs/leonardo/continued_pt_qwen3_30b_a3b_leonardo.yaml" \

--- a/forge/training/configs/leonardo/continued_pt_qwen3_30b_a3b_leonardo.yaml
+++ b/forge/training/configs/leonardo/continued_pt_qwen3_30b_a3b_leonardo.yaml
@@ -1,31 +1,42 @@
 # Phase 1 — Continued pre-training of the teacher, Leonardo Booster edition.
 #
 # Target: Qwen3-30B-A3B-Base + LoRA on the full 700M-token Italian legal
-# corpus, on ONE Leonardo Booster node (4x NVIDIA A100 64 GB), sharded
-# with DeepSpeed ZeRO-3 across the 4 GPUs:
+# corpus, on ONE Leonardo Booster node (4x NVIDIA A100 64 GB). The base is
+# quantized and REPLICATED on every GPU — plain data parallelism, no
+# parameter sharding of any kind:
 #
-#   frozen 30B BF16 weights, sharded 4-way      ~15 GB / GPU
-#   LoRA params + grads + Adam, sharded          ~1 GB / GPU
+#   frozen 30B weights, 8-bit, REPLICATED       ~31 GB / GPU
+#   LoRA params + grads + Adam (fp32)            ~2 GB / GPU
 #   activations (grad ckpt, seq len 1024)        ~4 GB / GPU
-#   ZeRO-3 gather buffers                    see below / GPU
+#   ────────                                    ─────
+#   total                                       ~37 GB / 64 GB per GPU
 #
-# The gather buffers are the line that matters on a MoE, and the first
-# run got them wrong: budgeted at ~10 GB, they took everything. ZeRO-3
-# keeps parameters partitioned at rest but must materialise a whole layer
-# on EVERY GPU to compute it, and one layer here is 128 experts x 3
-# matrices ~= 625 M parameters, 1.25 GB in bf16, against ~25 M for a dense
-# layer of the same hidden size. With the dense config's 1e9 live-parameter
-# limit and prefetch, several such layers were resident at once and 63.4
-# GiB of every A100 filled twenty seconds into the first forward (job
-# 56760964, 2026-09-08). ds_zero3_moe.json caps the gathered working set.
+# NO DEEPSPEED, NO ZeRO-3 — and that is the whole lesson of 2026-09-08.
+# Three jobs OOM'd trying to make ZeRO-3 fit this model (56760964 at the
+# first forward, 56768626 in backward 94 MiB short, 56781343 again at 62
+# GiB with halved sequence length and overlap_comm off, which moved the
+# peak by nothing). The diagnosis was wrong each time because the question
+# was wrong.
 #
-# That fix got the forward through — GPUs reached 100% — and job 56768626
-# then OOM'd in the BACKWARD pass instead, asking for 768 MiB with 674 MiB
-# free: 94 MiB short of 63.42 GiB. Hence cutoff_len 1024 and
-# overlap_comm false, which buy headroom rather than a 94 MiB pass. The one
-# lever still unused is offload_param to CPU; the node had 287 GiB of
-# system memory free at the moment of the failure, and host RAM cannot
-# rescue a full GPU unless offloading is configured explicitly.
+# ZeRO-3 exists to shard the optimizer state, gradients and parameters of a
+# model that is BEING TRAINED. Here the base is frozen and only 107 M of
+# 30.6 B parameters get gradients, so the optimizer state it would shard is
+# negligible — we were paying ZeRO-3's entire all-gather cost to distribute
+# 45 GB of weights that never change. And on a MoE that cost is brutal:
+# ZeRO-3 must materialise a whole layer on EVERY GPU to compute it, and one
+# layer here is 128 experts x 3 matrices ~= 625 M parameters against ~25 M
+# for a dense layer of the same hidden size.
+#
+# The answer to "45 GB of static weights do not fit" is to compress them,
+# not to keep shipping them between GPUs. Quantized and replicated, each
+# rank holds the whole model, there is no all-gather at all, and the only
+# communication left is the gradient reduction over 107 M LoRA parameters
+# — which is nothing. This is the maximum-throughput configuration on this
+# node, not a compromise.
+#
+# 8-bit first, 4-bit as the fallback if this does not leave comfortable
+# headroom. Anything that fits with a few hundred MiB to spare is not a
+# configuration, it is a coincidence waiting for an eval batch.
 #
 # WHY THIS MODEL, and not the Qwen3-32B-Base this file used to name:
 # Qwen3-32B-Base does not exist. Neither does Qwen3-7B-Base, the student
@@ -74,13 +85,25 @@
 model_name_or_path: Qwen/Qwen3-30B-A3B-Base
 trust_remote_code: false
 
-### distributed (DeepSpeed ZeRO-3 across the node's 4 GPUs)
-# __REPO_ROOT__ is replaced by forge/scripts/train.sh at launch time.
-# ds_zero3_moe.json, not ds_zero3.json: the dense-tuned limits let ZeRO-3
-# gather several MoE layers at once and filled 63.4 GiB of every A100 in
-# twenty seconds at the first forward (job 56760964). See that file's
-# _README for the arithmetic.
-deepspeed: __REPO_ROOT__/forge/training/configs/ds_zero3_moe.json
+### distributed (plain DDP — every rank holds the whole quantized model)
+# No `deepspeed:` key on purpose; see the header. torchrun starts one rank
+# per GPU and LLaMA-Factory falls back to DistributedDataParallel, which
+# here reduces gradients over the LoRA parameters only.
+#
+# find_unused_parameters stays false: with LoRA on the four attention
+# projections every trainable parameter is used on every step, so the
+# expensive graph traversal that `true` enables would buy nothing. It is
+# stated rather than left to default because a MoE is exactly the kind of
+# model where someone reaches for `true` — the *experts* are conditionally
+# used, but they are frozen and have no gradients to look for.
+ddp_find_unused_parameters: false
+
+### quantization (QLoRA: frozen base quantized, adapters in fp32)
+# 8 before 4: the less lossy option first. The Phase-1 adapter is trained
+# on top of THESE weights, so Phase 2 must load the teacher with the same
+# quantization_bit or the adapter lands on weights it never saw. That
+# dependency spans two jobs days apart — see docs/legal-it-4b-strategy.md.
+quantization_bit: 8
 
 ### method (continued pre-training with LoRA)
 stage: pt
@@ -104,13 +127,12 @@ lora_dropout: 0.05
 dataset_dir: __DATASET_DIR__
 dataset: legal_it_train
 eval_dataset: legal_it_val
-# 1024, not the 2048 the single-GPU config uses. Halving the sequence
-# halves activation memory, which is what the backward pass ran out of:
-# the forward now completes (GPUs reached 100%) and backward asked for
-# 768 MiB with 674 MiB free — 94 MiB short of 63.42 GiB. Fitting by 94 MiB
-# is not fitting; the first eval batch or a run of allocator fragmentation
-# would OOM hours in instead of minutes in. Same total tokens, twice the
-# optimizer steps. Raise it back once a run is measured and has room.
+# 1024, not the 2048 the single-GPU config uses. It was halved while
+# fighting the ZeRO-3 OOMs and is kept here only because nothing has
+# measured the real activation cost yet; under DDP with a quantized base
+# the memory picture is completely different and this is very likely
+# affordable at 2048 again. Same total tokens either way, twice the
+# optimizer steps at 1024. Raise it once a run reports its peak.
 cutoff_len: 1024
 preprocessing_num_workers: 8
 overwrite_cache: false


### PR DESCRIPTION
…e it

Three jobs OOM'd trying to make ZeRO-3 fit Qwen3-30B-A3B: 56760964 at the first forward, 56768626 in backward 94 MiB short of 63.42 GiB, and 56781343 again at 62 GiB with the sequence halved and overlap_comm off, which moved the peak by nothing at all. Each diagnosis was wrong, because the question was wrong.

ZeRO-3 shards the optimizer state, gradients and parameters of a model that is being trained. This base is frozen: 107 M of 30.6 B parameters get gradients, so there is essentially no optimizer state to shard. We were paying ZeRO-3's entire all-gather cost to distribute 45 GB of weights that never change — and on a MoE that cost is brutal, since a whole layer must be materialised on every GPU to compute it and one layer here is 128 experts x 3 matrices against a dense layer's single one.

The answer to "45 GB of static weights do not fit" is to compress them, not to keep shipping them between GPUs. The base is now loaded at 8-bit (~31 GB) and replicated on every rank under plain DDP: no all-gather, no offload, no sharding, and the only communication left is the gradient reduction over the LoRA parameters. 4-bit is the fallback if 8-bit does not leave comfortable headroom — a configuration that fits by a few hundred MiB is a coincidence, not a configuration.

Adds the instrumentation that should have existed before the first OOM. A sitecustomize probe on PYTHONPATH — the only hook into LLaMA-Factory's workers that does not mean forking it — prints peak allocated and reserved per GPU at exit, and the allocator summary on a CUDA OOM, which is the breakdown the exception never carries. expandable_segments is on, since every one of the three failures asked for a few hundred MiB while the allocator held gigabytes it could not defragment. And the job now opens with its own identity: commit, config, quantization, batch, sequence length, accumulation, so two runs a week apart can be compared at all.

Recorded in the config header, including the cross-phase dependency this creates: the Phase-1 adapter is trained on top of quantized weights, so Phase 2 must load the teacher at the same quantization_bit or the adapter lands on weights it never saw.