### PR TITLE
feat(leonardo): measure where the allocation's calendar goes, and who…

### DIFF
--- a/docs/leonardo-allocation-plan.md
+++ b/docs/leonardo-allocation-plan.md
@@ -50,6 +50,48 @@ of thing that is remembered at the next call.
 Roughly a fifth. The rest needs work that is worth doing, not work invented
 to burn hours.
 
+## Measured, 2026-09-11
+
+Not projections. From `queue_stats.py` and `budget.sh`, nine days in.
+
+| | |
+|---|---:|
+| node-hours consumed | 60.9 |
+| calendar since 02/09 | 226.3 h |
+| — at least one job running | 60.9 h (26.9 %) |
+| — idle, cluster full | 7.2 h |
+| — idle, queue empty | 158.2 h |
+| mean nodes while busy | 1.00 |
+
+**Leonardo is not why the allocation is under-used.** Seven hours lost to a
+full queue against a hundred and fifty-eight with nothing submitted, almost
+all of it between 02/09 and 08/09 while the pipeline was still being debugged.
+That is an uncomfortable line to write in the Final Report and it is the true
+one, and it is also the only half we can still change.
+
+The single largest resource wait so far is dated and worth quoting: the
+Phase-1 chain stalled **from 2026-09-10 21:07 to 2026-09-11 04:13**, 7h06m,
+because no node was free when the second link timed out. The handover before
+it took three minutes. A queued chain does not guarantee continuity.
+
+What that implies for the rest of the allocation: to average one busy node,
+there have to be stretches at two or three, because gaps are certain. The
+QoS permits 256 nodes and 1,000 submitted jobs per user, and
+`boost_usr_prod` has `OverSubscribe=NO`, so parallel jobs never share
+hardware. Nothing in the scheduler limits us — only having work ready.
+
+### In flight
+
+- **Phase 1** — chain of four, `56803262 → 56818854 → 56818982 → 56912622`.
+  Two links have timed out at 24 h as designed; epoch 0.6164 at the last
+  reading, loss 1.652 → 1.269. Expected to finish 12-13/09 at ~85-95 node-h.
+- **v1.1 pilot** — running beside it from a second checkout, `$WORK/eullm-v11`,
+  so the frozen chain keeps its own tree. P6 (int8 teacher against bf16) is
+  queued; P1, P2 and P3 follow. See
+  [`paper/v11-pilot-preregistration.md`](paper/v11-pilot-preregistration.md).
+- **Accounting** — `sbatch_queue_stats.slurm` re-submits itself daily until
+  02/11 and freezes each snapshot to JSON, because `sacct` forgets.
+
 ## Backlog — ordered by what it gives the project
 
 Keep this queue fed. Each item is a candidate the moment a node frees up.

--- a/docs/leonardo-runbook.md
+++ b/docs/leonardo-runbook.md
@@ -112,15 +112,160 @@ Move artifacts off Leonardo as they are produced — the allocation (and
 the storage) ends on 02/11/2026, and CINECA recommends not leaving data
 transfers to the last days.
 
-## Monitoring cheat-sheet
+## Monitoring
+
+### Is anything running, and how far along?
 
 ```bash
-squeue --me                      # queue state of your chain
-saldo -b                         # node-hour consumption vs monthly quota
-tail -f "$EULLM_RUN_DIR"/logs/*.out
-scancel <jobid>                  # kill one job of a chain
-scancel --me                     # kill everything (chain deps die with it)
+squeue --me -o '%.10i %.18j %.9T %.10M %.10L %R'
 ```
+
+`%M` is elapsed, `%L` is walltime left, `%R` is the node — or, for a pending
+job, the reason. `(Dependency)` is a chain link waiting its turn, `(Priority)`
+is the cluster being full, `(BeginTime)` is a job deliberately scheduled for
+later.
+
+For the training itself, read the log rather than the queue:
+
+```bash
+cd "$EULLM_RUN_DIR"
+LOG="$(ls -t logs/*.out | head -1)"
+tail -50000 "$LOG" | grep -v MatMul8bitLt | tail -10
+```
+
+**The `tail | grep -v` is not decoration.** With an 8-bit base, bitsandbytes
+prints `MatMul8bitLt: inputs will be cast…` once per quantized matmul — 48
+layers × 4 projections × every step. The Phase-1 log reached **2.1 GB in 24
+hours**, and a plain `grep` over it sits there long enough to look hung. Two
+sessions were lost to pressing Ctrl-C on a `grep` that was working fine.
+`tail` reads only the end of the file and returns instantly at any size.
+
+The line worth finding looks like:
+
+```
+{'loss': '1.269', 'grad_norm': '0.5634', 'learning_rate': '3.422e-06', 'epoch': '0.6164'}
+```
+
+`epoch` is the honest progress indicator. **After a chained restart it is also
+the proof that the resume worked**: a job that silently began from scratch
+shows `epoch` near zero, and there is no other signal that 24 hours just
+evaporated.
+
+### Follow a job to its end
+
+```bash
+bash "$EULLM_REPO/forge/scripts/leonardo/watch_job.sh" <jobid>
+```
+
+Waits for the log to appear if the job is still queued, filters while it runs,
+stops when the job leaves the queue, and prints the `sacct` verdict plus the
+lines that caused it. `tail -f` does none of that: when a job dies the tail
+just sits there, which is how one failure went unnoticed for twenty minutes.
+
+### Budget
+
+```bash
+bash "$EULLM_REPO/forge/scripts/leonardo/budget.sh"
+bash "$EULLM_REPO/forge/scripts/leonardo/budget.sh" --reserve 200
+```
+
+**Do not decide anything on `saldo -b` alone.** It counts finished *and
+billed* jobs, and the lag is long: on 2026-09-11 it reported 907 core-hours
+against 1,675 actually spent — a job that had ended ten hours earlier was
+neither still running nor yet billed. `budget.sh` sums `sacct` over the whole
+allocation instead and shows `saldo` underneath as a cross-check.
+
+### Where the calendar went
+
+```bash
+python3 "$EULLM_REPO/forge/scripts/leonardo/queue_stats.py" 2026-09-02 \
+    --json "$WORK/eullm_runs/qstats/queue_stats_$(date +%Y%m%d_%H%M).json"
+```
+
+Node-hours are not this allocation's binding constraint; **calendar is** (see
+[`leonardo-allocation-plan.md`](leonardo-allocation-plan.md)). One node kept
+busy continuously for the whole two months consumes essentially the entire
+grant, so every idle hour expires unrecoverably.
+
+`queue_stats.py` splits the idle time by cause, because the two halves mean
+opposite things in the Final Report:
+
+| | |
+|---|---|
+| **idle, cluster full** | a job was queued and would not start. About the machine. |
+| **idle, queue empty** | nothing was submitted, because nothing was ready. Ours. |
+
+It also separates **queue wait** from **dependency wait**, which is where the
+obvious arithmetic goes wrong: `Start - Submit` on a chained job counts the
+time it spent waiting for its own predecessor. On the Phase-1 chain that gave
+77 hours against 7 real ones. The clock here starts at the predecessor's end.
+
+Every wait comes out dated, from and to, so the report can quote an interval
+instead of a total — "the chain stalled from 2026-09-10 21:07 to 2026-09-11
+04:13" is evidence; "7h06m of queue wait" is not.
+
+`sacct` has a retention window, so these intervals stop being recoverable a
+few weeks after the jobs run. That is what `--json` is for.
+
+### Keeping the record without a scheduler
+
+Leonardo permits no user `crontab`, and `scrontab` is disabled cluster-wide.
+The substitute is a job that re-submits itself:
+
+```bash
+sbatch "$EULLM_REPO/forge/scripts/leonardo/sbatch_queue_stats.slurm"
+squeue --me -n eullm-queue-stats    # exactly one PENDING row, always
+```
+
+Three seconds of one core on the serial partition, once a day, until the
+allocation ends. Its one failure mode is a re-submission that does not happen:
+nothing announces it, the job simply stops existing. If that `squeue` line
+comes back empty, submit it again.
+
+Worth doing **in addition**, at the end of any real sbatch script:
+
+```bash
+python3 "$EULLM_REPO/forge/scripts/leonardo/queue_stats.py" 2026-09-02 \
+    --json "$EULLM_RUN_DIR/qstats/queue_stats_$(date +%Y%m%d_%H%M).json" || true
+```
+
+The daily job gives regular cadence; this catches the handover between one
+chained job and the next, which is precisely when the gaps open. The `|| true`
+matters — an instrument must never fail the job it is measuring.
+
+### Stopping things
+
+```bash
+scancel <jobid>                  # one job of a chain
+scancel --me                     # everything (chain deps die with it)
+```
+
+## Running the pilot beside a frozen run
+
+Queued jobs read their scripts from `$EULLM_REPO` **when they start**, not
+when they were submitted. So while a chain is in flight, a `git pull` silently
+changes what the not-yet-started links will execute.
+
+That does not mean waiting. Clone a second checkout:
+
+```bash
+git clone https://github.com/eullm/eullm.git "$WORK/eullm-v11"
+python -m venv "$WORK/v11_venv"
+```
+
+`$WORK/eullm` stays pinned for the chain; `$WORK/eullm-v11` tracks `main` and
+the new work runs from there with `EULLM_REPO` and `EULLM_RUN_DIR` pointed at
+it. 300 MB, and the freeze stops being a blocker.
+
+**The separate venv is the part that actually matters.** Installing vLLM into
+the venv a running chain uses would change its PyTorch, and the next link
+would pick that up on restart — the most efficient way to lose four days of
+compute. Read-only use of the training venv is fine; installing into it is not.
+
+Jobs cannot collide on hardware: `boost_usr_prod` has `OverSubscribe=NO`, so
+SLURM never places two jobs on the same node. The QoS allows 256 nodes and
+1,000 submitted jobs per user, so parallelism is limited by budget and by
+having work worth running, not by the scheduler.
 
 ## Troubleshooting
 
@@ -138,3 +283,23 @@ scancel --me                     # kill everything (chain deps die with it)
   previous job already finished the phase; the chain drains cheaply.
 - **Low priority / long queue waits** — monthly quota exceeded (budget
   linearization). Check `saldo -b`; jobs still run, just deprioritized.
+- **`nano`, `watch`, `htop` die with a segmentation fault** — not a broken
+  binary. The `python/3.11.7` module loads its own `ncurses/6.5` and puts it
+  first on `LD_LIBRARY_PATH`; the system binaries were linked against the
+  OS copy and crash on the mismatch. Run them with that variable stripped:
+  ```bash
+  alias nano='env -u LD_LIBRARY_PATH nano'
+  alias watch='env -u LD_LIBRARY_PATH watch'
+  ```
+  This cost half an hour twice before the two crashes were recognised as the
+  same one. To edit a file without an editor at all, `cat > file <<'EOF'`
+  with the marker quoted writes it verbatim, `$VARIABLES` included.
+- **A `grep` over a training log appears to hang** — it is not hung, the file
+  is gigabytes of repeated bitsandbytes warnings. Use
+  `tail -50000 "$LOG" | grep -v MatMul8bitLt` instead; see Monitoring above.
+- **A chain link resumed but you cannot tell from what** — check `epoch` in
+  the last training line, not the loss. A fresh start shows it near zero while
+  the loss can look plausible either way.
+- **`crontab` refused, `scrontab: fatal: scrontab is disabled`** — expected,
+  neither is available. Use the self-resubmitting job pattern in
+  `sbatch_queue_stats.slurm`.

--- a/forge/scripts/leonardo/budget.sh
+++ b/forge/scripts/leonardo/budget.sh
@@ -10,15 +10,20 @@
 # Three numbers, and the third is the one that answers "how much can I still
 # promise to something else":
 #
-#   settled    what saldo reports — completed jobs only
-#   in flight  running jobs, elapsed x nodes x 32 core-hours per node-hour
-#   committed  settled + in flight + the walltime every queued and running job
-#              could still consume. The worst case, known now rather than
-#              discovered at the end.
+#   consumed        every job since the allocation opened, finished and
+#                   running alike, elapsed x nodes x 32 core-hours per node-hour
+#   still bookable  the walltime every queued and running job could yet use
+#   committed       the two together. The worst case, known now rather than
+#                   discovered at the end.
 #
 # Usage:
 #   bash forge/scripts/leonardo/budget.sh
 #   bash forge/scripts/leonardo/budget.sh --reserve 200   # node-hours to keep
+#
+# Calendar, rather than node-hours, is the binding constraint on this
+# allocation — see docs/leonardo-allocation-plan.md. `queue_stats.py` in this
+# directory measures that side: where the calendar went and whose fault each
+# idle stretch was.
 #
 # CINECA bills a whole node: 1 node-hour = 32 core-hours on Booster, whatever
 # the job does with the GPUs.
@@ -26,31 +31,43 @@
 set -uo pipefail
 
 CORES_PER_NODE="${CORES_PER_NODE:-32}"
+PARTITION="${PARTITION:-boost_usr_prod}"
 RESERVE_NODE_H=0
 if [ "${1:-}" = "--reserve" ]; then
     RESERVE_NODE_H="${2:?--reserve needs a number of node-hours}"
 fi
 
-# ── settled, from saldo ──────────────────────────────────────────────────
+# ── the allocation's own numbers, from saldo ─────────────────────────────
 # Columns on the data row: 1 account, 2 start, 3 end, 4 total, 5 localCluster,
 # 6 totConsumed, 7 pct, 8 monthTotal, 9 monthConsumed. Guarded by NF so a
 # change in saldo's output degrades to a clear message instead of nonsense.
-read -r TOTAL SETTLED MONTH_TOTAL MONTH_USED <<<"$(
+read -r TOTAL ALLOC_START SETTLED MONTH_TOTAL MONTH_USED <<<"$(
     saldo -b 2>/dev/null |
-    awk 'NF >= 9 && $4 ~ /^[0-9]+$/ && $2 ~ /^[0-9]{8}$/ {print $4, $6, $8, $9; exit}'
+    awk 'NF >= 9 && $4 ~ /^[0-9]+$/ && $2 ~ /^[0-9]{8}$/ {print $4, $2, $6, $8, $9; exit}'
 )"
 if [ -z "${TOTAL:-}" ]; then
     echo "[err] could not parse 'saldo -b' — run it by hand and check the columns" >&2
     exit 2
 fi
+# saldo prints the allocation start as YYYYMMDD; sacct wants YYYY-MM-DD.
+SINCE="${ALLOC_START:0:4}-${ALLOC_START:4:2}-${ALLOC_START:6:2}"
 
-# ── in flight and committed, from sacct/squeue ───────────────────────────
+# ── consumed, from sacct ─────────────────────────────────────────────────
+# NOT from saldo. On 2026-09-11 saldo's totConsumed read 907 core-hours while
+# the jobs since the allocation opened added up to 1,675: a job that ENDED
+# hours earlier is neither still running nor yet billed, and falls through the
+# gap between the two columns. Summing sacct over the whole allocation counts
+# finished and running work alike, and needs no reconciliation.
+#
 # ElapsedRaw is seconds, which avoids parsing SLURM's D-HH:MM:SS by hand.
-IN_FLIGHT_CH="$(
-    sacct -X -n -s RUNNING --format=ElapsedRaw,NNodes 2>/dev/null |
+# Restricted to one partition because billing is per-partition: a one-core
+# job on the serial queue reports NNodes=1 and would otherwise be charged a
+# whole 32-core Booster node.
+CONSUMED_CH="$(
+    sacct -X -n -S "$SINCE" -r "$PARTITION" --format=ElapsedRaw,NNodes 2>/dev/null |
     awk -v c="$CORES_PER_NODE" '{s += $1 * $2 * c} END {printf "%.0f", s/3600}'
 )"
-IN_FLIGHT_CH="${IN_FLIGHT_CH:-0}"
+CONSUMED_CH="${CONSUMED_CH:-0}"
 
 # %L is the remaining time limit for running jobs and the full limit for
 # pending ones — i.e. exactly what each job may still burn.
@@ -69,7 +86,7 @@ REMAINING_CH="$(
 )"
 REMAINING_CH="${REMAINING_CH:-0}"
 
-COMMITTED_CH=$(( SETTLED + IN_FLIGHT_CH + REMAINING_CH ))
+COMMITTED_CH=$(( CONSUMED_CH + REMAINING_CH ))
 FREE_CH=$(( TOTAL - COMMITTED_CH ))
 RESERVE_CH=$(( RESERVE_NODE_H * CORES_PER_NODE ))
 
@@ -78,10 +95,8 @@ pct()   { awk -v v="$1" -v t="$TOTAL" 'BEGIN {printf "%.1f", (t ? 100*v/t : 0)}'
 
 printf '\n  allocation      %8s core-h  = %8s node-h\n' "$TOTAL" "$(nodeh "$TOTAL")"
 printf '  ─────────────────────────────────────────────────────\n'
-printf '  settled         %8s core-h  = %8s node-h   %5s%%   (saldo: finished jobs only)\n' \
-    "$SETTLED" "$(nodeh "$SETTLED")" "$(pct "$SETTLED")"
-printf '  in flight       %8s core-h  = %8s node-h   %5s%%   (running, not yet billed)\n' \
-    "$IN_FLIGHT_CH" "$(nodeh "$IN_FLIGHT_CH")" "$(pct "$IN_FLIGHT_CH")"
+printf '  consumed        %8s core-h  = %8s node-h   %5s%%   (sacct, %s onward, finished + running)\n' \
+    "$CONSUMED_CH" "$(nodeh "$CONSUMED_CH")" "$(pct "$CONSUMED_CH")" "$SINCE"
 printf '  still bookable  %8s core-h  = %8s node-h   %5s%%   (walltime queued+running may use)\n' \
     "$REMAINING_CH" "$(nodeh "$REMAINING_CH")" "$(pct "$REMAINING_CH")"
 printf '  ─────────────────────────────────────────────────────\n'
@@ -90,6 +105,7 @@ printf '  COMMITTED       %8s core-h  = %8s node-h   %5s%%\n' \
 printf '  free to promise %8s core-h  = %8s node-h   %5s%%\n' \
     "$FREE_CH" "$(nodeh "$FREE_CH")" "$(pct "$FREE_CH")"
 printf '\n  month           %8s core-h quota, %s used\n' "$MONTH_TOTAL" "$MONTH_USED"
+printf '  saldo settled   %8s core-h              (lags: cross-check only)\n' "$SETTLED"
 
 if [ "$RESERVE_CH" -gt 0 ]; then
     printf '\n'

--- a/forge/scripts/leonardo/queue_stats.py
+++ b/forge/scripts/leonardo/queue_stats.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Where the allocation's calendar went, and whose fault each gap was.
+
+`saldo` and `budget.sh` answer "how many node-hours did we spend". The
+EuroHPC Final Report asks something harder: given an allocation sized for two
+months of continuous use, **why did you not spend more of it**. That question
+has two answers with opposite implications, and reporting them as one number
+hides the only part we can act on:
+
+  * **cluster full** — a job was submitted and sat in the queue. Evidence
+    about the machine, cited without apology.
+  * **queue empty** — nothing was submitted, because nothing was ready. Ours.
+
+Both are measured here, dated, so the report can quote an interval rather
+than a total. "7h06m of queue wait" is not citable; "the chain stalled from
+2026-09-10 21:07 to 2026-09-11 04:13" is.
+
+Three traps, all of them met on this allocation:
+
+1. **`Start - Submit` is not queue wait.** For a job submitted with
+   `--dependency`, most of it is time spent waiting for the predecessor,
+   which is by design. On the Phase-1 chain that arithmetic reported 77 hours
+   against 7 real ones. Here the clock starts when the predecessor ends.
+
+2. **With parallel jobs, summed durations are not elapsed calendar.** Two
+   nodes for an hour is one hour of calendar, not two, so the busy intervals
+   are merged before being measured.
+
+3. **`sacct` has a retention window.** These intervals stop being
+   recoverable some weeks after the jobs run, which is why `--json` exists:
+   it freezes them to disk while they are still queryable.
+
+    python3 queue_stats.py [alloc-start YYYY-MM-DD] [--json report.json]
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime
+
+FMT = "%Y-%m-%dT%H:%M:%S"
+STAMP = "%Y-%m-%d %H:%M"
+FIELDS = "JobID,JobName,State,Submit,Start,End,ElapsedRaw,NNodes"
+
+
+def hours(seconds: float) -> str:
+    sign = "-" if seconds < 0 else ""
+    h, m = divmod(int(abs(seconds)) // 60, 60)
+    return f"{sign}{h}h{m:02d}m"
+
+
+def parse(raw: str, now: datetime) -> list[dict]:
+    """Rows of `sacct -P` into jobs, skipping anything that never started."""
+    jobs: list[dict] = []
+    for line in raw.splitlines():
+        f = line.split("|")
+        if len(f) < 8:
+            continue
+        jid, name, state, submit, start, end, elapsed, nodes = f[:8]
+        if start in ("Unknown", "None", ""):
+            continue            # still queued: there is no wait to close yet
+        try:
+            t_submit = datetime.strptime(submit, FMT)
+            t_start = datetime.strptime(start, FMT)
+        except ValueError:
+            continue
+        # A RUNNING job has no End. It is occupying the machine right now, so
+        # it counts as busy up to this instant.
+        try:
+            t_end = datetime.strptime(end, FMT)
+        except ValueError:
+            t_end = now
+        jobs.append({
+            "id": jid, "name": name, "state": state,
+            "submit": t_submit, "start": t_start, "end": t_end,
+            "nodes": int(nodes or 1),
+            "node_seconds": int(elapsed or 0) * int(nodes or 1),
+        })
+    return sorted(jobs, key=lambda j: j["start"])
+
+
+def gate_of(job: dict, jobs: list[dict]) -> datetime:
+    """The instant from which the job *could* have started.
+
+    For a link in a chain that is the predecessor's end, not the submission:
+    before that moment it was held back by our own `--dependency`, and
+    charging that to the scheduler is how a 7-hour wait gets reported as 77.
+    The predecessor is the last job of the same name to finish before this
+    one started — SLURM does not record the dependency itself in `sacct`, and
+    same-name-and-ordered is what a chain actually looks like.
+    """
+    prev_end = max(
+        (j["end"] for j in jobs
+         if j["name"] == job["name"] and j["id"] != job["id"]
+         and j["end"] <= job["start"]),
+        default=None,
+    )
+    return max(job["submit"], prev_end) if prev_end else job["submit"]
+
+
+def merge(intervals: list[tuple]) -> list[tuple]:
+    """Union of intervals, so parallel jobs do not double-count calendar."""
+    out: list[tuple] = []
+    for start, end in sorted(intervals):
+        if out and start <= out[-1][1]:
+            out[-1] = (out[-1][0], max(out[-1][1], end))
+        else:
+            out.append((start, end))
+    return out
+
+
+def gaps_of(busy: list[tuple], jobs: list[dict], alloc_start: datetime,
+            now: datetime) -> list[dict]:
+    """Every stretch with nothing running, each attributed to a cause.
+
+    A gap during which some job was already submitted and had not yet started
+    is the cluster being full; a gap with nothing submitted is ours.
+    """
+    out: list[dict] = []
+    cursor = alloc_start
+    for s, e in busy + [(now, now)]:
+        if s > cursor:
+            waiting = [j["id"] for j in jobs
+                       if j["submit"] <= cursor and j["start"] >= s]
+            out.append({
+                "from": cursor, "to": s,
+                "seconds": (s - cursor).total_seconds(),
+                "cause": "cluster full" if waiting else "queue empty",
+                "waiting": waiting,
+            })
+        cursor = max(cursor, e)
+    return out
+
+
+def summarise(jobs: list[dict], alloc_start: datetime, now: datetime) -> dict:
+    """Everything the report needs, computed once for print and for JSON."""
+    waits = []
+    wait_res = wait_dep = 0.0
+    for j in jobs:
+        gate = gate_of(j, jobs)
+        r = (j["start"] - gate).total_seconds()
+        wait_res += r
+        wait_dep += (j["start"] - j["submit"]).total_seconds() - r
+        if r >= 60:
+            waits.append({"job": j["id"], "from": gate,
+                          "to": j["start"], "seconds": r})
+
+    busy = merge([(j["start"], j["end"]) for j in jobs])
+    gaps = gaps_of(busy, jobs, alloc_start, now)
+    busy_h = sum((e - s).total_seconds() for s, e in busy) / 3600
+    used_h = sum(j["node_seconds"] for j in jobs) / 3600
+    calendar_h = (now - alloc_start).total_seconds() / 3600
+    full_h = sum(g["seconds"] for g in gaps if g["cause"] == "cluster full") / 3600
+    empty_h = sum(g["seconds"] for g in gaps if g["cause"] == "queue empty") / 3600
+    return {
+        "resource_waits": waits, "idle_gaps": gaps,
+        "node_hours_used": used_h, "calendar_hours": calendar_h,
+        "busy_hours": busy_h,
+        "idle_cluster_full_hours": full_h, "idle_queue_empty_hours": empty_h,
+        "mean_nodes_when_busy": (used_h / busy_h) if busy_h else 0.0,
+        "resource_wait_seconds": wait_res, "dependency_wait_seconds": wait_dep,
+    }
+
+
+def report(jobs: list[dict], s: dict, alloc_start: datetime) -> None:
+    print("JOBS")
+    print(f"{'job':>11} {'name':<22} {'state':<10} {'start':<16} "
+          f"{'end':<16} {'elapsed':>8} {'nodes':>5}")
+    for j in jobs:
+        print(f"{j['id']:>11} {j['name'][:22]:<22} {j['state'][:10]:<10} "
+              f"{j['start']:{STAMP}} {j['end']:{STAMP}} "
+              f"{hours(j['node_seconds'] / j['nodes']):>8} {j['nodes']:>5}")
+
+    print()
+    print("QUEUE WAIT  (from the predecessor's end, or from submission)")
+    print(f"{'job':>11} {'from':<16} {'to':<16} {'waited':>8}")
+    for w in s["resource_waits"]:
+        print(f"{w['job']:>11} {w['from']:{STAMP}} {w['to']:{STAMP}} "
+              f"{hours(w['seconds']):>8}")
+    if not s["resource_waits"]:
+        print("            (nothing waited more than a minute)")
+
+    print()
+    print("CALENDAR IDLE")
+    print(f"{'from':<16} {'to':<16} {'duration':>9}  cause")
+    for g in s["idle_gaps"]:
+        who = f"  (job {', '.join(g['waiting'])})" if g["waiting"] else ""
+        print(f"{g['from']:{STAMP}} {g['to']:{STAMP}} "
+              f"{hours(g['seconds']):>9}  {g['cause']}{who}")
+
+    cal = s["calendar_hours"]
+    print()
+    print(f"  node-hours used             {s['node_hours_used']:9.1f}")
+    print(f"  calendar since {alloc_start:%Y-%m-%d}    {cal:9.1f} h")
+    print(f"    at least one job running  {s['busy_hours']:9.1f} h"
+          f"   ({100 * s['busy_hours'] / cal if cal else 0:.1f} %)")
+    print(f"    idle, cluster full        {s['idle_cluster_full_hours']:9.1f} h")
+    print(f"    idle, queue empty         {s['idle_queue_empty_hours']:9.1f} h")
+    print(f"  mean nodes while busy       {s['mean_nodes_when_busy']:9.2f}")
+    print()
+    print(f"  queue wait, total           {hours(s['resource_wait_seconds']):>11}")
+    print(f"  dependency wait (by design) {hours(s['dependency_wait_seconds']):>11}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    out_json = None
+    if "--json" in argv:
+        i = argv.index("--json")
+        try:
+            out_json = argv[i + 1]
+        except IndexError:
+            print("--json needs a path", file=sys.stderr)
+            return 2
+        del argv[i:i + 2]
+    alloc_start = datetime.strptime(argv[0] if argv else "2026-09-02", "%Y-%m-%d")
+    now = datetime.now()
+
+    raw = subprocess.run(
+        ["sacct", "-S", alloc_start.strftime("%Y-%m-%d"), "-X", "-P",
+         "--noheader", f"--format={FIELDS}"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    jobs = parse(raw, now)
+    if not jobs:
+        print(f"no jobs since {alloc_start:%Y-%m-%d}")
+        return 1
+
+    s = summarise(jobs, alloc_start, now)
+    report(jobs, s, alloc_start)
+
+    if out_json:
+        def iso(o):
+            return o.strftime(FMT) if isinstance(o, datetime) else o
+        payload = {
+            "captured_at": now.strftime(FMT),
+            "allocation_start": alloc_start.strftime("%Y-%m-%d"),
+            "jobs": [{k: iso(v) for k, v in j.items()} for j in jobs],
+            "resource_waits": [{k: iso(v) for k, v in w.items()}
+                               for w in s["resource_waits"]],
+            "idle_gaps": [{k: iso(v) for k, v in g.items()}
+                          for g in s["idle_gaps"]],
+            "totals": {k: v for k, v in s.items()
+                       if k not in ("resource_waits", "idle_gaps")},
+        }
+        with open(out_json, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False)
+        print(f"\nwrote {out_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/forge/scripts/leonardo/sbatch_queue_stats.slurm
+++ b/forge/scripts/leonardo/sbatch_queue_stats.slurm
@@ -1,0 +1,52 @@
+#!/bin/bash
+# A daily snapshot of where the allocation's calendar is going, that keeps
+# itself alive.
+#
+# Leonardo has no user cron (`crontab` is not permitted) and `scrontab` is
+# disabled cluster-wide, so there is no scheduler to hang this off. What does
+# work is a job that re-submits itself with `--begin=now+1day` before
+# exiting: the successor sits PENDING for a day, which costs nothing, then
+# does the same. It runs until the allocation ends and then stops on its own.
+#
+# It lives on the serial partition and takes about three seconds of one core.
+# Putting it on boost_usr_prod would reserve four A100s to run some Python.
+#
+#   sbatch forge/scripts/leonardo/sbatch_queue_stats.slurm
+#   squeue --me -n eullm-queue-stats     # must always show exactly one PENDING
+#
+# The chain's one failure mode is a re-submission that does not happen — a
+# full queue, an expired allocation, a typo in a path. Nothing announces it;
+# the job simply stops existing. Check for that one PENDING row now and then,
+# and if it is gone, submit this again.
+#
+#SBATCH --job-name=eullm-queue-stats
+#SBATCH --partition=lrd_all_serial
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=2G
+#SBATCH --time=00:10:00
+#SBATCH --output=%x-%j.out
+
+set -uo pipefail
+
+# Absolute, because a batch job inherits none of the login shell's exports and
+# $WORK does not exist here. Override when the project path differs.
+BASE="${EULLM_BASE:-/leonardo_work/AIFAC_P02_1147}"
+REPO="${EULLM_REPO:-$BASE/eullm-v11}"
+OUT="$BASE/eullm_runs/qstats"
+ALLOC_START="${EULLM_ALLOC_START:-2026-09-02}"
+ALLOC_END="${EULLM_ALLOC_END:-20261102}"
+
+mkdir -p "$OUT"
+
+# `|| true` on purpose: an instrument must never fail the thing it measures,
+# and here that thing includes its own re-submission below.
+python3 "$REPO/forge/scripts/leonardo/queue_stats.py" "$ALLOC_START" \
+    --json "$OUT/queue_stats_$(date +%Y%m%d_%H%M).json" || true
+
+# Re-arm, unless the allocation is over. Without this guard the chain would
+# keep trying past the end date and fill the directory with failures.
+if [ "$(date +%Y%m%d)" -lt "$ALLOC_END" ]; then
+    cd "$OUT" || exit 0
+    sbatch --begin=now+1day "$REPO/forge/scripts/leonardo/sbatch_queue_stats.slurm"
+fi

--- a/forge/tests/test_queue_stats.py
+++ b/forge/tests/test_queue_stats.py
@@ -1,0 +1,155 @@
+"""Tests for the allocation queue/idle accounting.
+
+Two of these encode bugs that were live: the first version charged
+dependency wait to the scheduler (77 hours reported against 7 real), and an
+earlier helper left trailing whitespace on a value it was supposed to trim.
+The attribution rules are the whole point of the script — if they drift, the
+numbers stay plausible and become wrong, which is the worst failure mode for
+something feeding a report.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "leonardo" / "queue_stats.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("queue_stats", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+qs = _load()
+
+
+def at(stamp: str) -> datetime:
+    return datetime.strptime(stamp, qs.FMT)
+
+
+# The real Phase-1 chain: three 24 h jobs submitted together, so each waits
+# for its predecessor. Job 3 also waited 7h06m for a free node.
+CHAIN = "\n".join([
+    "56803262|eullm-p1|TIMEOUT|2026-09-08T20:50:00|2026-09-08T20:57:02|2026-09-09T21:00:06|86584|1",
+    "56818854|eullm-p1|TIMEOUT|2026-09-08T22:08:00|2026-09-09T21:03:26|2026-09-10T21:07:03|86617|1",
+    "56818982|eullm-p1|RUNNING|2026-09-08T22:09:00|2026-09-11T04:13:23|Unknown|21397|1",
+    # Submitted but never started: must not appear anywhere.
+    "57294041|eullm-p6|PENDING|2026-09-11T09:50:00|Unknown|Unknown|0|1",
+])
+NOW = at("2026-09-11T10:10:00")
+
+
+def test_pending_jobs_are_skipped():
+    jobs = qs.parse(CHAIN, NOW)
+    assert [j["id"] for j in jobs] == ["56803262", "56818854", "56818982"]
+
+
+def test_running_job_counts_as_busy_until_now():
+    jobs = qs.parse(CHAIN, NOW)
+    assert jobs[-1]["end"] == NOW
+
+
+def test_queue_wait_excludes_dependency_wait():
+    """The bug this file exists for.
+
+    56818982 was submitted 2026-09-08 22:09 and started 2026-09-11 04:13 —
+    54 hours later. All but 7h06m of that was waiting for two predecessors
+    it was explicitly told to wait for.
+    """
+    jobs = qs.parse(CHAIN, NOW)
+    job = next(j for j in jobs if j["id"] == "56818982")
+    wait = (job["start"] - qs.gate_of(job, jobs)).total_seconds()
+    assert wait == pytest.approx(7 * 3600 + 6 * 60, abs=60)
+
+
+def test_first_job_of_a_chain_measures_from_submission():
+    """With no predecessor there is nothing to subtract."""
+    jobs = qs.parse(CHAIN, NOW)
+    job = next(j for j in jobs if j["id"] == "56803262")
+    wait = (job["start"] - qs.gate_of(job, jobs)).total_seconds()
+    assert wait == pytest.approx(7 * 60, abs=30)
+
+
+def test_unrelated_job_names_are_not_treated_as_a_chain():
+    """A differently-named job must not become someone's predecessor."""
+    raw = "\n".join([
+        "1|alpha|COMPLETED|2026-09-01T00:00:00|2026-09-01T00:00:00|2026-09-01T05:00:00|18000|1",
+        "2|beta|COMPLETED|2026-09-01T00:00:00|2026-09-01T06:00:00|2026-09-01T07:00:00|3600|1",
+    ])
+    jobs = qs.parse(raw, at("2026-09-01T08:00:00"))
+    beta = next(j for j in jobs if j["id"] == "2")
+    # Gate is beta's own submission, not alpha's end, so the wait is 6 h.
+    assert (beta["start"] - qs.gate_of(beta, jobs)).total_seconds() == 6 * 3600
+
+
+def test_parallel_jobs_do_not_double_count_calendar():
+    a, b = at("2026-09-01T00:00:00"), at("2026-09-01T01:00:00")
+    merged = qs.merge([(a, b), (a, b)])
+    assert len(merged) == 1
+    assert (merged[0][1] - merged[0][0]).total_seconds() == 3600
+
+
+def test_merge_joins_touching_intervals():
+    a, b, c = (at("2026-09-01T00:00:00"), at("2026-09-01T01:00:00"),
+               at("2026-09-01T02:00:00"))
+    assert qs.merge([(a, b), (b, c)]) == [(a, c)]
+
+
+def test_gap_with_a_job_queued_is_the_cluster_s_fault():
+    jobs = qs.parse(CHAIN, NOW)
+    busy = qs.merge([(j["start"], j["end"]) for j in jobs])
+    gaps = qs.gaps_of(busy, jobs, at("2026-09-08T00:00:00"), NOW)
+    stall = next(g for g in gaps if g["from"] == at("2026-09-10T21:07:03"))
+    assert stall["cause"] == "cluster full"
+    assert "56818982" in stall["waiting"]
+
+
+def test_gap_with_nothing_queued_is_ours():
+    """The allocation opened on the 2nd; the first job was submitted on the 8th."""
+    jobs = qs.parse(CHAIN, NOW)
+    busy = qs.merge([(j["start"], j["end"]) for j in jobs])
+    gaps = qs.gaps_of(busy, jobs, at("2026-09-02T00:00:00"), NOW)
+    head = gaps[0]
+    assert head["from"] == at("2026-09-02T00:00:00")
+    assert head["cause"] == "queue empty"
+    assert head["waiting"] == []
+
+
+def test_totals_separate_the_two_kinds_of_idle():
+    jobs = qs.parse(CHAIN, NOW)
+    s = qs.summarise(jobs, at("2026-09-02T00:00:00"), NOW)
+    # 7h06m stall + a 3-minute handover, and six days before we started.
+    assert s["idle_cluster_full_hours"] == pytest.approx(7.15, abs=0.1)
+    assert s["idle_queue_empty_hours"] == pytest.approx(164.95, abs=0.1)
+    # One node throughout, so node-hours and busy calendar agree.
+    assert s["mean_nodes_when_busy"] == pytest.approx(1.0, abs=0.05)
+
+
+def test_dependency_wait_is_reported_but_kept_apart():
+    jobs = qs.parse(CHAIN, NOW)
+    s = qs.summarise(jobs, at("2026-09-02T00:00:00"), NOW)
+    assert s["resource_wait_seconds"] == pytest.approx(7 * 3600 + 16 * 60, abs=120)
+    assert s["dependency_wait_seconds"] > 60 * 3600
+
+
+def test_hours_formats_and_survives_negatives():
+    assert qs.hours(0) == "0h00m"
+    assert qs.hours(3600) == "1h00m"
+    assert qs.hours(25620) == "7h07m"
+    assert qs.hours(-90) == "-0h01m"
+
+
+def test_malformed_sacct_rows_are_ignored():
+    raw = "\n".join([
+        "not|enough|fields",
+        "9|x|COMPLETED|garbage|2026-09-01T00:00:00|2026-09-01T01:00:00|3600|1",
+        "10|x|COMPLETED|2026-09-01T00:00:00|2026-09-01T00:00:00|2026-09-01T01:00:00|3600|1",
+    ])
+    jobs = qs.parse(raw, at("2026-09-01T02:00:00"))
+    assert [j["id"] for j in jobs] == ["10"]


### PR DESCRIPTION
…se fault each gap is

Node-hours are not this allocation's binding constraint -- calendar is. One node kept busy for the two months consumes essentially the whole grant, so an idle hour expires and cannot be recovered by running something bigger later. Nothing measured that, and the Final Report has to account for it.

queue_stats.py splits idle calendar into "cluster full" (a job was queued and would not start; about the machine) and "queue empty" (nothing was submitted, because nothing was ready; ours), and prints every wait dated from and to, so the report can quote an interval rather than a total.

The arithmetic that looks obvious is wrong, and the tests pin that down. Start - Submit on a chained job counts the time it spent waiting for its own predecessor: on the Phase-1 chain that reported 77 hours against 7 real ones. The clock starts at the predecessor's end instead. Summed durations are also not elapsed calendar once jobs run in parallel, so busy intervals are merged before being measured. Reintroducing either bug fails the suite.

budget.sh took "consumed" from saldo, which counts finished AND billed jobs. A job that ended hours ago is neither still running nor yet billed and fell through the gap between the two columns: on 2026-09-11 saldo read 907 core-hours against 1,675 actually spent. Consumption now comes from sacct over the whole allocation, with saldo shown underneath as a cross-check.

Leonardo permits no user crontab and scrontab is disabled cluster-wide, so sbatch_queue_stats.slurm re-submits itself with --begin=now+1day and keeps the record alive on three seconds of one serial core per day, stopping on the allocation's end date. sacct has a retention window; the JSON snapshots outlive it.

The runbook gains the monitoring practice this cost us: read logs with tail piped through grep -v, never grep alone, because the 8-bit base writes 2.1 GB of bitsandbytes warnings a day and a plain grep looks hung; check epoch, not loss, to prove a chained job resumed; and the ncurses/LD_LIBRARY_PATH mismatch that segfaults nano, watch and htop, which cost half an hour twice before the two crashes were recognised as one.