### PR TITLE
docs(adr-001): measure offline against online instead of choosing off…

### DIFF
--- a/docs/adr-001-offline-distillation.md
+++ b/docs/adr-001-offline-distillation.md
@@ -1,14 +1,26 @@
-# ADR-001 — Freeze legal-it v1.0, then move distillation offline
+# ADR-001 — Freeze legal-it v1.0, then stop co-hosting teacher and student
 
-> Status: **accepted, 2026-09-08** · Supersedes nothing · Affects Phase 1 and
-> Phase 2 of the verticalization pipeline from v1.1 onward.
+> Status: **accepted, 2026-09-08** (revised the same day, see *Revision*) ·
+> Affects Phase 1 and Phase 2 of the verticalization pipeline from v1.1 on.
 
 ## Decision, in one line
 
 Let the running job produce `legal-it v1.0` untouched as a reproducible
 baseline, and design the *next* pipeline so the teacher and the student never
-occupy VRAM at the same time — which removes the constraint that forced every
-architectural compromise made on 2026-09-08.
+occupy VRAM at the same time — measuring two ways of achieving that rather
+than picking one in advance.
+
+## Revision — why this document no longer prescribes offline caching
+
+The first version of this ADR chose offline top-K caching outright. That was
+premature: it committed to an architecture before measuring, which is the
+mistake that produced the ZeRO-3 configuration in the first place.
+
+The correction matters because of the specific model in play. Qwen3-30B-A3B
+activates **3.3 B of 30.5 B parameters per token**, so a teacher forward is
+cheap. Spending ~270 GB of disk, an I/O pipeline and a whole new class of
+correctness bugs to avoid a cheap forward may well be a bad trade. The two
+candidates are therefore both built and both measured.
 
 ## Part 1 — v1.0 is frozen
 
@@ -18,133 +30,214 @@ throughput improvement, not for a better memory layout, not for anything
 learned after it started.
 
 This is a deliberate stop. Between the first submission and this run, four
-jobs failed and the configuration was changed five times, each change
-justified by the failure before it. That is the right way to find a working
-configuration and the wrong way to obtain a *result*: a run that is adjusted
-while it executes cannot be compared with anything, including itself.
+jobs failed and the configuration changed five times, each change justified
+by the failure before it. That is the right way to find a working
+configuration and the wrong way to obtain a *result*: a run adjusted while it
+executes cannot be compared with anything, including itself.
 
 ### What must be captured, because it cannot be recovered afterwards
 
-* Git commit and the complete resolved YAML
-* Versions: PyTorch, Transformers, DeepSpeed, bitsandbytes, peft, CUDA driver
-* Checkpoints, and the loss curve
-* Peak VRAM per GPU — **allocated, not reserved** (see the note below)
-* GPU utilisation and throughput (seconds per optimizer step)
-* Node-hours consumed, and the failed attempts that preceded it
-* The corpus revision, including that it went through the round-6 PII sweep
+Commit and resolved YAML; versions of PyTorch, Transformers, DeepSpeed,
+bitsandbytes, peft and the CUDA driver; checkpoints and the loss curve; peak
+VRAM per GPU **as allocated, not reserved**; GPU utilisation and seconds per
+optimizer step; node-hours, including the failed attempts; and the corpus
+revision, including that it went through the round-6 PII sweep.
 
 `forge/scripts/leonardo/capture_provenance.sh` collects these into the
-checkpoint directory. Run it while the job is alive: the pre-flight block and
-the run banner are in the job log, and a log is not an artifact.
+checkpoint directory. Run it while the job is alive: a job log is not an
+artifact.
 
 > **Reserved is not allocated.** `nvidia-smi` reports what the caching
-> allocator has reserved from the driver, and with `expandable_segments` that
-> pool grows toward the card's capacity and is not returned. A run showing
-> 63,188 MiB of 64,946 MiB is not necessarily 1.7 GB from an OOM; it may have
-> gigabytes of free space inside its own pool. The number that means anything
-> is `torch.cuda.max_memory_allocated`, which the memprobe prints at exit.
-> Any headroom criterion stated in reserved terms measures the allocator, not
-> the model.
+> allocator has taken from the driver, and with `expandable_segments` that
+> pool grows toward the card's capacity and is never returned. A run showing
+> 63,188 MiB of 64,946 MiB is not necessarily 1.7 GB from an OOM; it may hold
+> gigabytes of free space inside its own pool. `torch.cuda.max_memory_allocated`
+> is the number that means something, and the memprobe prints it at exit. A
+> headroom criterion stated in reserved terms measures the allocator, not the
+> model.
 
-## Part 2 — the constraint we should have attacked
+## Part 2 — the constraint, and two ways to remove it
 
 Every problem of 2026-09-08 descends from one requirement: in online
 distillation the teacher and the student must be resident together. That is
-what makes 61 GB of frozen teacher a problem worth sharding, what made ZeRO-3
-look necessary, what made ZeRO-3's all-gather explode on a 128-expert MoE,
-and what ultimately forced the teacher to 8-bit so it would fit beside
-everything else.
+what made 61 GB of frozen teacher worth sharding, what made ZeRO-3 look
+necessary, what made its all-gather explode on a 128-expert MoE, and what
+finally forced the teacher to 8-bit so it would fit beside everything else.
 
-Quantizing the teacher was a way around the constraint. Removing the
-constraint is better, and it is not difficult.
+Quantizing was a way around the constraint. Both designs below remove it, and
+**neither is chosen before the pilot measures them.**
 
-### Offline top-K logit distillation
+### A — offline top-K logit cache
 
-**Phase 2A — teacher pass.** Load the teacher in BF16, spread across the four
-A100s, and run the corpus once. For every position write: the token id, the
-top-K token ids, their logits or probabilities, any normalisation metadata,
-and the sample/document id for traceability. No student is loaded. No
-gradients exist.
+Teacher BF16 across the four cards runs the corpus once and writes top-K
+logits to disk. The teacher is then unloaded and the student trains against
+the cache with the whole node to itself.
 
-**Phase 2B — student training.** Unload the teacher entirely. Train the
-student against the cached distributions with the same
-`α · KL + (1−α) · CE` objective. The teacher is not in VRAM at all.
+### B — online split node, 2+2
 
-What this buys, beyond fitting:
+Teacher BF16 with tensor parallelism across GPUs 0-1 (about 30.5 GB per card
+before activations); student training on GPUs 2-3. No persistent cache.
 
-* **The teacher returns to BF16.** Not as a concession — there is simply
-  nothing left to share memory with. The quantization gates added today stop
-  being load-bearing for Phase 2 and become a v1.0 property.
-* **The teacher pass is reusable.** It is computed once and consumed by every
-  subsequent student: a 4 B and a 7 B, a different LoRA rank, a repeated run
-  after a bug. Today, changing the student means re-running the teacher.
-* **Both halves suit a 24 h batch queue.** Each is separately resumable — the
-  teacher pass by corpus offset, the student by checkpoint — where an online
-  run must checkpoint two models in lockstep.
-* **Tensor and expert parallelism become optional.** With no student
-  competing for memory, a BF16 teacher fits comfortably across four cards
-  under a plain `device_map`. Native Qwen3-MoE expert parallelism is worth
-  measuring for the teacher pass, but the offline split means it is a
-  throughput question, not a feasibility one.
+### Which wins is a question about the teacher's stability, not only speed
 
-### The cost, stated up front
+The decision criterion that is easiest to overlook: **a logit cache is
+invalidated by any change to the teacher.** Re-run Phase 1 and 270 GB become
+waste. So:
 
-Storage. At K=64, each position needs 64 ids (int32) and 64 logits (fp16),
-or 384 bytes; across roughly 700 M tokens that is **~268 GB**. K=32 halves it
-to ~134 GB. The `$WORK` quota is 1 TB, so it fits — but this is the real price
-of the design and it belongs in the comparison of Part 4, not in a footnote.
+* **Offline pays when the teacher is fixed and the student varies** — several
+  student sizes, LoRA ranks, or repeated runs after a bug, all reading one
+  teacher pass.
+* **Online pays while the teacher is still moving**, which is where the
+  project is now.
 
-Worth measuring in the pilot: fp16 logits may be more precision than the KL
-objective can use, and storing normalised log-probabilities as int16 would
-halve the cache again.
+This is a choice per phase, not a permanent one, and the pilot should report
+node-hours for both under the assumption that the teacher is re-run once.
 
-### K is measured, not chosen
+## Part 3 — teacher inference for design A
 
-Pilot on one subset at **K=32** and **K=64**, and report:
+First backend to try: **vLLM** — Apache-2.0, so it clears the project's
+copyleft rule. Not as a replacement for the EULLM engine, but because this
+phase needs direct HF/BF16 loading, Qwen3-MoE tensor parallelism, batched
+teacher-forcing, and bulk extraction of per-position top-K.
 
-* probability mass retained by the top-K truncation
-* KL against the full distribution on that subset
-* resulting student quality
-* cache size on disk
-* teacher-pass and student-training throughput
+Behind an interface, to avoid a structural dependency:
 
-Pick K from those numbers. A truncation that discards meaningful mass makes
-the student fit a distribution the teacher never had, which is the same class
-of error the quantization gate exists to catch.
+```
+TeacherLogitProvider          # returns RAW LOGITS, not log-probabilities
+└── VllmTeacherProvider       # first implementation
+└── EullmTeacherProvider      # later, if the engine gains logit export
+```
 
-## Part 3 — tokenizer compatibility bounds the teacher choice
+Raw logits, not log-probabilities, or the temperature story in Part 4 breaks.
 
-Logit-level KD requires teacher and student to share a vocabulary; the KL is
-computed over vocabulary positions and two tokenizers make that meaningless.
-Qwen3-30B-A3B → Qwen3-4B/7B is therefore the natural path, and this is why
-the Qwen3.5/3.8 line was excluded earlier: vocab 248,320 against Qwen3's
-151,936.
+> **Verify this before building around it.** Teacher-forcing needs vLLM's
+> `prompt_logprobs`, which returns values for every *prompt* position — not
+> the `logprobs` of generation. It exists, but at large K over long sequences
+> it is memory-hungry and has a history of rough edges. The first thing the
+> pilot must establish is whether vLLM emits K=64 prompt-logprobs on
+> Qwen3-MoE at an acceptable cost. If it does not, the provider is built
+> around a different backend and no time is lost on an interface shaped by a
+> tool that cannot do the job.
 
-**Qwen3.8-27B must not replace the KL teacher in v1.x** until a genuine
-cross-tokenizer strategy exists. It can be evaluated separately in roles that
-operate on *text* rather than on logits, where the tokenizer difference is
-irrelevant:
+### Teacher topology benchmark
 
-* sequence-level KD teacher (SeqKD)
-* synthetic data generator
-* reasoning / instruction teacher
-* evaluator or judge
+On the same subset, compare **TP=4** (one teacher across four GPUs) against
+**2 × TP=2** (two independent replicas, half the corpus each), reporting
+tokens/s, documents/s, GPU utilisation, VRAM, wall time, node-hours and
+communication overhead. Do not assume 2×TP2 wins: MoE all-to-all traffic
+does not scale the way dense tensor-parallel traffic does.
 
-## Part 4 — the new pipeline must earn its place
+## Part 4 — cache format for design A
 
-Before a full run: a short end-to-end test showing no OOM, **at least 2–3 GB
-of headroom per GPU measured as allocated**, scaling across the four cards,
-teacher-pass throughput, logit cache size, student throughput, and quality
-equivalent to online distillation.
+Per position: sample/document id, sequence position, target token, top-K
+token ids (uint32), top-K **raw** logits (fp16/bf16), normalisation metadata,
+tokenizer fingerprint, and the teacher checkpoint/commit/config.
 
-And v1.0 is not discarded. It is the experimental baseline the replacement is
-measured against, and the replacement must win quantitatively on at least one
-of: quality, throughput, node-hours, VRAM, stability, or the ability to train
-a larger student. "Better designed" is not a result.
+Normalised probabilities alone are not enough. Softmax at temperature T over
+the *full* vocabulary cannot be recovered from the T=1 normaliser, so store
+the log-sum-exp for **T = 1, 2, 4** — three fp32 per position, about 8 GB
+over the corpus, against re-running the teacher to change a hyperparameter.
+
+Sharded, never one monolithic file.
+
+### Storage, with the arithmetic done
+
+At 700 M positions, ids as uint32 and logits as fp16:
+
+| K | bytes/position | corpus |
+|---:|---:|---:|
+| 16 | 96 | ~67 GB |
+| 32 | 192 | ~134 GB |
+| 64 | 384 | **~268 GB** |
+| 128 | 768 | **~537 GB** |
+
+The `$WORK` quota is 1 TB and also holds the HF cache (~69 GB), the corpus
+and every checkpoint. **K=128 is therefore a pilot measurement on a subset,
+not a full-corpus option** unless compression changes the picture.
+
+And compression is the lever this plan is missing. Top-K logits are highly
+compressible: store the top-1 absolutely and the remaining K−1 as deltas in
+int8, and logit storage falls by 2–4×. That puts K=64 under 150 GB and brings
+K=128 back into range. Measure it in the pilot rather than assuming fp16.
+
+## Part 5 — K is measured, not chosen
+
+Pilot on one subset at **K = 16, 32, 64, 128**, reporting for each: retained
+probability mass, error against the full distribution, bytes per position,
+throughput, and a short student-training quality check. Then pick one K for
+the whole corpus.
+
+A truncation that discards meaningful mass makes the student fit a
+distribution the teacher never had — the same class of error the quantization
+gate exists to catch.
+
+## Part 6 — cache correctness tests are mandatory
+
+This is the section most likely to save the project, because the failure it
+guards against is silent. An off-by-one between `logits[t]` and
+`target[t+1]` does not raise the loss in any obvious way; it poisons 270 GB
+of cache and is discovered after the node-hours are spent.
+
+Automated tests for: the `logits[t] → target[t+1]` alignment; padding;
+packing boundaries; BOS/EOS handling; sample boundaries; cached top-K equal
+to live top-K within tolerance; the probability mass discarded; and tokenizer
+compatibility.
+
+**The tokenizer check must not stop at vocabulary size.** Two tokenizers can
+agree on 151,936 and differ in merges or special-token ids. Compare a
+fingerprint over the vocabulary mapping and the special-token ids.
+
+## Part 7 — resume
+
+The teacher pass is fully resumable. Every shard is written atomically and
+recorded in a manifest with: document range, teacher commit, adapter or
+checkpoint, tokenizer hash, K, dtype, temperature metadata, and completion
+status. A job killed at the walltime cap restarts from the first incomplete
+shard.
+
+## Part 8 — the student, and where sharding *is* the right tool
+
+* 4 B LoRA → DDP
+* 7 B LoRA → DDP if memory allows
+* full fine-tune of 4 B or 7 B → **do not assume DDP suffices.** A 4 B full
+  fine-tune needs roughly 56 GB for weights, fp32 master copy and Adam state
+  before activations. FSDP or ZeRO-2/3 is the correct tool here.
+
+Worth stating plainly, because today's failure invites the wrong conclusion:
+the lesson is not that ZeRO is bad. It is that **ZeRO is for trainable
+parameters.** On a frozen base it bought nothing and cost everything; on a
+fully fine-tuned student it is exactly right.
+
+## Part 9 — EULLM's place
+
+EULLM remains the runtime for the model Forge produces. Do **not** convert the
+teacher to GGUF merely to use EULLM in Phase 2A — the pilot uses the HF/BF16
+checkpoint directly.
+
+Batched teacher-forcing with per-token top-K/raw-logit export and multi-GPU
+teacher inference is a plausible EULLM feature, to be decided *after*
+benchmarking against vLLM, not before.
+
+## Part 10 — Qwen3.8
+
+Not usable for token-level KL toward a Qwen3 student: the tokenizers are
+incompatible (248,320 against 151,936), and KL over vocabulary positions is
+meaningless across them. Evaluate it separately in roles that operate on
+text, where the difference does not matter: sequence-level KD teacher,
+synthetic-data generator, reasoning/instruction teacher, evaluator or judge.
+
+## Part 11 — success criteria
+
+The new pipeline replaces v1.0 only on a measured improvement in at least one
+of quality, node-hours, throughput, VRAM headroom, stability, or the ability
+to train a larger student — **without substantial regression in the others**.
+
+v1.0 is not discarded. It is the baseline the replacement is measured
+against, and "better designed" is not a result.
 
 ## What this does not change
 
 The corpus, the pseudonymisation pipeline and its gate, the model naming, the
-Phase 3 GGUF path, and the licence constraints all stand. This ADR is about
+Phase 3 GGUF path and the licence constraints all stand. This ADR is about
 where the teacher's parameters live while the student learns, and nothing
 else.

--- a/docs/legal-it-4b-strategy.md
+++ b/docs/legal-it-4b-strategy.md
@@ -301,11 +301,13 @@ When the pipeline finishes we publish:
 The run producing v1.0 uses an 8-bit teacher under plain DDP, because online
 distillation needs teacher and student resident together and a bf16 teacher
 does not fit beside one. [`adr-001-offline-distillation.md`](adr-001-offline-distillation.md)
-freezes v1.0 as the baseline and moves Phase 2 to cached top-K logits: the
-teacher runs the corpus once in bf16, writes its distributions to disk, and
-is unloaded before the student trains. That removes the co-residency
-constraint rather than working around it, and with it the reason to quantize
-the teacher at all.
+freezes v1.0 as the baseline and removes the co-residency constraint rather
+than working around it — which also removes the reason to quantize the
+teacher at all. Two designs are built and measured rather than one being
+chosen up front: an offline top-K logit cache, and an online split of the
+node with the teacher on two GPUs and the student on the other two. Which
+wins depends on more than throughput, since a logit cache is invalidated by
+any change to the teacher.
 
 v1.0 is not superseded by that plan — it is what the plan has to beat, on
 quality, throughput, node-hours, VRAM, stability, or student size.


### PR DESCRIPTION
…line

The first draft picked offline top-K caching outright, which was the same mistake that produced the ZeRO-3 configuration: committing to an architecture before measuring it. Both designs are now built and compared — an offline logit cache, and an online split of the node with the teacher tensor-parallel on two GPUs and the student on the other two.

The correction matters for this model specifically. Qwen3-30B-A3B activates 3.3 B of 30.5 B parameters per token, so a teacher forward is cheap; spending ~270 GB of disk, an I/O pipeline and a new class of correctness bugs to avoid a cheap forward may simply be a bad trade.

Four things this revision adds beyond restructuring.

The decision criterion nobody had named: a logit cache is invalidated by any change to the teacher, so offline pays when the teacher is fixed and the student varies, online pays while the teacher is still moving — which is where the project is now. That makes it a choice per phase rather than a permanent one, and the pilot should cost both assuming one teacher re-run.

Storage arithmetic instead of an estimate: at 700 M positions K=64 is ~268 GB and K=128 is ~537 GB against a 1 TB quota that also holds the HF cache, the corpus and every checkpoint. K=128 is a pilot measurement on a subset, not a full-corpus option — unless compression changes it, and compression is the lever the plan was missing: storing the top-1 logit absolutely and the rest as int8 deltas cuts logit storage 2-4x.

A feasibility check to run before designing around vLLM: teacher-forcing needs prompt_logprobs, not generation logprobs, and at large K over long sequences that path is memory-hungry and historically rough. Establish that it works on Qwen3-MoE before shaping an interface around a tool that may not do the job.

And the conclusion today's failure invites but does not support: the lesson is not that ZeRO is bad, it is that ZeRO is for trainable parameters. On the frozen base it bought nothing and cost everything; on a fully fine-tuned 4 B student — roughly 56 GB of weights, fp32 master and Adam state — it is exactly the right tool.