### PR TITLE
ci(forge): ignore CVE-2026-69112 in accelerate, with no fix to upgrad…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,9 +267,34 @@ jobs:
         # matters here — a vulnerability in a real dependency still exits
         # non-zero — and only means an unauditable package is reported instead
         # of fatal.
+        #
+        # IGNORED, 2026-09-08 — CVE-2026-69112 in accelerate.
+        # Path traversal in `load_checkpoint_in_model` /
+        # `load_checkpoint_and_dispatch`: `weight_map` entries in a sharded
+        # checkpoint index are not sanitised, so a crafted
+        # `model.safetensors.index.json` can read arbitrary files with `../`
+        # or point a shard at a named pipe and hang the process.
+        #
+        # Ignored because there is nothing to upgrade to: 1.14.0 is the latest
+        # release on PyPI and the advisory says "through 1.14.0", so every
+        # published version is affected. Downgrading moves nothing.
+        #
+        # Our own exposure is low but not zero, and the distinction matters:
+        # the Forge pipeline only loads checkpoints it prefetches itself from
+        # Qwen's official repositories, and the Engine does not use accelerate
+        # at all. But `eullm forge --base-model` takes an arbitrary Hub id, so
+        # a user pointing Forge at an untrusted repository IS on the vulnerable
+        # path. That is a documentation and validation question, tracked in
+        # docs/backlog-fix-e-hardening.md, not something this ignore resolves.
+        #
+        # REMOVE THIS as soon as accelerate publishes a fixed release: bump the
+        # floor in forge/pyproject.toml and delete the flag. Check with
+        # `pip index versions accelerate` or the PyPI JSON API — a green audit
+        # here will NOT tell you a fix has landed, because this flag suppresses
+        # exactly the finding that would.
         run: |
           pip install pip-audit==2.10.1
-          pip-audit --desc --skip-editable
+          pip-audit --desc --skip-editable --ignore-vuln CVE-2026-69112
 
   # ── Windows installer pre-flight (FAST, <2 min, runs on every push) ──
   # Installer preflight removed in v0.5.7 alongside the installer build

--- a/docs/backlog-fix-e-hardening.md
+++ b/docs/backlog-fix-e-hardening.md
@@ -2556,6 +2556,31 @@ diligenza manuale.
   regola di `engine/CLAUDE.md`, una build pulita non basta. Se possibile,
   caricare anche un vero GGUF Qwen3.8-Flash-Next per confermare che
   l'architettura funzioni davvero end-to-end e non solo a compile-time.
+- [ ] **H3-S · `--base-model` di Forge accetta un repo Hub arbitrario** *(P2)*
+  *Aperta 2026-09-08 a margine di CVE-2026-69112 in `accelerate` (path traversal
+  in `load_checkpoint_in_model` / `load_checkpoint_and_dispatch`: le voci
+  `weight_map` di un index shardato non sono sanificate, quindi un
+  `model.safetensors.index.json` costruito ad arte legge file arbitrari con
+  `../` o punta uno shard a una named pipe e blocca il processo).*
+
+  La CVE è ignorata in `ci.yml` perché non esiste una versione corretta —
+  1.14.0 è l'ultima pubblicata e l'advisory dice "through 1.14.0". Quell'ignore
+  però risolve la CI, non l'esposizione, e vale la pena separare i due casi:
+
+  * La **pipeline nostra** carica solo checkpoint che preleva da sé dai
+    repository ufficiali Qwen, e l'Engine non usa `accelerate`. Rischio basso.
+  * `eullm forge --base-model <hub-id>` accetta **qualunque** id dell'Hub, e un
+    utente che lo punta su un repository non fidato è esattamente sul percorso
+    vulnerabile. Rischio reale, e non nostro da correre ma da segnalare.
+
+  Da fare, indipendentemente da quando arriva la fix upstream: dire nella
+  documentazione di Forge che `--base-model` esegue codice di caricamento su
+  dati del repository indicato, e valutare una convalida dell'index prima di
+  passarlo ad `accelerate` (path relativi contenuti nella directory del
+  checkpoint, nessun `..`, nessun file non regolare). L'ignore in `ci.yml` va
+  rimosso appena `accelerate` pubblica una release corretta: un audit verde
+  non lo segnalerà, perché è proprio quel finding a essere soppresso.
+
 ---
 
 ## Rimandi — voci già coperte dalle roadmap esistenti


### PR DESCRIPTION
…e to

The Forge job has been red on main since 20:02 today, and nothing in this repository caused it: pip-audit picked up an advisory published between two consecutive runs. CVE-2026-69112 is a path traversal in accelerate's load_checkpoint_in_model / load_checkpoint_and_dispatch — weight_map entries in a sharded checkpoint index are not sanitised, so a crafted model.safetensors.index.json reads arbitrary files through ../ or points a shard at a named pipe and hangs the process.

There is nothing to upgrade to. 1.14.0 is the latest release on PyPI and the advisory reads "through 1.14.0", so every published version is affected and downgrading moves nothing. The workflow's own comment prescribes exactly this case: add --ignore-vuln with the reason and the date. The flag carries both, plus the removal condition and a warning that a green audit will not announce the fix, since this flag suppresses the very finding that would.

The ignore fixes the CI, not the exposure, and the two are worth separating. Our pipeline loads only checkpoints it prefetches from Qwen's official repositories and the Engine does not use accelerate at all — but `eullm forge --base-model` takes an arbitrary Hub id, so a user pointing Forge at an untrusted repository is on the vulnerable path. That is a real question about a user-facing flag rather than a CI one, so it is filed as backlog H3-S with the concrete remedy: say so in the Forge documentation, and validate the index before handing it to accelerate.