### PR TITLE
fix(forge): drop the line anchor that hid the heartbeat from its own …

### DIFF
--- a/forge/scripts/leonardo/capture_provenance.sh
+++ b/forge/scripts/leonardo/capture_provenance.sh
@@ -98,7 +98,10 @@ if [ -n "$LOG" ]; then
         grep -o "{'eval_loss'[^}]*}" "$LOG" || echo "(no eval yet)"
         echo
         echo "## Heartbeat, every 10th sample"
-        grep '^\[hb\]' "$LOG" | awk 'NR % 10 == 1'
+        # Unanchored: interleaved writes from the background loop and the
+        # training process put many [hb] lines mid-line, and an anchor loses
+        # them.
+        grep '\[hb\]' "$LOG" | awk 'NR % 10 == 1'
     } > "$DEST/measurements.txt"
 fi
 

--- a/forge/scripts/leonardo/watch_job.sh
+++ b/forge/scripts/leonardo/watch_job.sh
@@ -26,7 +26,12 @@ cd "$RUN_DIR" || { echo "no such directory: $RUN_DIR" >&2; exit 2; }
 # Lines worth seeing while the job runs. Deliberately not `error`: the corpus
 # is Italian legal text and every other page contains the word "errore",
 # which matched thousands of times the first time this filter was written.
-KEEP='^\[hb\]|pre-flight|trainable params|'"'"'loss'"'"':|eval_loss|Traceback|OutOfMemoryError|RuntimeError|ValueError|AssertionError|out of memory|Killed'
+# Unanchored on purpose. The heartbeat writes from a background subshell
+# while the training process writes its own lines, and with no synchronisation
+# between the two a [hb] line regularly lands mid-line. A '^\[hb\]' anchor
+# therefore drops most of them: measured on a 10h run, the log held 645
+# heartbeat lines and the anchored pattern showed none.
+KEEP='\[hb\]|pre-flight|trainable params|'"'"'loss'"'"':|eval_loss|Traceback|OutOfMemoryError|RuntimeError|ValueError|AssertionError|out of memory|Killed'
 
 # Patterns that identify the actual cause in the post-mortem.
 CAUSE='Traceback|OutOfMemoryError|RuntimeError|ValueError|KeyError|TypeError|AssertionError|out of memory|Killed|CUDA error'


### PR DESCRIPTION
…monitor

watch_job.sh filtered the log with '^\[hb\]' and capture_provenance.sh sampled it the same way, so both showed nothing while the heartbeat was working perfectly. Measured on a 10 h run: the log held 645 heartbeat lines, one a minute with no gaps, and the anchored pattern matched none of them.

The heartbeat writes from a background subshell while the training process writes its own output, with no synchronisation between the two, so a [hb] line regularly lands in the middle of another line. An anchor on start-of- line is therefore wrong by construction here — not occasionally unlucky.

Unanchored in both. The irony is worth keeping in the comment: the tooling built to answer "is this job alive?" was itself reporting silence from a component that had not missed a beat in ten hours.