### PR TITLE
feat(forge): on-disk format for the teacher's top-K distributions

### DIFF
--- a/forge/eullm_forge/teacher_cache/__init__.py
+++ b/forge/eullm_forge/teacher_cache/__init__.py
@@ -1,0 +1,33 @@
+"""EULLM Forge — the teacher's top-K distributions, on disk.
+
+The v1.1 distillation pipeline (ADR-001) lets one teacher pass serve any
+number of student runs. This package is the record it leaves behind, and the
+checks that make it trustworthy.
+"""
+
+from .fingerprint import fingerprint_tokenizer, fingerprint_vocab
+from .format import (
+    DEFAULT_TEMPERATURES,
+    CachedSequence,
+    CacheProvenance,
+    LogitCacheReader,
+    LogitCacheWriter,
+    check_normalisers,
+    from_bf16_bits,
+    to_bf16_bits,
+    validate_sequence,
+)
+
+__all__ = [
+    "DEFAULT_TEMPERATURES",
+    "CacheProvenance",
+    "CachedSequence",
+    "LogitCacheReader",
+    "LogitCacheWriter",
+    "check_normalisers",
+    "fingerprint_tokenizer",
+    "fingerprint_vocab",
+    "from_bf16_bits",
+    "to_bf16_bits",
+    "validate_sequence",
+]

--- a/forge/eullm_forge/teacher_cache/fingerprint.py
+++ b/forge/eullm_forge/teacher_cache/fingerprint.py
@@ -1,0 +1,57 @@
+"""A tokenizer fingerprint that does not stop at vocabulary size.
+
+ADR-001 Part 6.3 is explicit about this, and the reason is that the failure
+is invisible. Two tokenizers can agree on 151,936 entries and differ in a
+handful of merges or in a special-token id; a cache written with one and
+read with the other produces targets that are wrong for a small fraction of
+positions, which looks like a student that trains slightly badly rather than
+a cache that is corrupt.
+
+Comparing the whole vocabulary mapping catches that. Hashing it rather than
+storing it keeps the manifest small and makes the comparison a string
+equality.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+def fingerprint_vocab(
+    vocab: dict[str, int], special_token_ids: dict[str, int | None]
+) -> str:
+    """A stable digest over the mapping and the special-token ids.
+
+    Sorted by token id rather than by token text: the id is the thing the
+    model indexes with, and two tokenizers that assign the same ids to the
+    same strings are interchangeable for this purpose whatever order their
+    files happen to list them in.
+    """
+    items = sorted(((int(i), str(t)) for t, i in vocab.items()))
+    h = hashlib.sha256()
+    h.update(b"eullm-tokenizer-fingerprint-v1\n")
+    h.update(f"size={len(items)}\n".encode())
+    for i, t in items:
+        h.update(f"{i}\t{t}\n".encode("utf-8", errors="surrogatepass"))
+    h.update(b"special\n")
+    h.update(
+        json.dumps(
+            {k: (None if v is None else int(v)) for k, v in sorted(special_token_ids.items())},
+            ensure_ascii=False,
+        ).encode()
+    )
+    return h.hexdigest()
+
+
+def fingerprint_tokenizer(tokenizer) -> str:
+    """The same digest, taken from a HuggingFace tokenizer.
+
+    Kept separate from `fingerprint_vocab` so the logic is testable without
+    transformers installed — which is also how it runs in CI.
+    """
+    specials = {
+        name: getattr(tokenizer, f"{name}_token_id", None)
+        for name in ("bos", "eos", "pad", "unk", "sep", "cls", "mask")
+    }
+    return fingerprint_vocab(tokenizer.get_vocab(), specials)

--- a/forge/eullm_forge/teacher_cache/format.py
+++ b/forge/eullm_forge/teacher_cache/format.py
@@ -1,0 +1,419 @@
+"""On-disk format for the teacher's top-K distributions.
+
+ADR-001 Part 4 specifies it; this implements it. The cache lets one teacher
+pass serve any number of student runs, which is what makes design A pay —
+but only if what comes back is exactly what the teacher said, and the
+failure mode when it is not is silent. An off-by-one in the
+`logits[t] -> target[t+1]` alignment does not raise the loss in any obvious
+way; it poisons the whole cache and is discovered after the node-hours are
+spent. So the invariants are checked on write, not documented and hoped for.
+
+**What is stored**, per sequence: the token ids, the top-K token ids, the
+top-K *raw logits* in bf16, and the `logZ_T` normalisers in fp32 for each
+temperature. Plus provenance: teacher checkpoint, adapter, precision,
+tokenizer fingerprint, git commit.
+
+**What is deliberately not stored**, because a derived field that is written
+down anyway is a field that can contradict its own source:
+
+* the position of a token — it is the index within the sequence record;
+* the target token — it is `token_ids[i + 1]` for the distribution at `i`,
+  and making that structural rather than stored is what makes the alignment
+  checkable instead of conventional;
+* normalised probabilities — they would fix a temperature at write time,
+  which is the thing `logZ_T` exists to avoid;
+* residual mass — `1 - sum_topK exp((logit - logZ_T)/T)`, exact from what is
+  already here.
+
+**bf16 and not fp16**, and the reason is not dynamic range: the teacher
+computes in bf16, so its logits already carry exactly that precision.
+Storing them in bf16 is lossless with respect to the source, at identical
+size. fp16's two extra mantissa bits would hold no information.
+
+Sharded, never one file: 700 M positions at K=64 is ~277 GB.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+MANIFEST = "manifest.json"
+SHARD_GLOB = "shard-*.npz"
+
+# T=1 is the objective's own temperature; 2 and 4 are the ones a distillation
+# schedule realistically reaches. Storing three fp32 per position costs ~12
+# bytes against re-running the teacher to change a hyperparameter.
+DEFAULT_TEMPERATURES: tuple[float, ...] = (1.0, 2.0, 4.0)
+
+
+# ── bf16 <-> fp32, without a dependency ──────────────────────────────────
+# numpy has no bfloat16, so the bits are carried as uint16. This is a
+# reinterpretation, not a conversion: the stored value IS the teacher's,
+# truncated exactly where bf16 truncates.
+
+def to_bf16_bits(x: np.ndarray) -> np.ndarray:
+    """fp32 -> the top 16 bits, rounded to nearest even.
+
+    Truncating instead of rounding would bias every logit downward in
+    magnitude, which is small per value and systematic across 700 M of them.
+    """
+    a = np.ascontiguousarray(x, dtype=np.float32)
+    u = a.view(np.uint32)
+    rounded = u + (((u >> 16) & np.uint32(1)) + np.uint32(0x7FFF))
+    return (rounded >> 16).astype(np.uint16)
+
+
+def from_bf16_bits(b: np.ndarray) -> np.ndarray:
+    """The top 16 bits back to fp32. Exact — bf16 is a prefix of fp32."""
+    return (np.ascontiguousarray(b, dtype=np.uint16).astype(np.uint32) << 16).view(
+        np.float32
+    )
+
+
+@dataclass(frozen=True)
+class CacheProvenance:
+    """Everything needed to say which teacher produced this, and on what.
+
+    A cache outlives the session that wrote it and will be read by a run
+    nobody remembers configuring. `tokenizer_fingerprint` is the field that
+    earns its place: two tokenizers can agree on a vocabulary size of 151,936
+    and differ in merges or special-token ids, and the resulting corruption
+    looks like a bad student rather than a bad cache.
+    """
+
+    teacher_model: str
+    teacher_precision: str
+    tokenizer_fingerprint: str
+    top_k: int
+    # Not decoration: it is what makes the logZ check two-sided. Without it a
+    # normaliser can only be shown to be too small, and the commonest way to
+    # get one wrong — reusing another temperature's — makes it too large.
+    vocab_size: int
+    temperatures: tuple[float, ...] = DEFAULT_TEMPERATURES
+    teacher_adapter: str | None = None
+    git_commit: str | None = None
+    config_digest: str | None = None
+    notes: dict = field(default_factory=dict)
+
+    def to_json(self) -> dict:
+        d = asdict(self)
+        d["temperatures"] = list(self.temperatures)
+        return d
+
+    @classmethod
+    def from_json(cls, d: dict) -> CacheProvenance:
+        d = dict(d)
+        d["temperatures"] = tuple(float(t) for t in d["temperatures"])
+        return cls(**d)
+
+
+@dataclass(frozen=True)
+class CachedSequence:
+    """One sequence's worth of teacher output.
+
+    `topk_logits` are raw logits, not log-probabilities. `logz[:, j]` is the
+    normaliser of the FULL vocabulary at `temperatures[j]` — which is the
+    whole point: a truncated top-K cannot be turned back into a distribution
+    without it, and the softmax at T=2 cannot be recovered from the T=1
+    normaliser.
+    """
+
+    seq_id: str
+    token_ids: np.ndarray      # int32, (L,)
+    topk_ids: np.ndarray       # uint32, (L-1, K)
+    topk_logits: np.ndarray    # float32 decoded from bf16, (L-1, K)
+    logz: np.ndarray           # float32, (L-1, n_temperatures)
+    temperatures: tuple[float, ...]
+
+    @property
+    def targets(self) -> np.ndarray:
+        """The token each stored distribution predicts.
+
+        Derived, never stored. `logits[t]` predicts `token_ids[t+1]`, so this
+        is `token_ids[1:]` — and because the writer requires exactly `L-1`
+        distributions for `L` tokens, an off-by-one cannot be written down in
+        the first place.
+        """
+        return self.token_ids[1:]
+
+    def probs(self, temperature: float) -> np.ndarray:
+        """Top-K probabilities at one of the cached temperatures."""
+        j = self._temperature_index(temperature)
+        return np.exp(self.topk_logits / temperature - self.logz[:, j : j + 1])
+
+    def residual_mass(self, temperature: float) -> np.ndarray:
+        """Probability mass outside the top-K, per position.
+
+        Derived rather than stored, and useful: it is the truncation error of
+        Part 5 measured on the cache itself.
+        """
+        return 1.0 - self.probs(temperature).sum(axis=1)
+
+    def _temperature_index(self, temperature: float) -> int:
+        for j, t in enumerate(self.temperatures):
+            if abs(t - temperature) < 1e-9:
+                return j
+        raise KeyError(
+            f"temperature {temperature} not cached; have {list(self.temperatures)}"
+        )
+
+
+def validate_sequence(
+    token_ids: np.ndarray,
+    topk_ids: np.ndarray,
+    topk_logits: np.ndarray,
+    logz: np.ndarray,
+    n_temperatures: int,
+) -> None:
+    """Refuse to write anything that cannot be read back correctly.
+
+    Every check here corresponds to a failure that is silent at training
+    time. They run on write because that is the only moment the live teacher
+    is still around to be re-asked.
+    """
+    n = len(token_ids) - 1
+    if n < 1:
+        raise ValueError("a sequence needs at least 2 tokens to predict anything")
+    if topk_ids.shape[0] != n:
+        raise ValueError(
+            f"alignment: {len(token_ids)} tokens give {n} predictable positions, "
+            f"got {topk_ids.shape[0]} distributions"
+        )
+    if topk_logits.shape != topk_ids.shape:
+        raise ValueError(
+            f"top-K ids {topk_ids.shape} and logits {topk_logits.shape} disagree"
+        )
+    if logz.shape != (n, n_temperatures):
+        raise ValueError(
+            f"logZ must be ({n}, {n_temperatures}), got {logz.shape}"
+        )
+    if not np.isfinite(topk_logits).all() or not np.isfinite(logz).all():
+        raise ValueError("non-finite logits or logZ")
+    if (np.diff(topk_logits, axis=1) > 1e-3).any():
+        raise ValueError("top-K logits must be sorted descending")
+
+
+def check_normalisers(
+    topk_logits: np.ndarray,
+    logz: np.ndarray,
+    temperatures: tuple[float, ...],
+    vocab_size: int | None = None,
+) -> None:
+    """Bound `logZ_T` from both sides, because each side catches a different bug.
+
+    **Below**: `logZ_T` is a logsumexp over the whole vocabulary, so it cannot
+    be smaller than the same quantity over a subset of it. A normaliser
+    computed over the top-K instead of the full vocabulary fails here — and
+    that cache would read back cleanly while training against a distribution
+    that sums to one over K tokens.
+
+    **Above**: `logZ_T <= max(logit)/T + log(V)`, since V terms each at most
+    `exp(max)`. This is the side that was missing, and a test found it. The
+    commonest way to get a normaliser wrong is to reuse another temperature's,
+    and since `logZ` falls as T rises, substituting T=1's value for T=4's
+    makes it too *large* — invisible to the lower bound alone. Needs the
+    vocabulary size, which is why provenance carries it.
+    """
+    for j, t in enumerate(temperatures):
+        scaled = topk_logits / t
+        m = scaled.max(axis=1)
+        truncated = m + np.log(np.exp(scaled - m[:, None]).sum(axis=1))
+        # A tolerance, because both sides are float and can agree to the last
+        # bit when K covers essentially all the mass.
+        if (truncated - logz[:, j] > 1e-3).any():
+            worst = float((truncated - logz[:, j]).max())
+            raise ValueError(
+                f"logZ at T={t} is below the top-K's own logsumexp by {worst:.4g} "
+                "— the normaliser does not belong to these logits"
+            )
+        if vocab_size:
+            ceiling = m + np.log(float(vocab_size))
+            if (logz[:, j] - ceiling > 1e-3).any():
+                worst = float((logz[:, j] - ceiling).max())
+                raise ValueError(
+                    f"logZ at T={t} exceeds max(logit)/T + log(V) by {worst:.4g} "
+                    f"over {vocab_size} tokens — likely another temperature's "
+                    "normaliser, or logits and logZ from different batches"
+                )
+
+
+class LogitCacheWriter:
+    """Writes shards and a manifest. Not thread-safe; one writer per rank.
+
+    Shards are closed as they fill, so an interrupted teacher pass leaves
+    every completed shard readable rather than one truncated file.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        provenance: CacheProvenance,
+        sequences_per_shard: int = 512,
+        shard_prefix: str = "shard",
+    ) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.provenance = provenance
+        self.sequences_per_shard = sequences_per_shard
+        self.shard_prefix = shard_prefix
+        self._buf: list[dict] = []
+        self._shards: list[str] = []
+        self._n_sequences = 0
+        self._n_positions = 0
+        self._closed = False
+
+    def add(
+        self,
+        seq_id: str,
+        token_ids: np.ndarray,
+        topk_ids: np.ndarray,
+        topk_logits: np.ndarray,
+        logz: np.ndarray,
+    ) -> None:
+        if self._closed:
+            raise RuntimeError("writer is closed")
+        token_ids = np.ascontiguousarray(token_ids, dtype=np.int32)
+        topk_ids = np.ascontiguousarray(topk_ids, dtype=np.uint32)
+        topk_logits = np.ascontiguousarray(topk_logits, dtype=np.float32)
+        logz = np.ascontiguousarray(logz, dtype=np.float32)
+
+        validate_sequence(
+            token_ids, topk_ids, topk_logits, logz, len(self.provenance.temperatures)
+        )
+        if topk_ids.shape[1] != self.provenance.top_k:
+            raise ValueError(
+                f"K mismatch: manifest says {self.provenance.top_k}, "
+                f"sequence has {topk_ids.shape[1]}"
+            )
+        check_normalisers(
+            topk_logits,
+            logz,
+            self.provenance.temperatures,
+            self.provenance.vocab_size,
+        )
+
+        self._buf.append(
+            {
+                "seq_id": seq_id,
+                "token_ids": token_ids,
+                "topk_ids": topk_ids,
+                "topk_logits": to_bf16_bits(topk_logits),
+                "logz": logz,
+            }
+        )
+        self._n_sequences += 1
+        self._n_positions += topk_ids.shape[0]
+        if len(self._buf) >= self.sequences_per_shard:
+            self._flush()
+
+    def _flush(self) -> None:
+        if not self._buf:
+            return
+        name = f"{self.shard_prefix}-{len(self._shards):05d}.npz"
+        path = self.root / name
+        # Concatenated arrays plus offsets: one sequence per npz entry would
+        # put millions of members in a zip, which no reader enjoys.
+        offsets = np.zeros(len(self._buf) + 1, dtype=np.int64)
+        tok_offsets = np.zeros(len(self._buf) + 1, dtype=np.int64)
+        for i, rec in enumerate(self._buf):
+            offsets[i + 1] = offsets[i] + rec["topk_ids"].shape[0]
+            tok_offsets[i + 1] = tok_offsets[i] + rec["token_ids"].shape[0]
+        np.savez(
+            path,
+            seq_ids=np.array([r["seq_id"] for r in self._buf], dtype=object),
+            offsets=offsets,
+            token_offsets=tok_offsets,
+            token_ids=np.concatenate([r["token_ids"] for r in self._buf]),
+            topk_ids=np.concatenate([r["topk_ids"] for r in self._buf]),
+            topk_logits=np.concatenate([r["topk_logits"] for r in self._buf]),
+            logz=np.concatenate([r["logz"] for r in self._buf]),
+            allow_pickle=True,
+        )
+        self._shards.append(name)
+        self._buf.clear()
+
+    def close(self) -> dict:
+        if self._closed:
+            return self.manifest()
+        self._flush()
+        self._closed = True
+        m = self.manifest()
+        (self.root / MANIFEST).write_text(
+            json.dumps(m, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        return m
+
+    def manifest(self) -> dict:
+        return {
+            "format_version": 1,
+            "provenance": self.provenance.to_json(),
+            "shards": list(self._shards),
+            "n_sequences": self._n_sequences,
+            "n_positions": self._n_positions,
+        }
+
+    def __enter__(self) -> LogitCacheWriter:
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+
+class LogitCacheReader:
+    """Random access over the shards, one shard resident at a time."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        manifest_path = self.root / MANIFEST
+        if not manifest_path.exists():
+            raise FileNotFoundError(
+                f"no {MANIFEST} in {self.root} — an interrupted teacher pass "
+                "leaves shards without one; re-run or write it by hand"
+            )
+        self.manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        self.provenance = CacheProvenance.from_json(self.manifest["provenance"])
+        self._shards = self.manifest["shards"]
+        self._counts: list[int] = []
+        self._cached_shard: tuple[int, dict] | None = None
+        for name in self._shards:
+            with np.load(self.root / name, allow_pickle=True) as z:
+                self._counts.append(len(z["offsets"]) - 1)
+        self._cum = np.cumsum([0, *self._counts])
+
+    def __len__(self) -> int:
+        return int(self._cum[-1])
+
+    def _load(self, shard: int) -> dict:
+        if self._cached_shard and self._cached_shard[0] == shard:
+            return self._cached_shard[1]
+        with np.load(self.root / self._shards[shard], allow_pickle=True) as z:
+            data = {k: z[k] for k in z.files}
+        self._cached_shard = (shard, data)
+        return data
+
+    def __getitem__(self, i: int) -> CachedSequence:
+        if i < 0:
+            i += len(self)
+        if not 0 <= i < len(self):
+            raise IndexError(i)
+        shard = int(np.searchsorted(self._cum, i, side="right") - 1)
+        j = i - int(self._cum[shard])
+        d = self._load(shard)
+        a, b = int(d["offsets"][j]), int(d["offsets"][j + 1])
+        ta, tb = int(d["token_offsets"][j]), int(d["token_offsets"][j + 1])
+        return CachedSequence(
+            seq_id=str(d["seq_ids"][j]),
+            token_ids=d["token_ids"][ta:tb],
+            topk_ids=d["topk_ids"][a:b],
+            topk_logits=from_bf16_bits(d["topk_logits"][a:b]),
+            logz=d["logz"][a:b],
+            temperatures=self.provenance.temperatures,
+        )
+
+    def __iter__(self):
+        for i in range(len(self)):
+            yield self[i]

--- a/forge/tests/test_teacher_cache.py
+++ b/forge/tests/test_teacher_cache.py
@@ -1,0 +1,302 @@
+"""Tests for the teacher logit cache.
+
+ADR-001 Part 6 separates two questions that must not share a test: whether
+the cache faithfully records what the teacher said, and how much truncating
+to K loses. This file is the first — pure round-trip and invariant checking,
+no model involved. The second needs a live teacher and belongs to the pilot.
+
+The bias is deliberate: nearly every test here is about a failure that would
+NOT raise the training loss. An off-by-one, a normaliser from the wrong
+temperature, a tokenizer that differs in three merges — each produces a cache
+that reads back cleanly and trains something subtly wrong, discovered after
+the node-hours are gone.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eullm_forge.teacher_cache import (
+    CacheProvenance,
+    LogitCacheReader,
+    LogitCacheWriter,
+    check_normalisers,
+    fingerprint_vocab,
+    from_bf16_bits,
+    to_bf16_bits,
+    validate_sequence,
+)
+
+TEMPS = (1.0, 2.0, 4.0)
+K = 8
+VOCAB = 512
+
+
+def provenance(top_k: int = K) -> CacheProvenance:
+    return CacheProvenance(
+        teacher_model="Qwen/Qwen3-30B-A3B-Base",
+        teacher_precision="bf16",
+        tokenizer_fingerprint="deadbeef",
+        top_k=top_k,
+        vocab_size=VOCAB,
+        temperatures=TEMPS,
+    )
+
+
+def fake_sequence(length: int = 6, top_k: int = K, seed: int = 0):
+    """A sequence whose logZ is the exact full-vocabulary normaliser.
+
+    Built from a real (small) vocabulary rather than made up, so the
+    normaliser invariants hold the way they would for a real teacher.
+    """
+    rng = np.random.default_rng(seed)
+    token_ids = rng.integers(0, VOCAB, size=length).astype(np.int32)
+    n = length - 1
+    # A bf16 teacher's logits already carry exactly bf16 precision, which is
+    # the ADR's reason for storing them that way. Generating them already
+    # rounded makes "lossless with respect to the source" a claim the
+    # round-trip tests can check exactly rather than approximately.
+    logits = from_bf16_bits(
+        to_bf16_bits(rng.normal(0.0, 4.0, size=(n, VOCAB)).astype(np.float32))
+    )
+
+    order = np.argsort(-logits, axis=1)[:, :top_k]
+    topk_ids = order.astype(np.uint32)
+    topk_logits = np.take_along_axis(logits, order, axis=1).astype(np.float32)
+
+    logz = np.zeros((n, len(TEMPS)), dtype=np.float32)
+    for j, t in enumerate(TEMPS):
+        s = logits / t
+        m = s.max(axis=1, keepdims=True)
+        logz[:, j] = (m[:, 0] + np.log(np.exp(s - m).sum(axis=1))).astype(np.float32)
+    return token_ids, topk_ids, topk_logits, logz, logits
+
+
+# ── bf16 ─────────────────────────────────────────────────────────────────
+
+def test_bf16_roundtrip_is_exact_for_representable_values():
+    x = from_bf16_bits(to_bf16_bits(np.array([1.0, -2.5, 1024.0], dtype=np.float32)))
+    assert np.array_equal(x, np.array([1.0, -2.5, 1024.0], dtype=np.float32))
+
+
+def test_bf16_rounds_to_nearest_rather_than_truncating():
+    """Truncation would bias every logit toward zero, systematically.
+
+    Per value it is tiny; across 700 M positions it is a consistent shift of
+    the distribution the student learns.
+    """
+    rng = np.random.default_rng(7)
+    x = rng.normal(0, 10, size=200_000).astype(np.float32)
+    err = from_bf16_bits(to_bf16_bits(x)) - x
+    # Round-to-nearest keeps the mean error near zero; truncation would make
+    # it negative in magnitude terms for every value.
+    assert abs(float(err.mean())) < float(np.abs(err).mean()) * 0.1
+
+
+def test_bf16_relative_error_stays_within_the_format():
+    rng = np.random.default_rng(11)
+    x = rng.normal(0, 10, size=50_000).astype(np.float32)
+    rel = np.abs(from_bf16_bits(to_bf16_bits(x)) - x) / np.maximum(np.abs(x), 1e-6)
+    assert rel.max() < 2 ** -8
+
+
+# ── round trip ───────────────────────────────────────────────────────────
+
+def test_written_sequence_reads_back_identically(tmp_path):
+    token_ids, topk_ids, topk_logits, logz, _ = fake_sequence()
+    with LogitCacheWriter(tmp_path, provenance()) as w:
+        w.add("doc-1", token_ids, topk_ids, topk_logits, logz)
+
+    r = LogitCacheReader(tmp_path)
+    assert len(r) == 1
+    got = r[0]
+    assert got.seq_id == "doc-1"
+    assert np.array_equal(got.token_ids, token_ids)
+    assert np.array_equal(got.topk_ids, topk_ids)
+    assert np.allclose(got.logz, logz)
+    # Exactly equal, not merely close: the source is already bf16, so the
+    # format loses nothing. If this ever becomes approximate, something is
+    # converting through a narrower type than it should.
+    assert np.array_equal(got.topk_logits, topk_logits)
+
+
+def test_sequences_survive_sharding(tmp_path):
+    with LogitCacheWriter(tmp_path, provenance(), sequences_per_shard=3) as w:
+        for i in range(10):
+            w.add(f"doc-{i}", *fake_sequence(length=5 + i, seed=i)[:4])
+
+    r = LogitCacheReader(tmp_path)
+    assert len(r) == 10
+    assert len(r.manifest["shards"]) == 4          # 3 + 3 + 3 + 1
+    assert [s.seq_id for s in r] == [f"doc-{i}" for i in range(10)]
+    # Variable lengths must not bleed across the offset boundaries.
+    for i, s in enumerate(r):
+        assert len(s.token_ids) == 5 + i
+        assert s.topk_ids.shape[0] == 4 + i
+
+
+def test_reader_reports_totals(tmp_path):
+    with LogitCacheWriter(tmp_path, provenance()) as w:
+        for i in range(4):
+            w.add(f"d{i}", *fake_sequence(length=6, seed=i)[:4])
+    r = LogitCacheReader(tmp_path)
+    assert r.manifest["n_sequences"] == 4
+    assert r.manifest["n_positions"] == 4 * 5
+
+
+# ── alignment, the silent one ────────────────────────────────────────────
+
+def test_targets_are_derived_and_offset_by_one(tmp_path):
+    token_ids, topk_ids, topk_logits, logz, _ = fake_sequence(length=6)
+    with LogitCacheWriter(tmp_path, provenance()) as w:
+        w.add("doc", token_ids, topk_ids, topk_logits, logz)
+    s = LogitCacheReader(tmp_path)[0]
+    assert np.array_equal(s.targets, token_ids[1:])
+    assert len(s.targets) == s.topk_ids.shape[0]
+
+
+def test_one_distribution_too_many_is_refused():
+    """The off-by-one that poisons a cache silently."""
+    token_ids, topk_ids, topk_logits, logz, _ = fake_sequence(length=6)
+    extra = (np.vstack([topk_ids, topk_ids[-1:]]),
+             np.vstack([topk_logits, topk_logits[-1:]]),
+             np.vstack([logz, logz[-1:]]))
+    with pytest.raises(ValueError, match="alignment"):
+        validate_sequence(token_ids, *extra, len(TEMPS))
+
+
+def test_one_distribution_too_few_is_refused():
+    token_ids, topk_ids, topk_logits, logz, _ = fake_sequence(length=6)
+    with pytest.raises(ValueError, match="alignment"):
+        validate_sequence(token_ids, topk_ids[:-1], topk_logits[:-1],
+                          logz[:-1], len(TEMPS))
+
+
+def test_a_single_token_predicts_nothing():
+    with pytest.raises(ValueError, match="at least 2 tokens"):
+        validate_sequence(np.array([7], dtype=np.int32),
+                          np.zeros((0, K), np.uint32),
+                          np.zeros((0, K), np.float32),
+                          np.zeros((0, 3), np.float32), 3)
+
+
+# ── normalisers ──────────────────────────────────────────────────────────
+
+def test_logz_below_the_topk_logsumexp_is_refused():
+    """logZ is over the whole vocabulary, so it cannot be the smaller one.
+
+    This catches a normaliser computed over the top-K instead of the full
+    vocabulary — a cache that is internally consistent, reads back fine, and
+    trains against a distribution that sums to one over 8 tokens.
+    """
+    _, _, topk_logits, logz, _ = fake_sequence()
+    check_normalisers(topk_logits, logz, TEMPS, VOCAB)   # the honest one passes
+    with pytest.raises(ValueError, match="below the top-K"):
+        check_normalisers(topk_logits, logz - 5.0, TEMPS, VOCAB)
+
+
+def test_logz_from_the_wrong_temperature_is_refused():
+    """T=1's normaliser reused for T=4 — the mistake the field invites."""
+    _, _, topk_logits, logz, _ = fake_sequence()
+    wrong = logz.copy()
+    wrong[:, 2] = wrong[:, 0]
+    with pytest.raises(ValueError, match="T=4"):
+        check_normalisers(topk_logits, wrong, TEMPS, VOCAB)
+    # And the lower bound alone would NOT have caught it: logZ falls as T
+    # rises, so T=1's value is too large, not too small. This is the gap
+    # the test found.
+    check_normalisers(topk_logits, wrong, TEMPS, vocab_size=None)
+
+
+def test_probabilities_and_residual_mass_are_consistent(tmp_path):
+    token_ids, topk_ids, topk_logits, logz, full = fake_sequence(length=8, top_k=K)
+    with LogitCacheWriter(tmp_path, provenance()) as w:
+        w.add("d", token_ids, topk_ids, topk_logits, logz)
+    s = LogitCacheReader(tmp_path)[0]
+
+    for t in TEMPS:
+        p = s.probs(t)
+        assert (p > 0).all()
+        total = p.sum(axis=1)
+        assert (total <= 1.0 + 1e-3).all()
+        assert np.allclose(s.residual_mass(t), 1.0 - total, atol=1e-6)
+
+    # Against the full vocabulary it started from: the top-K mass is what
+    # the truncation actually retains.
+    s1 = full / 1.0
+    m = s1.max(axis=1, keepdims=True)
+    full_p = np.exp(s1 - m) / np.exp(s1 - m).sum(axis=1, keepdims=True)
+    retained = np.take_along_axis(full_p, topk_ids.astype(np.int64), axis=1).sum(axis=1)
+    assert np.allclose(s.probs(1.0).sum(axis=1), retained, atol=1e-3)
+
+
+def test_uncached_temperature_is_an_error(tmp_path):
+    with LogitCacheWriter(tmp_path, provenance()) as w:
+        w.add("d", *fake_sequence()[:4])
+    with pytest.raises(KeyError, match="not cached"):
+        LogitCacheReader(tmp_path)[0].probs(3.0)
+
+
+# ── shape and provenance guards ──────────────────────────────────────────
+
+def test_k_mismatch_against_the_manifest_is_refused(tmp_path):
+    token_ids, topk_ids, topk_logits, logz, _ = fake_sequence(top_k=K)
+    with LogitCacheWriter(tmp_path, provenance(top_k=K + 1)) as w:
+        with pytest.raises(ValueError, match="K mismatch"):
+            w.add("d", token_ids, topk_ids, topk_logits, logz)
+
+
+def test_unsorted_topk_is_refused():
+    token_ids, topk_ids, topk_logits, logz, _ = fake_sequence()
+    shuffled = topk_logits[:, ::-1].copy()
+    with pytest.raises(ValueError, match="sorted descending"):
+        validate_sequence(token_ids, topk_ids, shuffled, logz, len(TEMPS))
+
+
+def test_non_finite_values_are_refused():
+    token_ids, topk_ids, topk_logits, logz, _ = fake_sequence()
+    bad = topk_logits.copy()
+    bad[0, 0] = np.inf
+    with pytest.raises(ValueError, match="non-finite"):
+        validate_sequence(token_ids, topk_ids, bad, logz, len(TEMPS))
+
+
+def test_provenance_round_trips(tmp_path):
+    p = CacheProvenance(
+        teacher_model="m", teacher_precision="bf16",
+        tokenizer_fingerprint="abc", top_k=K, vocab_size=VOCAB,
+        temperatures=TEMPS,
+        teacher_adapter="./ckpt", git_commit="cafe123",
+    )
+    with LogitCacheWriter(tmp_path, p) as w:
+        w.add("d", *fake_sequence()[:4])
+    got = LogitCacheReader(tmp_path).provenance
+    assert got == p
+    assert got.temperatures == TEMPS
+
+
+def test_reading_a_cache_with_no_manifest_says_so(tmp_path):
+    (tmp_path / "shard-00000.npz").write_bytes(b"not really")
+    with pytest.raises(FileNotFoundError, match="manifest"):
+        LogitCacheReader(tmp_path)
+
+
+# ── tokenizer fingerprint ────────────────────────────────────────────────
+
+def test_same_vocabulary_gives_the_same_fingerprint():
+    v = {"a": 0, "b": 1, "c": 2}
+    s = {"bos": 0, "eos": 2, "pad": None}
+    assert fingerprint_vocab(v, s) == fingerprint_vocab(dict(reversed(v.items())), s)
+
+
+def test_one_differing_merge_changes_the_fingerprint():
+    """Equal sizes, one token different — the case a size check waves through."""
+    a = fingerprint_vocab({"a": 0, "b": 1, "c": 2}, {"bos": 0})
+    b = fingerprint_vocab({"a": 0, "b": 1, "d": 2}, {"bos": 0})
+    assert a != b
+
+
+def test_a_differing_special_token_id_changes_the_fingerprint():
+    v = {"a": 0, "b": 1, "c": 2}
+    assert fingerprint_vocab(v, {"eos": 2}) != fingerprint_vocab(v, {"eos": 1})


### PR DESCRIPTION
ADR-001 Part 4 specifies the cache that lets one teacher pass serve any number of student runs; this implements it, along with the checks that make it trustworthy. Nothing here needs a GPU or a model, which is why it could be written while the pilot is still deciding which backend fills it.

The design point is that derived fields are not stored. A token's position is its index; the target is `token_ids[i+1]`; normalised probabilities would fix a temperature at write time, which is what `logZ_T` exists to avoid; residual mass is exact from what is already there. A derived field written down anyway is a field that can contradict its own source.

That choice is what makes the alignment checkable rather than conventional. A sequence of L tokens admits exactly L-1 distributions, the writer refuses anything else, and `targets` is computed on read. The off-by-one this prevents does not raise the training loss — it poisons the cache and is found after the node-hours are spent.

Logits are bf16 because a bf16 teacher's logits already carry exactly that precision: the format is lossless with respect to its source, and the tests assert exact equality rather than closeness to say so. numpy has no bfloat16, so the bits travel as uint16 with round-to-nearest-even — truncating would bias every logit toward zero, negligibly per value and systematically across 700 M of them.

Normalisers are bounded from both sides, and the second side exists because a test found it missing. Below: `logZ_T` cannot be smaller than the top-K's own logsumexp, which catches a normaliser computed over K tokens instead of the vocabulary. Above: `logZ_T <= max(logit)/T + log(V)`, which catches another temperature's normaliser being reused — and since logZ falls as T rises, that mistake makes it too large and was invisible to the lower bound alone. Provenance carries the vocabulary size for exactly this.

The tokenizer fingerprint hashes the whole vocabulary mapping and the special-token ids rather than the size. Two tokenizers can agree on 151,936 entries and differ in a few merges, and the resulting corruption looks like a student that trains badly rather than a cache that is wrong.