### PR TITLE
fix(leonardo): choose the python that runs queue_stats, do not assume…

### DIFF
--- a/forge/scripts/leonardo/sbatch_queue_stats.slurm
+++ b/forge/scripts/leonardo/sbatch_queue_stats.slurm
@@ -53,6 +53,49 @@ TOOL="$REPO/forge/scripts/leonardo/queue_stats.py"
 
 mkdir -p "$OUT"
 
+# `python3` is not a fixed thing on this cluster. RHEL 8's system interpreter
+# is 3.6, which cannot even parse `from __future__ import annotations`, while
+# `module load python/3.11.7` puts a modern one ahead of it on PATH. A job
+# that inherits the module from its submitter works; the same job submitted
+# from a clean shell dies with a SyntaxError. That happened interactively on
+# a different login node, and the batch chain had the same latent fault.
+#
+# So the interpreter is chosen here rather than assumed, and a failure to
+# find one is loud.
+usable_python() {
+    command -v "$1" >/dev/null 2>&1 &&
+        "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 7) else 1)' \
+            >/dev/null 2>&1
+}
+
+PY=""
+# An explicit override is still checked. Pointing it at a path that does not
+# exist, or at the system 3.6, should say so here rather than fail somewhere
+# less obvious a few lines later.
+if [ -n "${EULLM_QSTATS_PYTHON:-}" ]; then
+    if usable_python "$EULLM_QSTATS_PYTHON"; then
+        PY="$EULLM_QSTATS_PYTHON"
+    else
+        echo "[qstats] FATAL: EULLM_QSTATS_PYTHON='$EULLM_QSTATS_PYTHON' is missing" >&2
+        echo "[qstats] or older than 3.7 — the daily chain stops here." >&2
+        exit 1
+    fi
+else
+    for candidate in python3.12 python3.11 python3.10 python3.9 python3; do
+        if usable_python "$candidate"; then
+            PY="$candidate"
+            break
+        fi
+    done
+fi
+if [ -z "$PY" ]; then
+    echo "[qstats] FATAL: no python >= 3.7 on PATH — the daily chain stops here." >&2
+    echo "[qstats] Try 'module load python/3.11.7' before submitting, or set" >&2
+    echo "[qstats] EULLM_QSTATS_PYTHON to an interpreter." >&2
+    exit 1
+fi
+echo "[qstats] python $("$PY" -c 'import sys; print(sys.version.split()[0])') ($PY)"
+
 # Check before acting. A self-perpetuating job that cannot find itself has no
 # second chance: there is no next run to notice the problem.
 for f in "$SELF" "$TOOL"; do
@@ -66,7 +109,7 @@ done
 
 # `|| true` only covers a genuine runtime failure of a tool we have just
 # confirmed exists — never a missing file, which is what it used to hide.
-if ! python3 "$TOOL" "$ALLOC_START" \
+if ! "$PY" "$TOOL" "$ALLOC_START" \
         --json "$OUT/queue_stats_$(date +%Y%m%d_%H%M).json"; then
     echo "[qstats] snapshot failed; re-arming anyway so one bad day is not fatal" >&2
 fi


### PR DESCRIPTION
… one

`python3` is not a fixed thing on this cluster. RHEL 8's system interpreter is 3.6, which cannot parse `from __future__ import annotations` at all, while `module load python/3.11.7` puts a modern one ahead of it on PATH. Whether a shell has that module decides which interpreter the name resolves to.

It surfaced interactively — the same alias worked on one login node and raised a SyntaxError on another the next morning — but the batch chain had the identical fault and would have hit it less visibly. The daily job inherits its submitter's environment, so it has been finding a modern python by luck; a re-submission from a clean shell would have ended the series with a parse error in a log nobody opens.

The interpreter is now selected and verified before use, preferring a specific minor version over the bare name, and a failure to find one exits non-zero with what to do about it. An explicit EULLM_QSTATS_PYTHON is checked too, since pointing it at a path that does not exist should say so here rather than fail a few lines later with less context. The chosen version is printed, because "which python ran this" is the question this whole class of failure turns on.