### PR TITLE
feat(pilot): P1 probe for vLLM prompt scoring, and P6's first measure…

### DIFF
--- a/docs/paper/legal-it-4b-report-outline.md
+++ b/docs/paper/legal-it-4b-report-outline.md
@@ -138,6 +138,38 @@ for a throughput loss it was not causing, and two ZeRO-3 levers that raised
 the memory peak they were meant to lower. "We expected X and measured Y" is a
 result; "we measured Y" is a data point.
 
+### Scored so far
+
+| | predicted | measured | |
+|---|---|---|---|
+| **P6** KL | < 0.01 nats | **0.0061** | held |
+| **P6** top-1 agreement | > 99 % | **95.65 %** | **falsified** |
+
+*(2026-09-11, 20 val documents / 10,186 positions, Qwen3-30B-A3B-Base at
+int8 against bf16, no adapter. 9 minutes on one node.)*
+
+**The two halves disagree, and the disagreement is the finding.** Top-5
+agreement is 99.95 % and the KL is 0.006 nats, so where the argmax flips, the
+first two candidates were near-tied: the change is in which of two almost
+equal probabilities wins, not in the distribution. Distillation optimises a
+divergence against the teacher's probabilities, not agreement on its argmax,
+and 0.006 nats against a student loss around 1.27 is about 0.5 % of the
+signal.
+
+So the question P6 was asked to answer — *did quantizing the teacher to make
+it fit distort the target?* — is answered **no**, and v1.0's Phase-1 adapter
+needs no asterisk.
+
+But the prediction was posed badly, and that is recorded rather than quietly
+repaired. Top-1 agreement was chosen because it is the half a reader can
+interpret without information theory; it measures the stability of an argmax,
+not the fidelity of a distribution, and on formulaic Italian legal text — full
+of positions with two near-equiprobable continuations — the argmax is unstable
+even between two copies of the same model. The threshold that should have been
+pre-registered is KL alone, with top-1 reported as context. Per the
+pre-registration's own scoring rule, a badly posed prediction is itself a
+result.
+
 ## Incidents log
 
 One line each, with the cost. This is the section that makes the report

--- a/forge/scripts/leonardo/sbatch_p1_logprob_probe.slurm
+++ b/forge/scripts/leonardo/sbatch_p1_logprob_probe.slurm
@@ -1,0 +1,80 @@
+#!/bin/bash
+# P1 — can vLLM score the corpus with the teacher, and how fast?
+#
+# The first pilot job for the v1.1 pipeline, and the one that decides whether
+# design A of ADR-001 is buildable at all. It runs beside a Phase-1 chain
+# without touching it: different checkout, different run directory, and a
+# venv of its own.
+#
+# **The venv is not a detail.** vLLM pins its own PyTorch. Installing it into
+# the venv a running chain uses would change that chain's torch the moment its
+# next link restarts, which is the most efficient way to lose days of compute.
+# Prepare it on a login node, where there is internet:
+#
+#   python -m venv "$WORK/v11_venv"
+#   "$WORK/v11_venv/bin/pip" install --upgrade pip
+#   "$WORK/v11_venv/bin/pip" install 'vllm==0.28.0'
+#
+#   cd "$WORK/eullm_runs/v11_pilot"
+#   sbatch "$WORK/eullm-v11/forge/scripts/leonardo/sbatch_p1_logprob_probe.slurm"
+#
+# Exits non-zero when P1 is falsified — which is a result, not a malfunction.
+# The report JSON carries the numbers either way.
+#
+#SBATCH --job-name=eullm-p1-logprobs
+#SBATCH --partition=boost_usr_prod
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=32
+#SBATCH --gres=gpu:4
+#SBATCH --mem=450G
+#SBATCH --time=02:00:00
+#SBATCH --output=logs/%x-%j.out
+
+set -uo pipefail
+
+# Spelled out rather than taken from EULLM_REPO: env.sh sets that to whatever
+# tree a frozen run is pinned to, and sbatch exports the submitting shell's
+# environment. A pilot job must run from the pilot checkout.
+BASE="${EULLM_BASE:-$WORK}"
+export EULLM_REPO="${EULLM_PILOT_REPO:-$BASE/eullm-v11}"
+export EULLM_RUN_DIR="${EULLM_PILOT_RUN_DIR:-$BASE/eullm_runs/v11_pilot}"
+PILOT_VENV="${EULLM_PILOT_VENV:-$BASE/v11_venv}"
+
+# shellcheck disable=SC1091
+source "$EULLM_REPO/forge/scripts/leonardo/env.sh"
+mkdir -p "$EULLM_RUN_DIR/logs"
+cd "$EULLM_RUN_DIR" || exit 1
+
+if [ ! -x "$PILOT_VENV/bin/python" ]; then
+    echo "[p1] FATAL: no venv at $PILOT_VENV — see the header of this file." >&2
+    exit 1
+fi
+
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+
+# shellcheck disable=SC1091
+source "$EULLM_REPO/forge/scripts/leonardo/heartbeat.sh"
+heartbeat_start
+
+echo "[p1] commit $(git -C "$EULLM_REPO" rev-parse --short HEAD)"
+"$PILOT_VENV/bin/python" -c 'import vllm, torch; print(f"[p1] vllm {vllm.__version__}, torch {torch.__version__}")'
+
+"$PILOT_VENV/bin/python" "$EULLM_REPO/forge/scripts/pilot/probe_teacher_logprobs.py" \
+    --model Qwen/Qwen3-30B-A3B-Base \
+    --data "$EULLM_DATA_DIR/val.jsonl" \
+    --samples 32 \
+    --top-k 64 \
+    --seq-len 1024 \
+    --tensor-parallel-size 4 \
+    --report "$EULLM_RUN_DIR/p1_prompt_logprobs_k64.json"
+STATUS=$?
+
+# An instrument must not fail the job it measures.
+python3 "$EULLM_REPO/forge/scripts/leonardo/queue_stats.py" 2026-09-02 \
+    --json "$BASE/eullm_runs/qstats/queue_stats_$(date +%Y%m%d_%H%M).json" || true
+
+# Pass the probe's verdict up: non-zero means P1 was falsified, which the
+# report records as a finding rather than as a broken run.
+exit "$STATUS"

--- a/forge/scripts/pilot/probe_teacher_logprobs.py
+++ b/forge/scripts/pilot/probe_teacher_logprobs.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""P1: can vLLM score a corpus with the teacher, and what does it cost?
+
+Design A in ADR-001 caches the teacher's top-K distribution once and trains
+any number of students against the cache. The whole design rests on one
+unverified assumption: that vLLM will return top-K logprobs **for every
+position of a prompt**, in one pass, on a Qwen3 MoE. If it will not, the
+provider interface gets built around a different backend and the rest of the
+plan is unaffected — which is exactly why this runs first, and why it is
+cheap.
+
+The pre-registration (docs/paper/v11-pilot-preregistration.md) calls P1
+falsified if the call fails, if fewer than K values come back per position,
+or if scoring is within 20% of generation-mode throughput — that last one
+because it would mean the path is not doing the extra work we expect and
+something else is wrong.
+
+**"Throughput" is defined here as positions scored per second**, and the
+definition matters more than the number. Generation mode emits K logprobs per
+*generated* token, one token at a time; prompt scoring emits K logprobs per
+*prompt* position, a whole sequence at a time. Tokens/s would compare two
+different things. What the cache actually needs is "how long to score N
+positions", so that is what both halves measure.
+
+Two things this deliberately records rather than assumes:
+
+  * **What comes back is logprobs, not logits.** ADR-001 Part 4 specifies a
+    provider returning raw logits. vLLM normalises. The difference is one
+    additive constant per position, and the cache format already stores a
+    per-temperature normaliser for exactly this reason — but the assumption
+    should be corrected in the ADR from a measurement, not from memory.
+  * **How many entries per position actually arrive.** vLLM may include the
+    prompt's own token beyond the top-K, so K+1 is a pass, not a failure.
+    Fewer than K is the falsification.
+
+    python probe_teacher_logprobs.py --model Qwen/Qwen3-30B-A3B-Base \\
+        --data "$EULLM_DATA_DIR/val.jsonl" --samples 32 --top-k 64 \\
+        --tensor-parallel-size 4 --report p1.json
+
+Failure is an answer. A backend that cannot do this exits non-zero with the
+reason written to the report, rather than raising through the sbatch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import time
+from pathlib import Path
+
+
+def load_samples(path: Path, n: int, seed: int, field: str) -> list[str]:
+    """Reservoir-sample n texts without holding the whole corpus in memory."""
+    rng = random.Random(seed)
+    picked: list[str] = []
+    seen = 0
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                text = json.loads(line).get(field)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(text, str) or len(text) < 200:
+                continue
+            seen += 1
+            if len(picked) < n:
+                picked.append(text)
+            else:
+                j = rng.randrange(seen)
+                if j < n:
+                    picked[j] = text
+    return picked
+
+
+def inspect_prompt_logprobs(outputs, top_k: int) -> dict:
+    """What vLLM actually returned, as opposed to what we hoped.
+
+    Position 0 carries no distribution — nothing precedes it — and vLLM
+    returns None there. That is expected and not counted as a short position.
+    """
+    scored = 0
+    short: list[int] = []
+    widths: set[int] = set()
+    sample_entry = None
+    for out in outputs:
+        plp = getattr(out, "prompt_logprobs", None)
+        if not plp:
+            continue
+        for pos, entry in enumerate(plp):
+            if entry is None:          # first position: no context
+                continue
+            widths.add(len(entry))
+            if len(entry) < top_k:
+                short.append(len(entry))
+            if sample_entry is None:
+                sample_entry = next(iter(entry.values()))
+            scored += 1
+    return {
+        "positions_scored": scored,
+        "entries_per_position": sorted(widths),
+        "positions_below_k": len(short),
+        # A Logprob object carries .logprob (normalised) — recording the
+        # attribute names is how the ADR's "raw logits" claim gets corrected
+        # from evidence.
+        "value_attributes": sorted(
+            a for a in dir(sample_entry) if not a.startswith("_")
+        ) if sample_entry is not None else [],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--model", required=True)
+    p.add_argument("--data", type=Path, required=True)
+    p.add_argument("--field", default="text")
+    p.add_argument("--samples", type=int, default=32)
+    p.add_argument("--top-k", type=int, default=64)
+    p.add_argument("--seq-len", type=int, default=1024)
+    p.add_argument("--tensor-parallel-size", type=int, default=4)
+    p.add_argument("--gpu-memory-utilization", type=float, default=0.85)
+    p.add_argument("--gen-tokens", type=int, default=64,
+                   help="tokens to generate for the comparison half")
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--report", type=Path, default=None)
+    args = p.parse_args(argv)
+
+    report: dict = {"model": args.model, "top_k": args.top_k,
+                    "tensor_parallel_size": args.tensor_parallel_size,
+                    "seq_len": args.seq_len, "samples": args.samples}
+
+    def finish(code: int) -> int:
+        if args.report:
+            args.report.write_text(json.dumps(report, indent=2), encoding="utf-8")
+            print(f"\n[ok] report written to {args.report}")
+        return code
+
+    try:
+        from vllm import LLM, SamplingParams
+    except Exception as exc:                       # noqa: BLE001 - reported
+        report["verdict"] = "vllm-unavailable"
+        report["error"] = f"{type(exc).__name__}: {exc}"
+        print(f"[FAIL] cannot import vllm: {exc}", file=sys.stderr)
+        return finish(2)
+
+    texts = load_samples(args.data, args.samples, args.seed, args.field)
+    if not texts:
+        report["verdict"] = "no-samples"
+        print(f"[FAIL] no usable samples in {args.data}", file=sys.stderr)
+        return finish(2)
+    print(f"[..] {len(texts)} samples, loading {args.model} "
+          f"on TP={args.tensor_parallel_size}", flush=True)
+
+    t0 = time.time()
+    try:
+        llm = LLM(model=args.model,
+                  tensor_parallel_size=args.tensor_parallel_size,
+                  max_model_len=args.seq_len,
+                  gpu_memory_utilization=args.gpu_memory_utilization,
+                  enforce_eager=False)
+    except Exception as exc:                       # noqa: BLE001 - reported
+        report["verdict"] = "load-failed"
+        report["error"] = f"{type(exc).__name__}: {exc}"
+        print(f"[FAIL] could not load the model: {exc}", file=sys.stderr)
+        return finish(2)
+    report["load_seconds"] = round(time.time() - t0, 1)
+    print(f"[ok] loaded in {report['load_seconds']}s", flush=True)
+
+    # ── the question: top-K for every prompt position, in one pass ────────
+    t0 = time.time()
+    try:
+        scored = llm.generate(
+            texts,
+            SamplingParams(max_tokens=1, temperature=0.0,
+                           prompt_logprobs=args.top_k),
+        )
+    except Exception as exc:                       # noqa: BLE001 - reported
+        report["verdict"] = "prompt-logprobs-unsupported"
+        report["error"] = f"{type(exc).__name__}: {exc}"
+        print(f"[FAIL] prompt_logprobs={args.top_k} rejected: {exc}",
+              file=sys.stderr)
+        return finish(1)
+    score_seconds = time.time() - t0
+
+    shape = inspect_prompt_logprobs(scored, args.top_k)
+    report["prompt_logprobs"] = shape
+    report["score_seconds"] = round(score_seconds, 1)
+    report["score_positions_per_second"] = round(
+        shape["positions_scored"] / score_seconds, 1) if score_seconds else 0.0
+
+    # ── the comparison: generation mode over the same prompts ─────────────
+    t0 = time.time()
+    generated = llm.generate(
+        texts,
+        SamplingParams(max_tokens=args.gen_tokens, temperature=0.0,
+                       logprobs=args.top_k),
+    )
+    gen_seconds = time.time() - t0
+    gen_positions = sum(len(o.outputs[0].token_ids) for o in generated)
+    report["gen_seconds"] = round(gen_seconds, 1)
+    report["gen_positions_per_second"] = round(
+        gen_positions / gen_seconds, 1) if gen_seconds else 0.0
+
+    fast = report["score_positions_per_second"]
+    slow = report["gen_positions_per_second"]
+    report["speedup_over_generation"] = round(fast / slow, 2) if slow else None
+
+    # ── verdict against the pre-registered thresholds ─────────────────────
+    reasons = []
+    if shape["positions_scored"] == 0:
+        reasons.append("no positions carried a distribution")
+    if shape["positions_below_k"]:
+        reasons.append(
+            f"{shape['positions_below_k']} positions returned fewer than "
+            f"{args.top_k} entries")
+    report["verdict"] = "holds" if not reasons else "falsified"
+    report["falsification_reasons"] = reasons
+
+    print()
+    print("=" * 62)
+    print(f"  positions scored      {shape['positions_scored']:>12,}")
+    print(f"  entries per position  {str(shape['entries_per_position']):>12}"
+          f"   (K={args.top_k}; K+1 is fine, fewer is not)")
+    print(f"  scoring               {report['score_positions_per_second']:>12,.1f} pos/s")
+    print(f"  generation            {report['gen_positions_per_second']:>12,.1f} pos/s")
+    print(f"  speedup               {str(report['speedup_over_generation']):>12}x")
+    print(f"  value attributes      {', '.join(shape['value_attributes'][:6])}")
+    print(f"  VERDICT               {report['verdict'].upper():>12}")
+    for r in reasons:
+        print(f"    - {r}")
+    print("=" * 62)
+
+    return finish(0 if report["verdict"] == "holds" else 1)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/forge/tests/test_probe_teacher_logprobs.py
+++ b/forge/tests/test_probe_teacher_logprobs.py
@@ -1,0 +1,107 @@
+"""Tests for the P1 probe's reading of what vLLM returns.
+
+The probe's job is to decide whether a pre-registered prediction held, so the
+part worth testing is the judgement, not the inference. Two rules are easy to
+get backwards and would silently invert the verdict:
+
+  * position 0 has no preceding context and comes back as None — counting it
+    as a short position would falsify P1 on every run;
+  * vLLM may add the prompt's own token on top of the top-K, so K+1 entries
+    is a pass.
+
+vLLM is not importable here (and needs GPUs), so the shapes it returns are
+reconstructed as plain dicts. That is the contract the probe reads.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+SCRIPT = (Path(__file__).resolve().parents[1]
+          / "scripts" / "pilot" / "probe_teacher_logprobs.py")
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("probe", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+probe = _load()
+
+
+class FakeLogprob:
+    """Stands in for vllm.sequence.Logprob: a normalised value plus a rank."""
+
+    def __init__(self, logprob: float, rank: int) -> None:
+        self.logprob = logprob
+        self.rank = rank
+        self.decoded_token = "x"
+
+
+class FakeOutput:
+    def __init__(self, prompt_logprobs) -> None:
+        self.prompt_logprobs = prompt_logprobs
+
+
+def entry(width: int) -> dict:
+    return {i: FakeLogprob(-float(i) - 0.1, i + 1) for i in range(width)}
+
+
+def test_first_position_is_not_counted_as_short():
+    """vLLM returns None for position 0; it has no distribution to return."""
+    out = FakeOutput([None] + [entry(64) for _ in range(9)])
+    shape = probe.inspect_prompt_logprobs([out], top_k=64)
+    assert shape["positions_scored"] == 9
+    assert shape["positions_below_k"] == 0
+
+
+def test_k_plus_one_entries_is_a_pass():
+    """The prompt's own token may be added beyond the top-K."""
+    out = FakeOutput([None] + [entry(65) for _ in range(4)])
+    shape = probe.inspect_prompt_logprobs([out], top_k=64)
+    assert shape["positions_below_k"] == 0
+    assert shape["entries_per_position"] == [65]
+
+
+def test_fewer_than_k_is_the_falsification():
+    out = FakeOutput([None, entry(64), entry(32), entry(64)])
+    shape = probe.inspect_prompt_logprobs([out], top_k=64)
+    assert shape["positions_below_k"] == 1
+    assert shape["entries_per_position"] == [32, 64]
+
+
+def test_empty_prompt_logprobs_scores_nothing():
+    """A backend that accepts the argument and ignores it must not pass."""
+    shape = probe.inspect_prompt_logprobs([FakeOutput(None)], top_k=64)
+    assert shape["positions_scored"] == 0
+
+
+def test_value_attributes_are_recorded():
+    """ADR-001 assumes raw logits; vLLM returns `logprob`. Record, don't assume."""
+    out = FakeOutput([None, entry(64)])
+    shape = probe.inspect_prompt_logprobs([out], top_k=64)
+    assert "logprob" in shape["value_attributes"]
+
+
+def test_positions_accumulate_across_sequences():
+    outs = [FakeOutput([None] + [entry(64)] * 4),
+            FakeOutput([None] + [entry(64)] * 6)]
+    shape = probe.inspect_prompt_logprobs(outs, top_k=64)
+    assert shape["positions_scored"] == 10
+
+
+def test_load_samples_skips_short_and_malformed(tmp_path):
+    data = tmp_path / "val.jsonl"
+    data.write_text("\n".join([
+        json.dumps({"text": "x" * 300}),
+        "{not json",
+        json.dumps({"text": "too short"}),
+        json.dumps({"other": "y" * 300}),
+        json.dumps({"text": "z" * 300}),
+    ]), encoding="utf-8")
+    got = probe.load_samples(data, n=10, seed=1, field="text")
+    assert len(got) == 2


### PR DESCRIPTION
…d result

Design A in ADR-001 caches the teacher's top-K distribution once and trains any number of students against it. The whole design rests on an assumption nobody has tested: that vLLM will return top-K logprobs for every position of a prompt, in one pass, on a Qwen3 MoE. The probe answers that, and answers it cheaply, so a failure redirects the provider interface at a different backend before anything is built on top of it.

Throughput is defined as positions scored per second, in both halves, and the definition matters more than the number. Generation mode emits K logprobs per generated token; prompt scoring emits K per prompt position. Tokens/s would compare two different things, while "how long to score N positions" is what the cache actually needs to know.

Two things the probe records rather than assumes. It reports the attribute names on what comes back, because ADR-001 Part 4 specifies a provider returning raw logits and vLLM normalises — a correction the ADR should take from a measurement. And it counts entries per position rather than trusting the argument, because K+1 is a pass (vLLM may add the prompt's own token) and fewer than K is the falsification. The tests pin both rules, along with position 0 returning None: counting that as short would falsify P1 on every run, including a successful one.

P6 is scored in the report outline from its first run. KL held at 0.0061 against a threshold of 0.01; top-1 agreement was 95.65 % against 99 % and is falsified. The two are reconciled by top-5 agreement at 99.95 %: where the argmax flips, the first two candidates were near-tied, which costs almost nothing in divergence. Distillation optimises against the teacher's probabilities rather than its argmax, so the question actually asked — did quantizing the teacher distort the target — is answered no, and v1.0's Phase-1 adapter needs no asterisk.

The prediction itself was posed badly, and that is recorded rather than repaired. Top-1 agreement measures the stability of an argmax, not the fidelity of a distribution, and on formulaic legal Italian the argmax is unstable between two copies of the same model. KL alone was the right threshold, with top-1 as context.