### PR TITLE
fix(leonardo): Phase 2 runs the checkout it was submitted from, and s…

### DIFF
--- a/forge/scripts/leonardo/sbatch_phase2.slurm
+++ b/forge/scripts/leonardo/sbatch_phase2.slurm
@@ -21,10 +21,34 @@
 
 set -euo pipefail
 
-EULLM_REPO="${EULLM_REPO:-$WORK/eullm}"
+# Which checkout this job runs is decided by where THIS FILE came from, not by
+# the submitting shell's environment.
+#
+# `sbatch` exports the submitter's environment by default and `env.sh` sets
+# EULLM_REPO to whatever tree the current run is pinned to — so submitting
+# `$WORK/eullm-v11/.../sbatch_phase2.slurm` from a shell that had sourced
+# env.sh for the frozen tree silently ran the frozen tree's code and config.
+# Nothing in the log said so. `scontrol` still knows the path the job was
+# submitted from, and the repo root is three directories above it.
+SELF="$(scontrol show job "${SLURM_JOB_ID:-0}" 2>/dev/null |
+        sed -n 's/.*Command=\([^ ]*\).*/\1/p' | head -1)"
+if [ -n "${EULLM_PHASE2_REPO:-}" ]; then
+    EULLM_REPO="$EULLM_PHASE2_REPO"          # explicit wins over everything
+elif [ -n "$SELF" ] && [ -f "$SELF" ]; then
+    EULLM_REPO="$(cd "$(dirname "$SELF")/../../.." && pwd)"
+else
+    EULLM_REPO="${EULLM_REPO:-$WORK/eullm}"  # interactive runs, no job id
+fi
+export EULLM_REPO
+
 # shellcheck disable=SC1091
 source "$EULLM_REPO/forge/scripts/leonardo/env.sh"
 cd "$EULLM_RUN_DIR"
+
+# Say which tree this is, on the first line, because the wrong answer is
+# invisible for hours otherwise.
+echo "[p2] repo   $EULLM_REPO"
+echo "[p2] commit $(git -C "$EULLM_REPO" rev-parse --short HEAD 2>/dev/null || echo '?')"
 
 # Phase 1 must have produced the teacher adapter this YAML points at.
 ADAPTER="./checkpoints/qwen3_30b_a3b_legal_it_continued_pt"


### PR DESCRIPTION
…ays which

`EULLM_REPO="${EULLM_REPO:-$WORK/eullm}"` looks like a sensible default and is a trap. sbatch exports the submitting shell's environment, and env.sh sets EULLM_REPO to whatever tree the current run is pinned to — so submitting $WORK/eullm-v11/.../sbatch_phase2.slurm from a shell that had sourced env.sh for the frozen v1.0 tree ran the frozen tree's code and config instead, with nothing in the log to say so. Seven chained jobs were queued that way.

It matters beyond tidiness here: ADR-001 now requires both arms of the A/B to run from the same current codebase, because running the old pipeline at its original commit would confound "which Phase-2 design" with every unrelated fix since. A silent fallback to the pinned tree breaks exactly that control.

The checkout is now decided by where the file came from. scontrol still knows the submitted path, and the repo root is three directories above it, so the job runs the tree it was launched from with no environment involved. EULLM_PHASE2_REPO overrides explicitly when that is wanted, and the old default remains for interactive runs with no job id.

The job also prints its repo path and commit on the first two lines. This class of mistake is invisible for hours otherwise — the earlier instance was only caught by reading the script, not the logs.