### PR TITLE
fix(lumi): the benchmark waited for the server it had started

### DIFF
--- a/tools/lumi/sbatch_bench.slurm
+++ b/tools/lumi/sbatch_bench.slurm
@@ -132,11 +132,17 @@ grep -iE "gpu|offload|device|layers" "$LOG" | head -12 | sed 's/^/  /'
 echo
 echo "=== timed: $CONCURRENCY concurrent requests ==="
 START=$(date +%s%N)
-for i in $(seq 1 "$CONCURRENCY"); do request "$i" & done
-wait
+# `wait` with no arguments waits for EVERY background child, and the server is
+# one of them — it never exits, so a bare `wait` hangs after the requests have
+# finished, holding the allocation until the walltime kills it. Found live: four
+# jobs sat idle at GPU 0% for eleven minutes past their last completed request.
+# Wait for the request PIDs and nothing else.
+PIDS=()
+for i in $(seq 1 "$CONCURRENCY"); do request "$i" & PIDS+=("$!"); done
+wait "${PIDS[@]}"
 ELAPSED_MS=$(( ($(date +%s%N) - START) / 1000000 ))
 
-python3 - "$WORK" "$ELAPSED_MS" <<'PY' | tee /dev/stderr
+python3 - "$WORK" "$ELAPSED_MS" <<'PY'
 import json, os, sys
 work, elapsed_ms = sys.argv[1], int(sys.argv[2])
 tok = prompt_tok = 0


### PR DESCRIPTION
`wait` with no arguments waits for every background child. The server is one of them and never exits, so the script hung after the last request came back, holding the allocation until the walltime killed it.

Caught on LUMI with four jobs in flight: GPU at 0%, clocks at idle, VRAM still holding the model, and a server log whose final audit entry was eleven minutes old. The benchmark had finished and the script could not notice. Left alone they would each have burned an hour — ten GCDs for nothing.

Now collects the request PIDs and waits on those. Verified with a stand-in server that outlives the requests: the targeted wait returns in 300 ms where the bare one would have blocked for the server's lifetime.

Also drops `| tee /dev/stderr` from the result block: in a batch job stdout and stderr are the same file, so it printed everything twice and bought nothing.