### PR TITLE
feat(pilot): P3 measures what top-K keeps, without waiting for vLLM

### DIFF
--- a/forge/scripts/leonardo/sbatch_p3_truncation.slurm
+++ b/forge/scripts/leonardo/sbatch_p3_truncation.slurm
@@ -1,0 +1,74 @@
+#!/bin/bash
+# P3 — how much of the teacher's distribution top-K actually keeps.
+#
+# Runs beside anything else: it needs one model, plain transformers, and the
+# venv Phase 1 already uses (read-only, nothing installed). No vLLM, so it is
+# not blocked behind P1 — which matters, because P3 answers a question about
+# the corpus and the teacher rather than about an inference backend.
+#
+# It decides the size of the cache. ADR-001 Part 4 puts K=32 at ~143 GB over
+# the corpus against ~277 GB at K=64, on a 1 TB quota that also holds the HF
+# cache, the corpus and every checkpoint.
+#
+#   cd "$WORK/eullm_runs/v11_pilot"
+#   sbatch "$WORK/eullm-v11/forge/scripts/leonardo/sbatch_p3_truncation.slurm"
+#
+#SBATCH --job-name=eullm-p3-truncation
+#SBATCH --partition=boost_usr_prod
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=32
+#SBATCH --gres=gpu:4
+#SBATCH --mem=450G
+#SBATCH --time=02:00:00
+#SBATCH --output=logs/%x-%j.out
+
+set -uo pipefail
+
+# Which checkout this job runs is decided by where the file came from, not by
+# the submitting shell: `sbatch` exports the submitter's environment and
+# `env.sh` sets EULLM_REPO to whatever tree the current run is pinned to.
+SELF="$(scontrol show job "${SLURM_JOB_ID:-0}" 2>/dev/null |
+        sed -n 's/.*Command=\([^ ]*\).*/\1/p' | head -1)"
+if [ -n "${EULLM_PILOT_REPO:-}" ]; then
+    EULLM_REPO="$EULLM_PILOT_REPO"
+elif [ -n "$SELF" ] && [ -f "$SELF" ]; then
+    EULLM_REPO="$(cd "$(dirname "$SELF")/../../.." && pwd)"
+else
+    EULLM_REPO="${EULLM_REPO:-$WORK/eullm-v11}"
+fi
+export EULLM_REPO
+export EULLM_RUN_DIR="${EULLM_PILOT_RUN_DIR:-$WORK/eullm_runs/v11_pilot}"
+
+# shellcheck disable=SC1091
+source "$EULLM_REPO/forge/scripts/leonardo/env.sh"
+mkdir -p "$EULLM_RUN_DIR/logs"
+cd "$EULLM_RUN_DIR" || exit 1
+
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+
+# shellcheck disable=SC1091
+source "$EULLM_REPO/forge/scripts/leonardo/heartbeat.sh"
+heartbeat_start
+
+echo "[p3] repo   $EULLM_REPO"
+echo "[p3] commit $(git -C "$EULLM_REPO" rev-parse --short HEAD 2>/dev/null || echo '?')"
+
+# bf16, deliberately: this measures a property of the teacher's distribution,
+# and doing it on the int8 copy would confound truncation with quantization.
+# P6 measured the quantization separately, which is what allows this to be
+# read on its own.
+python "$EULLM_REPO/forge/scripts/pilot/measure_topk_truncation.py" \
+    --model Qwen/Qwen3-30B-A3B-Base \
+    --data "$EULLM_DATA_DIR/val.jsonl" \
+    --samples 64 \
+    --seq-len 512 \
+    --k 16 32 64 128 \
+    --temperatures 1 2 4 \
+    --report "$EULLM_RUN_DIR/p3_topk_truncation.json"
+STATUS=$?
+
+python3 "$EULLM_REPO/forge/scripts/leonardo/queue_stats.py" 2026-09-02 \
+    --json "$WORK/eullm_runs/qstats/queue_stats_$(date +%Y%m%d_%H%M).json" || true
+
+exit "$STATUS"

--- a/forge/scripts/pilot/measure_topk_truncation.py
+++ b/forge/scripts/pilot/measure_topk_truncation.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""P3: how much of the teacher's distribution does top-K actually keep?
+
+ADR-001 Part 5 says K is measured, not chosen, and this is the measurement.
+It decides the size of the cache — K=32 is ~143 GB over the corpus against
+~277 GB at K=64 — and the pre-registration predicts that on Italian case law,
+a narrow and highly conventional register, K=32 already captures ≥99% of the
+mass at T=1.
+
+**No vLLM.** The full vocabulary distribution comes from a plain transformers
+forward, which is the same stack Phase 1 has been running for days. That is
+deliberate: P3 answers a question about the corpus and the teacher, not about
+an inference backend, so it must not be blocked behind P1.
+
+### The two thresholds in P3 are the same number
+
+The prediction asks for retained mass ≥ 99% **and** truncation KL < 0.01
+nats, as though they were independent checks. They are not. With `q` the
+top-K distribution renormalised over retained mass `M`:
+
+    KL(q || p) = sum_topK (p_i/M) log((p_i/M) / p_i) = -log M
+
+So `M = 0.99` is exactly `KL = 0.01005`. Both are reported, because the mass
+is the readable one and the KL is the one that composes with the training
+objective — but a reader should know they are one measurement, not two, and
+that agreement between them is arithmetic rather than evidence.
+
+Reported per K and per temperature, because truncation bites harder as T
+rises: a hotter softmax spreads mass into the tail the top-K does not hold.
+
+    python measure_topk_truncation.py --model Qwen/Qwen3-30B-A3B-Base \\
+        --data "$EULLM_DATA_DIR/val.jsonl" --samples 64 \\
+        --k 16 32 64 128 --report p3.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+
+DEFAULT_KS = (16, 32, 64, 128)
+DEFAULT_TEMPERATURES = (1.0, 2.0, 4.0)
+
+
+def load_samples(path: Path, n: int, seed: int, field: str) -> list[str]:
+    """Reservoir-sample n texts without holding the whole corpus in memory."""
+    rng = random.Random(seed)
+    picked: list[str] = []
+    seen = 0
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                text = json.loads(line).get(field)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(text, str) or len(text) < 200:
+                continue
+            seen += 1
+            if len(picked) < n:
+                picked.append(text)
+            else:
+                j = rng.randrange(seen)
+                if j < n:
+                    picked[j] = text
+    return picked
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--model", required=True)
+    p.add_argument("--adapter", default=None, help="Phase-1 LoRA adapter (optional)")
+    p.add_argument("--bits", type=int, choices=(4, 8), default=None,
+                   help="quantize the teacher; omit for bf16")
+    p.add_argument("--data", type=Path, required=True)
+    p.add_argument("--field", default="text")
+    p.add_argument("--samples", type=int, default=64)
+    p.add_argument("--seq-len", type=int, default=512)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--k", type=int, nargs="+", default=list(DEFAULT_KS))
+    p.add_argument("--temperatures", type=float, nargs="+",
+                   default=list(DEFAULT_TEMPERATURES))
+    p.add_argument("--report", type=Path, default=None)
+    args = p.parse_args(argv)
+
+    import torch
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    texts = load_samples(args.data, args.samples, args.seed, args.field)
+    if not texts:
+        print(f"[FAIL] no usable samples in {args.data}", file=sys.stderr)
+        return 2
+    print(f"[..] {len(texts)} samples, loading {args.model}", flush=True)
+
+    kwargs: dict = {"dtype": torch.bfloat16, "device_map": "auto"}
+    if args.bits:
+        from transformers import BitsAndBytesConfig
+
+        kwargs["quantization_config"] = BitsAndBytesConfig(
+            load_in_8bit=args.bits == 8,
+            load_in_4bit=args.bits == 4,
+            bnb_4bit_compute_dtype=torch.bfloat16,
+            bnb_4bit_quant_type="nf4",
+        )
+    model = AutoModelForCausalLM.from_pretrained(args.model, **kwargs)
+    if args.adapter:
+        from peft import PeftModel
+
+        model = PeftModel.from_pretrained(model, args.adapter)
+    model.eval()
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    print("[ok] loaded", flush=True)
+
+    ks = sorted(set(args.k))
+    temps = list(args.temperatures)
+    # Accumulate retained mass per (temperature, K) and count positions once.
+    mass = {(t, k): 0.0 for t in temps for k in ks}
+    positions = 0
+
+    for i, text in enumerate(texts, start=1):
+        enc = tokenizer(text, return_tensors="pt", truncation=True,
+                        max_length=args.seq_len)
+        ids = enc["input_ids"]
+        if ids.shape[1] < 8:
+            continue
+        with torch.no_grad():
+            logits = model(ids.to(model.device)).logits.float()
+        # Drop the last position: it predicts a token outside the window.
+        logits = logits[0, :-1, :]
+        positions += logits.shape[0]
+
+        for t in temps:
+            probs = torch.softmax(logits / t, dim=-1)
+            # One sort serves every K, and the largest K is a prefix of it.
+            top = probs.topk(max(ks), dim=-1).values
+            cumulative = top.cumsum(dim=-1)
+            for k in ks:
+                mass[(t, k)] += float(cumulative[:, k - 1].sum())
+
+        if i % 8 == 0:
+            print(f"  {i}/{len(texts)} samples, {positions} positions", flush=True)
+
+    if positions == 0:
+        print("[FAIL] no usable positions", file=sys.stderr)
+        return 2
+
+    import math
+
+    rows = []
+    for t in temps:
+        for k in ks:
+            m = mass[(t, k)] / positions
+            rows.append({
+                "temperature": t,
+                "k": k,
+                "retained_mass": m,
+                # KL(truncated-renormalised || full), which reduces exactly to
+                # -log M. Reported because it is the form that composes with
+                # the training objective, not because it is new information.
+                "truncation_kl_nats": -math.log(max(m, 1e-12)),
+            })
+
+    print()
+    print("=" * 56)
+    print(f"{'T':>5} {'K':>5} {'retained mass':>16} {'KL (nats)':>12}")
+    for r in rows:
+        print(f"{r['temperature']:>5.1f} {r['k']:>5} "
+              f"{r['retained_mass']:>15.4%} {r['truncation_kl_nats']:>12.5f}")
+    print("=" * 56)
+    print(f"positions: {positions:,}")
+
+    report = {
+        "model": args.model,
+        "adapter": args.adapter,
+        "bits": args.bits,
+        "samples": len(texts),
+        "seq_len": args.seq_len,
+        "positions": positions,
+        "rows": rows,
+    }
+    if args.report:
+        args.report.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print(f"[ok] report written to {args.report}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/forge/tests/test_topk_truncation.py
+++ b/forge/tests/test_topk_truncation.py
@@ -1,0 +1,94 @@
+"""Tests for the top-K truncation measurement.
+
+The arithmetic is the part worth pinning. P3 states two thresholds — retained
+mass >= 99% and truncation KL < 0.01 nats — as though they were independent,
+and they are the same number: KL(truncated-renormalised || full) reduces
+exactly to -log(retained mass). A test that fixes this identity stops the
+report from presenting one measurement as two agreeing ones.
+
+The model itself is not exercised here; that needs a GPU and belongs to the
+job. What is exercised is sampling and the reduction.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (Path(__file__).resolve().parents[1]
+          / "scripts" / "pilot" / "measure_topk_truncation.py")
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("p3", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+p3 = _load()
+
+
+def test_truncation_kl_is_minus_log_retained_mass():
+    """The identity P3's two thresholds rest on.
+
+    99% retained is 0.01005 nats, so "mass >= 99%" and "KL < 0.01" are one
+    check written twice — and the KL one is very slightly the stricter.
+    """
+    assert -math.log(0.99) == pytest.approx(0.010050, abs=1e-6)
+    # Which means the two thresholds do not even agree at the boundary: 99%
+    # retained mass FAILS "KL < 0.01". The mass that clears it is 99.005%,
+    # so the KL threshold is the marginally stricter of the two and a run
+    # landing between them would score as held on one and falsified on the
+    # other. Worth knowing before reporting them side by side.
+    assert -math.log(0.99) > 0.01
+    assert math.exp(-0.01) == pytest.approx(0.990050, abs=1e-6)
+
+
+def test_perfect_retention_is_zero_divergence():
+    assert -math.log(1.0) == 0.0
+
+
+def test_load_samples_skips_short_and_malformed(tmp_path):
+    data = tmp_path / "val.jsonl"
+    data.write_text("\n".join([
+        json.dumps({"text": "x" * 300}),
+        "{not json",
+        json.dumps({"text": "too short"}),
+        json.dumps({"other": "y" * 300}),
+        json.dumps({"text": "z" * 300}),
+    ]), encoding="utf-8")
+    assert len(p3.load_samples(data, n=10, seed=1, field="text")) == 2
+
+
+def test_load_samples_is_deterministic_for_a_seed(tmp_path):
+    data = tmp_path / "val.jsonl"
+    data.write_text(
+        "\n".join(json.dumps({"text": f"{i}" + "x" * 300}) for i in range(50)),
+        encoding="utf-8",
+    )
+    a = p3.load_samples(data, n=5, seed=42, field="text")
+    b = p3.load_samples(data, n=5, seed=42, field="text")
+    assert a == b
+    assert p3.load_samples(data, n=5, seed=43, field="text") != a
+
+
+def test_reservoir_returns_everything_when_the_corpus_is_small(tmp_path):
+    data = tmp_path / "val.jsonl"
+    data.write_text(
+        "\n".join(json.dumps({"text": f"{i}" + "y" * 300}) for i in range(3)),
+        encoding="utf-8",
+    )
+    assert len(p3.load_samples(data, n=100, seed=1, field="text")) == 3
+
+
+def test_defaults_span_the_range_the_adr_costs_out():
+    """ADR-001 Part 4 prices K = 16 / 32 / 64 / 128; all four get measured."""
+    assert p3.DEFAULT_KS == (16, 32, 64, 128)
+    # Truncation bites harder as T rises, so a single temperature would not
+    # answer the question a distillation schedule actually asks.
+    assert p3.DEFAULT_TEMPERATURES == (1.0, 2.0, 4.0)


### PR DESCRIPTION
ADR-001 Part 5 says K is measured rather than chosen, and this is the measurement. It sets the size of the cache: ~143 GB over the corpus at K=32 against ~277 GB at K=64, on a 1 TB quota that also holds the HF cache, the corpus and every checkpoint.

The full distribution comes from a plain transformers forward, deliberately. P3 asks a question about the corpus and the teacher, not about an inference backend, so it must not sit behind P1 — and with one node busy and the Phase-2 chain dependency-bound behind Phase 1, a second job that can start now is worth more than a tidier one that cannot.

Measured in bf16 rather than on the int8 copy, so truncation is not confounded with quantization. P6 measured the quantization separately at 0.00616 nats, which is what lets this be read on its own.

One thing the tests pin, because it changes how the result should be reported: P3 states retained mass >= 99% and truncation KL < 0.01 nats as two thresholds, and they are one. KL(truncated-renormalised || full) reduces exactly to -log(retained mass), so 99% mass IS 0.01005 nats — which also means 99% fails the KL threshold, and 99.005% is where it actually clears. A run landing between them would score as held on one criterion and falsified on the other. The report should present this as a single measurement rather than two that happen to agree.

Reported per temperature as well as per K: truncation bites harder as T rises, since a hotter softmax spreads mass into the tail the top-K does not hold, and a single temperature would not answer the question a distillation schedule asks.