### PR TITLE
feat(forge): enforce the quantization invariants instead of documenti…

### DIFF
--- a/forge/scripts/check_training_env.py
+++ b/forge/scripts/check_training_env.py
@@ -128,6 +128,56 @@ def check_dataset(data_dir: Path) -> bool:
 DEFAULT_TOKENIZER_MODEL = "Qwen/Qwen3-1.7B-Base"
 
 
+def check_frozen_base_config(config_path: Path) -> bool:
+    """Audit a LoRA training config for sharding of the frozen base.
+
+    ZeRO-3 and FSDP exist to distribute what a *trainable* model needs:
+    optimizer state, gradients, parameters under update. With LoRA the
+    trainable set is a fraction of a percent, so sharding the frozen base
+    buys almost nothing and costs an all-gather of a whole layer onto every
+    GPU on each forward — which on a 128-expert MoE is what OOM'd three
+    jobs on 2026-09-08. Unsharded, the base is replicated, and replicated it
+    only fits if it is quantized. The two facts are checked together because
+    they are the same decision.
+    """
+    try:
+        import yaml
+    except ImportError:
+        warn("PyYAML not installed — cannot audit the training config")
+        return True
+    try:
+        cfg = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        fail(f"could not read {config_path}: {exc}")
+        return False
+
+    ok(f"config {config_path.name}")
+    good = True
+
+    sharding = [k for k in ("deepspeed", "fsdp", "fsdp_config") if cfg.get(k)]
+    if sharding:
+        fail(
+            f"{', '.join(sharding)} set: the frozen base would be sharded. "
+            "Quantize and replicate it instead (see the config header)."
+        )
+        good = False
+    else:
+        ok("no deepspeed/fsdp — the frozen base is not sharded")
+
+    if cfg.get("finetuning_type") == "lora":
+        bits = cfg.get("quantization_bit")
+        if bits in (4, 8):
+            ok(f"base quantized to {bits}-bit and replicated per rank")
+        elif not sharding:
+            fail(
+                "finetuning_type is lora with no quantization_bit and no "
+                "sharding: the full-precision base would be replicated on "
+                "every GPU."
+            )
+            good = False
+    return good
+
+
 def check_tokenizer(model_id: str, *, offline: bool = False) -> bool:
     """Smoke-load the tokenizer for the configured model. Confirms that
     transformers + huggingface_hub auth are working without committing
@@ -172,6 +222,17 @@ def main(argv: Iterable[str] | None = None) -> int:
         "--skip-tokenizer",
         action="store_true",
         help="Skip the HF tokenizer fetch (useful offline / CI)",
+    )
+    parser.add_argument(
+        "--assert-frozen-base",
+        type=Path,
+        default=None,
+        help=(
+            "Training YAML to audit before spending node-hours. Fails if it "
+            "declares deepspeed/fsdp (parameter sharding of a base that is "
+            "frozen buys nothing and cost three OOMs) or if a replicated base "
+            "is left unquantized (61 GB against a 64 GB card)."
+        ),
     )
     parser.add_argument(
         "--tokenizer-model",
@@ -248,6 +309,12 @@ def main(argv: Iterable[str] | None = None) -> int:
     print("== Dataset ==")
     if not check_dataset(args.data_dir):
         failed = True
+
+    if args.assert_frozen_base is not None:
+        print()
+        print("== Training config (frozen base must not be sharded) ==")
+        if not check_frozen_base_config(args.assert_frozen_base):
+            failed = True
 
     print()
     print("== Tokenizer (HF cache + auth check) ==")

--- a/forge/scripts/leonardo/sbatch_phase1.slurm
+++ b/forge/scripts/leonardo/sbatch_phase1.slurm
@@ -25,6 +25,8 @@ EULLM_REPO="${EULLM_REPO:-$WORK/eullm}"
 source "$EULLM_REPO/forge/scripts/leonardo/env.sh"
 cd "$EULLM_RUN_DIR"
 
+CFG="$EULLM_REPO/forge/training/configs/leonardo/continued_pt_qwen3_30b_a3b_leonardo.yaml"
+
 # Report on ourselves BEFORE the pre-flight, not after. The pre-flight
 # imports transformers, which on a cold node cache reads thousands of small
 # files off Lustre and takes minutes in complete silence — so starting the
@@ -36,7 +38,8 @@ heartbeat_start
 
 python "$EULLM_REPO/forge/scripts/check_training_env.py" \
     --offline --multi-gpu --expect-gpus 4 --data-dir "$EULLM_DATA_DIR" \
-    --tokenizer-model Qwen/Qwen3-30B-A3B-Base
+    --tokenizer-model Qwen/Qwen3-30B-A3B-Base \
+    --assert-frozen-base "$CFG"
 
 # LLaMA-Factory launches through torchrun with one rank per GPU. No
 # DeepSpeed config is passed, so this is plain DDP and every rank holds the
@@ -59,7 +62,6 @@ export PYTHONPATH="$EULLM_REPO/forge/scripts/leonardo/memprobe${PYTHONPATH:+:$PY
 # Run identity, in the log rather than in someone's memory. Comparing two
 # runs a week apart is impossible without knowing which commit and which
 # quantization produced each.
-CFG="$EULLM_REPO/forge/training/configs/leonardo/continued_pt_qwen3_30b_a3b_leonardo.yaml"
 echo "=================== RUN ==================="
 echo "  job          : ${SLURM_JOB_ID:-?} on ${SLURMD_NODENAME:-?}"
 echo "  commit       : $(git -C "$EULLM_REPO" rev-parse --short HEAD 2>/dev/null || echo '?')"
@@ -71,6 +73,4 @@ done
 echo "  deepspeed    : $(grep -qE '^deepspeed:' "$CFG" && echo yes || echo 'no (plain DDP)')"
 echo "==========================================="
 
-bash "$EULLM_REPO/forge/scripts/train.sh" \
-    "$EULLM_REPO/forge/training/configs/leonardo/continued_pt_qwen3_30b_a3b_leonardo.yaml" \
-    "$EULLM_DATA_DIR"
+bash "$EULLM_REPO/forge/scripts/train.sh" "$CFG" "$EULLM_DATA_DIR"

--- a/forge/scripts/leonardo/sbatch_phase2.slurm
+++ b/forge/scripts/leonardo/sbatch_phase2.slurm
@@ -34,6 +34,8 @@ ADAPTER="./checkpoints/qwen3_30b_a3b_legal_it_continued_pt"
     exit 1
 }
 
+CFG="$EULLM_REPO/forge/training/configs/leonardo/distill_qwen3_30b_a3b_to_4b_leonardo.yaml"
+
 # Report on ourselves BEFORE the pre-flight, not after. The pre-flight
 # imports transformers, which on a cold node cache reads thousands of small
 # files off Lustre and takes minutes in complete silence — so starting the
@@ -45,8 +47,33 @@ heartbeat_start
 
 python "$EULLM_REPO/forge/scripts/check_training_env.py" \
     --offline --expect-gpus 4 --data-dir "$EULLM_DATA_DIR" \
-    --tokenizer-model Qwen/Qwen3-4B-Base
+    --tokenizer-model Qwen/Qwen3-4B-Base \
+    --assert-frozen-base "$CFG"
 
-bash "$EULLM_REPO/forge/scripts/distill.sh" \
-    "$EULLM_REPO/forge/training/configs/leonardo/distill_qwen3_30b_a3b_to_4b_leonardo.yaml" \
-    "$EULLM_DATA_DIR"
+# Gate: the teacher is quantized, and in distillation its distribution IS
+# the target, so a quantization error is trained into the student rather
+# than merely degrading the run. Measure it before spending the budget.
+#
+# Cached deliberately. The check loads both teachers at once and takes
+# tens of minutes; running it again in every job of an afterany chain would
+# re-pay that for a result that cannot have changed. The report records
+# which bit width was validated, so switching 8-bit to 4-bit invalidates it.
+TEACHER_BITS="$(grep -qE '^teacher_load_in_8bit:[[:space:]]*true' "$CFG" && echo 8 \
+    || { grep -qE '^teacher_load_in_4bit:[[:space:]]*true' "$CFG" && echo 4 || echo 0; })"
+REPORT="$EULLM_RUN_DIR/quant_validation_${TEACHER_BITS}bit.json"
+
+if [ "$TEACHER_BITS" = "0" ]; then
+    echo "[..] teacher is not quantized — no logit validation needed"
+elif [ -f "$REPORT" ]; then
+    echo "[ok] teacher already validated at ${TEACHER_BITS}-bit ($REPORT)"
+else
+    echo "[..] validating the ${TEACHER_BITS}-bit teacher against bf16"
+    python "$EULLM_REPO/forge/scripts/validate_quantized_teacher.py" \
+        --model "$(grep -E '^teacher_model:' "$CFG" | cut -d: -f2- | xargs)" \
+        --bits "$TEACHER_BITS" \
+        --adapter "$(grep -E '^teacher_adapter:' "$CFG" | cut -d: -f2- | xargs)" \
+        --data "$EULLM_DATA_DIR/val.jsonl" \
+        --report "$REPORT"
+fi
+
+bash "$EULLM_REPO/forge/scripts/distill.sh" "$CFG" "$EULLM_DATA_DIR"

--- a/forge/scripts/validate_quantized_teacher.py
+++ b/forge/scripts/validate_quantized_teacher.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Gate Phase 2 on how much the quantized teacher's logits actually moved.
+
+In distillation the teacher's output distribution IS the training target, so
+a quantization error there is not a degradation of training — it is copied
+into the student by construction. That makes "we quantized the teacher to fit
+it in memory" a claim that has to be measured before Phase 2 runs, not a note
+in a config header.
+
+Both teachers are loaded at once — bf16 as the reference, quantized as the
+candidate — and run over real samples from the validation corpus. For every
+predicted position we compare the two distributions:
+
+  * **KL(bf16 || quantized)** in nats, averaged over positions. Reads as "how
+    much information is lost by believing the quantized model instead of the
+    reference". Zero means identical.
+  * **top-1 / top-5 agreement**: how often the quantized model's most likely
+    token, and its top-5 set, match the reference. This is the part a reader
+    can interpret without a background in information theory, and the part
+    that predicts whether generations diverge.
+
+Exits non-zero when any threshold is missed, so an sbatch script with
+`set -e` refuses to start Phase 2 rather than distilling from a teacher
+nobody checked.
+
+    python forge/scripts/validate_quantized_teacher.py \\
+        --model Qwen/Qwen3-30B-A3B-Base --bits 8 \\
+        --adapter ./checkpoints/qwen3_30b_a3b_legal_it_continued_pt \\
+        --data "$EULLM_DATA_DIR/val.jsonl" --samples 200
+
+THE DEFAULT THRESHOLDS ARE A STARTING POINT, NOT A RESULT. They are set
+where 8-bit weight quantization of a healthy model should land comfortably;
+nobody has yet measured this model, which is the entire purpose of the
+script. Record what the first run reports, then set the thresholds from
+evidence and say so in the report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+
+
+def load_samples(path: Path, n: int, seed: int, field: str) -> list[str]:
+    """Reservoir-sample n texts without holding the whole corpus in memory."""
+    rng = random.Random(seed)
+    picked: list[str] = []
+    seen = 0
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                text = json.loads(line).get(field)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(text, str) or len(text) < 200:
+                continue
+            seen += 1
+            if len(picked) < n:
+                picked.append(text)
+            else:
+                j = rng.randrange(seen)
+                if j < n:
+                    picked[j] = text
+    return picked
+
+
+def build_model(model_id: str, bits: int | None, adapter: str | None):
+    import torch
+    from transformers import AutoModelForCausalLM
+
+    kwargs: dict = {"dtype": torch.bfloat16, "device_map": "auto"}
+    if bits in (4, 8):
+        from transformers import BitsAndBytesConfig
+
+        kwargs["quantization_config"] = BitsAndBytesConfig(
+            load_in_8bit=bits == 8,
+            load_in_4bit=bits == 4,
+            bnb_4bit_compute_dtype=torch.bfloat16,
+            bnb_4bit_quant_type="nf4",
+        )
+    model = AutoModelForCausalLM.from_pretrained(model_id, **kwargs)
+    if adapter:
+        from peft import PeftModel
+
+        model = PeftModel.from_pretrained(model, adapter)
+    return model.eval()
+
+
+def compare(reference, candidate, tokenizer, texts: list[str], seq_len: int) -> dict:
+    """Mean KL and top-k agreement between two models over the same inputs."""
+    import torch
+    import torch.nn.functional as F
+
+    kl_total = 0.0
+    top1_hits = top5_hits = positions = 0
+
+    for i, text in enumerate(texts, start=1):
+        enc = tokenizer(
+            text, return_tensors="pt", truncation=True, max_length=seq_len
+        )
+        ids = enc["input_ids"]
+        if ids.shape[1] < 8:
+            continue
+        with torch.no_grad():
+            ref_logits = reference(ids.to(reference.device)).logits.float()
+            cand_logits = candidate(ids.to(candidate.device)).logits.float()
+        cand_logits = cand_logits.to(ref_logits.device)
+
+        # Drop the last position: it predicts a token outside the window.
+        ref = ref_logits[0, :-1, :]
+        cand = cand_logits[0, :-1, :]
+
+        ref_logprobs = F.log_softmax(ref, dim=-1)
+        cand_logprobs = F.log_softmax(cand, dim=-1)
+        # KL(reference || candidate), summed over vocabulary, mean over
+        # positions. `kl_div` expects (input=log q, target=p).
+        kl = F.kl_div(
+            cand_logprobs, ref_logprobs, log_target=True, reduction="none"
+        ).sum(dim=-1)
+        kl_total += float(kl.sum())
+
+        ref_top5 = ref.topk(5, dim=-1).indices
+        cand_top1 = cand.argmax(dim=-1)
+        top1_hits += int((cand_top1 == ref_top5[:, 0]).sum())
+        top5_hits += int((cand_top1.unsqueeze(-1) == ref_top5).any(dim=-1).sum())
+        positions += ref.shape[0]
+
+        if i % 25 == 0:
+            print(f"  {i}/{len(texts)} samples, {positions} positions", flush=True)
+
+    if positions == 0:
+        raise SystemExit("no usable samples — check --data and --field")
+    return {
+        "positions": positions,
+        "mean_kl_nats": kl_total / positions,
+        "top1_agreement": top1_hits / positions,
+        "top5_agreement": top5_hits / positions,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--model", required=True, help="Teacher model id or path")
+    p.add_argument("--bits", type=int, choices=(4, 8), required=True)
+    p.add_argument("--adapter", default=None, help="Phase-1 LoRA adapter (optional)")
+    p.add_argument("--data", type=Path, required=True, help="JSONL to sample from")
+    p.add_argument("--field", default="text")
+    p.add_argument("--samples", type=int, default=200)
+    p.add_argument("--seq-len", type=int, default=512)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--max-kl", type=float, default=0.05, help="nats, mean per position")
+    p.add_argument("--min-top1", type=float, default=0.95)
+    p.add_argument("--min-top5", type=float, default=0.99)
+    p.add_argument("--report", type=Path, default=None, help="Write metrics as JSON")
+    args = p.parse_args(argv)
+
+    from transformers import AutoTokenizer
+
+    texts = load_samples(args.data, args.samples, args.seed, args.field)
+    print(f"[..] {len(texts)} samples from {args.data}", flush=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    print("[..] loading bf16 reference", flush=True)
+    reference = build_model(args.model, None, args.adapter)
+    print(f"[..] loading {args.bits}-bit candidate", flush=True)
+    candidate = build_model(args.model, args.bits, args.adapter)
+
+    metrics = compare(reference, candidate, tokenizer, texts, args.seq_len)
+    metrics.update(
+        model=args.model, bits=args.bits, adapter=args.adapter,
+        samples=len(texts), seq_len=args.seq_len,
+    )
+
+    checks = [
+        ("mean KL (nats)", metrics["mean_kl_nats"], args.max_kl, "<="),
+        ("top-1 agreement", metrics["top1_agreement"], args.min_top1, ">="),
+        ("top-5 agreement", metrics["top5_agreement"], args.min_top5, ">="),
+    ]
+    print()
+    print("=" * 60)
+    failed = []
+    for name, value, threshold, op in checks:
+        ok = value <= threshold if op == "<=" else value >= threshold
+        print(f"  {name:>18}: {value:.5f}   ({op} {threshold})   {'PASS' if ok else 'FAIL'}")
+        if not ok:
+            failed.append(name)
+    print(f"  {'positions':>18}: {metrics['positions']:,}")
+    print("=" * 60)
+
+    metrics["passed"] = not failed
+    if args.report:
+        args.report.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+        print(f"[ok] metrics written to {args.report}")
+
+    if failed:
+        print(
+            f"\n[!!] {args.bits}-bit teacher rejected on: {', '.join(failed)}.\n"
+            "     In distillation the teacher's distribution is the target, so\n"
+            "     this error would be trained into the student. Use a higher\n"
+            "     precision, or change the thresholds deliberately and record\n"
+            "     why in docs/legal-it-4b-strategy.md.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"\n[ok] {args.bits}-bit teacher is within thresholds")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/forge/tests/test_quantization_consistency.py
+++ b/forge/tests/test_quantization_consistency.py
@@ -1,0 +1,98 @@
+"""The teacher must be quantized identically in Phase 1 and Phase 2.
+
+Phase 1 trains a LoRA adapter on top of a quantized frozen base. Phase 2
+loads that adapter onto the teacher and uses the teacher's logits as the
+distillation target. If the two phases quantize differently, the adapter is
+applied to weights it was never trained against, and the resulting error is
+not a degradation of training — it is the target the student is fitted to.
+
+The two configs live in different files, are edited weeks apart, and express
+the same fact in different vocabularies (`quantization_bit: 8` versus
+`teacher_load_in_8bit: true`). That is precisely the shape of divergence this
+project has already paid for more than once, so it is asserted rather than
+documented.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+CONFIG_DIR = Path(__file__).resolve().parents[1] / "training" / "configs" / "leonardo"
+PHASE1 = CONFIG_DIR / "continued_pt_qwen3_30b_a3b_leonardo.yaml"
+PHASE2 = CONFIG_DIR / "distill_qwen3_30b_a3b_to_4b_leonardo.yaml"
+
+
+def _load(path: Path) -> dict:
+    assert path.is_file(), f"missing config: {path}"
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _phase2_teacher_bits(cfg: dict) -> int | None:
+    """Phase 2 spells quantization as two booleans; normalise to bits."""
+    in8 = bool(cfg.get("teacher_load_in_8bit"))
+    in4 = bool(cfg.get("teacher_load_in_4bit"))
+    assert not (in8 and in4), "teacher_load_in_8bit and _in_4bit are both true"
+    if in8:
+        return 8
+    if in4:
+        return 4
+    return None
+
+
+def test_teacher_quantization_matches_across_phases():
+    p1_bits = _load(PHASE1).get("quantization_bit")
+    p2_bits = _phase2_teacher_bits(_load(PHASE2))
+    assert p1_bits == p2_bits, (
+        f"Phase 1 trains the adapter on a {p1_bits}-bit base while Phase 2 "
+        f"loads the teacher at {p2_bits}-bit. Change both or neither."
+    )
+
+
+def test_phase2_points_at_the_phase1_output():
+    p1 = _load(PHASE1)
+    p2 = _load(PHASE2)
+    out = str(p1["output_dir"]).rstrip("/")
+    adapter = str(p2["teacher_adapter"]).rstrip("/")
+    assert out == adapter, (
+        f"Phase 2 reads the adapter from {adapter!r} but Phase 1 writes "
+        f"{out!r}. This has already broken once, after a model rename."
+    )
+
+
+def test_phase1_does_not_shard_the_frozen_base():
+    """No ZeRO, FSDP or any other parameter-sharding of a frozen model.
+
+    Sharding exists to distribute what a trainable model needs — optimizer
+    state, gradients, parameters under update. With 107 M trainable of
+    30.6 B, there is nothing worth sharding, and the all-gather traffic it
+    costs took three jobs to OOM before this was believed.
+    """
+    cfg = _load(PHASE1)
+    forbidden = [k for k in ("deepspeed", "fsdp", "fsdp_config") if cfg.get(k)]
+    assert not forbidden, (
+        f"Phase 1 declares {forbidden}, which shards a frozen base. The base "
+        "is quantized and replicated instead; see the config header."
+    )
+
+
+def test_phase1_quantizes_the_frozen_base():
+    """A replicated base only fits because it is quantized."""
+    cfg = _load(PHASE1)
+    bits = cfg.get("quantization_bit")
+    assert bits in (4, 8), (
+        f"quantization_bit is {bits!r}. Without sharding, the base is "
+        "replicated on every GPU: at bf16 that is 61 GB against 64 GB of "
+        "card, before activations."
+    )
+
+
+def test_phase1_trains_only_adapters():
+    cfg = _load(PHASE1)
+    assert cfg.get("finetuning_type") == "lora", (
+        "quantization_bit only makes sense with a frozen base; a full "
+        "fine-tune of quantized weights is not what this config means."
+    )

--- a/forge/training/configs/leonardo/distill_qwen3_30b_a3b_to_4b_leonardo.yaml
+++ b/forge/training/configs/leonardo/distill_qwen3_30b_a3b_to_4b_leonardo.yaml
@@ -34,7 +34,14 @@ teacher_model: Qwen/Qwen3-30B-A3B-Base
 # ($EULLM_RUN_DIR) — i.e. the output_dir of the Phase-1 Leonardo config.
 teacher_adapter: ./checkpoints/qwen3_30b_a3b_legal_it_continued_pt
 student_model: Qwen/Qwen3-4B-Base
-teacher_load_in_8bit: false
+# MUST MATCH quantization_bit in the Phase-1 config. The Phase-1 LoRA
+# adapter below was trained on top of quantized weights; loading the
+# teacher at a different precision applies it to weights it never saw, and
+# in Phase 2 the teacher's logits ARE the distillation target, so the error
+# does not degrade training — it is copied into the student by
+# construction. tests/test_quantization_consistency.py fails on a
+# mismatch and the Phase-2 pre-flight refuses to start on one.
+teacher_load_in_8bit: true
 teacher_load_in_4bit: false
 
 ### teacher placement (Leonardo: shard across the node's 4 GPUs)


### PR DESCRIPTION
…ng them

Four properties that were true only because a comment said so, each now something that stops a run.

Phase 1 and Phase 2 must quantize the teacher identically. They did not: Phase 1 trains a LoRA adapter on an 8-bit base while Phase 2 still loaded the teacher at bf16, which applies the adapter to weights it never saw — and in distillation the teacher's distribution is the target, so that error is copied into the student rather than merely degrading a run. Phase 2 now loads 8-bit, and a test compares the two configs, which express the same fact in different vocabularies (quantization_bit versus teacher_load_in_8bit) in files edited weeks apart. The same test pins Phase 2's adapter path to Phase 1's output_dir, which has already broken once after a rename.

The frozen base must not be sharded, and unsharded it must be quantized — one decision, so checked as one. check_training_env.py gains --assert-frozen-base, which audits the training YAML before any node-hours are spent: deepspeed or fsdp on a LoRA config is a failure, and so is a config with neither sharding nor quantization, since that replicates 61 GB onto a 64 GB card. Both launchers now run it.

The quantized teacher must be measured against bf16 before Phase 2, not noted as a caveat. validate_quantized_teacher.py loads both teachers, compares their distributions over real validation samples, and exits non-zero on mean KL, top-1 or top-5 agreement outside thresholds; the Phase 2 launcher runs it under `set -e`, so distillation cannot start from an unchecked teacher. The result is cached per bit width, because the check costs tens of minutes and cannot change between jobs of one chain, and switching 8-bit to 4-bit invalidates it by name.

Each test was verified to fail when its invariant is broken, rather than assumed to. The default KL and agreement thresholds are a starting point and say so in the script: nothing has measured this model yet, which is the point of having the script.